### PR TITLE
Introduce UnionAlias and StringAlias

### DIFF
--- a/specification/specs/analysis/StopWords.ts
+++ b/specification/specs/analysis/StopWords.ts
@@ -1,3 +1,7 @@
-@class_serializer("StopWordsFormatter")
-class StopWords extends Union<string, string[]> {
-}
+/**
+ * Language value, such as _arabic_ or _thai_. Defaults to _english_.
+ * Each language value corresponds to a predefined list of stop words in Lucene. See Stop words by language for supported language values and their stop words.
+ * Also accepts an array of stop words.
+ * @class_serializer: StopWordsFormatter
+ */
+type StopWords = string | string []

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -46,10 +46,29 @@ interface long {}
 interface float {}
 interface double {}
 
-class ScrollId extends String {}
-class ScrollIds extends String {}
-class CategoryId extends String {}
-class ActionIds extends String {}
+type ScrollId = string
+type ScrollIds = string
+type CategoryId = string
+type ActionIds = string
+type Field = string
+type Fields = string
+type Id = string
+type Ids = string
+type IndexName = string
+type Indices = string
+type TypeName = string
+type Types = string
+type Routing = string
+type LongId = string
+type IndexMetrics = string
+type Metrics = string
+type Name = string
+type Names = string
+type NodeIds = string
+type PropertyName = string
+type RelationName = string
+type TaskId = string
+type Timestamp = string
 
 @namespace("")
 class PlainRequestBase<TParameters> extends RequestBase {

--- a/specification/specs/common_abstractions/infer/field/Field.ts
+++ b/specification/specs/common_abstractions/infer/field/Field.ts
@@ -1,3 +1,0 @@
-@class_serializer("FieldFormatter")
-class Field extends String {}
-class Fields extends String {}

--- a/specification/specs/common_abstractions/infer/id/Id.ts
+++ b/specification/specs/common_abstractions/infer/id/Id.ts
@@ -1,2 +1,0 @@
-@class_serializer("IdFormatter")
-class Id extends String {}

--- a/specification/specs/common_abstractions/infer/id/Ids.ts
+++ b/specification/specs/common_abstractions/infer/id/Ids.ts
@@ -1,2 +1,0 @@
-class Ids {
-}

--- a/specification/specs/common_abstractions/infer/index_name/IndexName.ts
+++ b/specification/specs/common_abstractions/infer/index_name/IndexName.ts
@@ -1,2 +1,0 @@
-@class_serializer("IndexNameFormatter")
-class IndexName extends String {}

--- a/specification/specs/common_abstractions/infer/indices/Indices.ts
+++ b/specification/specs/common_abstractions/infer/indices/Indices.ts
@@ -1,4 +1,0 @@
-@class_serializer("IndicesMultiSyntaxFormatter")
-class Indices extends String {}
-class TypeName extends String {}
-class Types extends String {}

--- a/specification/specs/common_abstractions/infer/join_field_routing/Routing.ts
+++ b/specification/specs/common_abstractions/infer/join_field_routing/Routing.ts
@@ -1,2 +1,0 @@
-@class_serializer("RoutingFormatter")
-class Routing extends String {}

--- a/specification/specs/common_abstractions/infer/long_id/LongId.ts
+++ b/specification/specs/common_abstractions/infer/long_id/LongId.ts
@@ -1,2 +1,0 @@
-class LongId {
-}

--- a/specification/specs/common_abstractions/infer/metrics/IndexMetrics.ts
+++ b/specification/specs/common_abstractions/infer/metrics/IndexMetrics.ts
@@ -1,1 +1,0 @@
-class IndexMetrics extends String {}

--- a/specification/specs/common_abstractions/infer/metrics/Metrics.ts
+++ b/specification/specs/common_abstractions/infer/metrics/Metrics.ts
@@ -1,1 +1,0 @@
-class Metrics extends String {}

--- a/specification/specs/common_abstractions/infer/name/Name.ts
+++ b/specification/specs/common_abstractions/infer/name/Name.ts
@@ -1,1 +1,0 @@
-class Name extends String {}

--- a/specification/specs/common_abstractions/infer/name/Names.ts
+++ b/specification/specs/common_abstractions/infer/name/Names.ts
@@ -1,1 +1,0 @@
-class Names extends String {}

--- a/specification/specs/common_abstractions/infer/node_id/NodeIds.ts
+++ b/specification/specs/common_abstractions/infer/node_id/NodeIds.ts
@@ -1,1 +1,0 @@
-class NodeIds extends String {}

--- a/specification/specs/common_abstractions/infer/property_name/PropertyName.ts
+++ b/specification/specs/common_abstractions/infer/property_name/PropertyName.ts
@@ -1,2 +1,0 @@
-@class_serializer("PropertyNameFormatter")
-class PropertyName extends String {}

--- a/specification/specs/common_abstractions/infer/relation_name/RelationName.ts
+++ b/specification/specs/common_abstractions/infer/relation_name/RelationName.ts
@@ -1,2 +1,0 @@
-@class_serializer("RelationNameFormatter")
-class RelationName extends String {}

--- a/specification/specs/common_abstractions/infer/task_id/TaskId.ts
+++ b/specification/specs/common_abstractions/infer/task_id/TaskId.ts
@@ -1,2 +1,0 @@
-@class_serializer("TaskIdFormatter")
-class TaskId extends String {}

--- a/specification/specs/common_abstractions/infer/timestamp/Timestamp.ts
+++ b/specification/specs/common_abstractions/infer/timestamp/Timestamp.ts
@@ -1,2 +1,0 @@
-class Timestamp {
-}

--- a/specification/specs/common_options/minimum_should_match/MinimumShouldMatch.ts
+++ b/specification/specs/common_options/minimum_should_match/MinimumShouldMatch.ts
@@ -1,3 +1,6 @@
-@class_serializer("MinimumShouldMatchFormatter")
-class MinimumShouldMatch extends Union<integer, string> {
-}
+/**
+ * The minimum number of terms that should match as integer, percentage or range
+ * @url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
+ * @class_serializer MinimumShouldMatchFormatter
+ */
+type MinimumShouldMatch = integer | string

--- a/specification/specs/query_dsl/specialized/more_like_this/like/Like.ts
+++ b/specification/specs/query_dsl/specialized/more_like_this/like/Like.ts
@@ -1,3 +1,6 @@
-@class_serializer("LikeFormatter")
-class Like extends Union<string, LikeDocument> {
-}
+/**
+ * Text that we want similar documents for or a lookup to a document's field for the text.
+ * @url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html#_document_input_parameters
+ * @class_serializer LikeFormatter
+ */
+type Like = string | LikeDocument

--- a/specification/specs/search/multi_search/MultiSearchResponse.ts
+++ b/specification/specs/search/multi_search/MultiSearchResponse.ts
@@ -1,6 +1,6 @@
 @class_serializer("MultiSearchResponseFormatter")
 class MultiSearchResponse extends ResponseBase {
-	all_responses: IResponse[];
+	all_responses: ResponseBase[];
 	took: long;
 	total_responses: integer;
 }

--- a/specification/specs/search/suggesters/context_suggester/Context.ts
+++ b/specification/specs/search/suggesters/context_suggester/Context.ts
@@ -1,5 +1,7 @@
-@class_serializer("ContextFormatter")
-class Context extends Union<string, GeoLocation> {
-	category: string;
-	geo: GeoLocation;
-}
+/**
+ * Text that we want similar documents for or a lookup to a document's field for the text.
+ * @url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html#_document_input_parameters
+ * @class_serializer ContextFormatter
+ */
+type Context = string | GeoLocation
+

--- a/specification/src/domain.ts
+++ b/specification/src/domain.ts
@@ -70,6 +70,12 @@ namespace Domain {
     openGenerics: string[];
     implementsUnion = (): boolean => Object.keys(this.inheritsFromUnresolved).includes("Union");
   }
+  export class UnionAlias extends TypeDeclaration {
+    wraps: Domain.UnionOf;
+  }
+  export class StringAlias extends TypeDeclaration {
+
+  }
 
   export class RequestInterface extends Interface {
     body: InstanceOf | InterfaceProperty[];

--- a/specification/src/main.ts
+++ b/specification/src/main.ts
@@ -17,8 +17,12 @@ The specification contains
 `)
   for (const e of specification.endpoints) {
     const type = specification.typeLookup[e.typeMapping.request];
-    if (["IndexRequest", "SearchRequest"].includes(type.name))
-      console.log(type);
+    // if (["IndexRequest", "SearchRequest"].includes(type.name))
+    //  console.log(type);
   }
+for (const t of specification.types) {
+  if (["StopWords"].includes(t.name))
+    console.log(t);
+}
 
 console.log('Done!')

--- a/specification/src/specification/type-reader.ts
+++ b/specification/src/specification/type-reader.ts
@@ -3,6 +3,7 @@ import _ from "lodash"
 import * as ts from "byots"
 import Domain = require("../domain")
 import path from "path"
+import {UnionAlias} from "../domain";
 
 class Visitor {
   constructor (protected checker: ts.TypeChecker) {}
@@ -43,14 +44,14 @@ class InterfaceVisitor extends Visitor {
   name: TypeName;
   specMapping: RestSpecMapping;
   constructor(
-    private interfaceNode: ts.InterfaceDeclaration | ts.ClassDeclaration,
+    private interfaceNode: ts.InterfaceDeclaration | ts.ClassDeclaration | ts.TypeAliasDeclaration,
     checker: ts.TypeChecker,
     private namespace: string
  ) {
    super(checker)
  }
 
-  visit(): Domain.Interface {
+  visit(): Domain.TypeDeclaration {
     const n = this.symbolName(this.interfaceNode.name)
     this.name = n
 
@@ -66,52 +67,70 @@ class InterfaceVisitor extends Visitor {
       this.specMapping = new RestSpecMapping(restSpec, n, responseName)
     }
 
-    const domainInterface = restSpec
-      ? new Domain.RequestInterface(n, this.namespace)
-      : new Domain.Interface(n, this.namespace)
+    const generatorHints = InterfaceVisitor.createGeneratorHints(this.interfaceNode.jsDoc || [])
+    const typeAlias = this.interfaceNode as ts.TypeAliasDeclaration
+    if (typeAlias !== null && typeAlias.kind === ts.SyntaxKind.TypeAliasDeclaration) {
+      const wrappedType = this.visitTypeNode(typeAlias.type);
+      if (wrappedType instanceof Domain.Type) {
+        if (wrappedType.name !== "string")
+          throw new Error(`Please only create type aliases for strings or unions, ${wrappedType.name} does not comply`);
+        return new Domain.StringAlias(n, this.namespace);
+      }
+      else if (wrappedType instanceof Domain.UnionOf) {
+        const ua = new Domain.UnionAlias(n, this.namespace);
+        ua.wraps = wrappedType;
+        return ua;
+      }
+      throw new Error(`Please only create type aliases for strings or unions, ${n} does not comply`);
+    }
+    else {
+      const domainInterface = restSpec
+        ? new Domain.RequestInterface(n, this.namespace)
+        : new Domain.Interface(n, this.namespace)
+      domainInterface.generatorHints = generatorHints;
 
-    if (restSpec) {
-      ts.forEachChild(this.interfaceNode, c => this.visitRequestProperties(c as ts.PropertySignature, domainInterface as Domain.RequestInterface))
-    } else {
-      ts.forEachChild(this.interfaceNode, c => this.visitInterfaceProperty(c as ts.PropertySignature, domainInterface as Domain.Interface))
+      if (restSpec) {
+        ts.forEachChild(this.interfaceNode, c => this.visitRequestProperties(c as ts.PropertySignature, domainInterface as Domain.RequestInterface))
+      } else {
+        ts.forEachChild(this.interfaceNode, c => this.visitInterfaceProperty(c as ts.PropertySignature, domainInterface as Domain.Interface))
+      }
+
+      const lookup = this.checker.getTypeAtLocation(this.interfaceNode) as ts.TypeReference
+      const generics = lookup.typeArguments || []
+      domainInterface.openGenerics = generics.map(g => g.getSymbol().name)
+
+      const s = this.interfaceNode.symbol
+      const x: any = s.valueDeclaration
+      const heritageClauses: ts.Node[] = (x ? x.heritageClauses : []) || []
+
+      domainInterface.inheritsFromUnresolved = heritageClauses
+        .flatMap(c => ((c as any).types || []) as ts.Node[])
+        .reduce((c, node) => {
+          const expression = ((node as any).expression as ts.Identifier)
+          const name = expression.text
+          // const typeRef = this.checker.getTypeFromTypeNode(node as ts.TypeNode) as ts.TypeReference;
+          const typeRef = node as ts.TypeReferenceNode;
+          if (!typeRef.typeArguments) {
+            const type = !typeRef.typeName
+              ? this.visitTypeNode(node)
+              : this.visitTypeReference(typeRef);
+            c[name] = [type];
+          } else {
+            c[name] = (typeRef.typeArguments).map(g => {
+              const typeArgRef = g as ts.TypeReferenceNode
+              return !typeArgRef.typeName
+                ? this.visitTypeNode(g)
+                : this.visitTypeReference(typeArgRef);
+            });
+          }
+          return c;
+        }, {});
+      return domainInterface;
     }
 
-    domainInterface.generatorHints  = InterfaceVisitor.createGeneratorHints(this.interfaceNode.jsDoc || []);
-
-    const lookup = this.checker.getTypeAtLocation(this.interfaceNode) as ts.TypeReference
-    const generics = lookup.typeArguments || []
-    domainInterface.openGenerics = generics.map(g => g.getSymbol().name)
-
-    const s = this.interfaceNode.symbol
-    const x: any = s.valueDeclaration
-    const heritageClauses: ts.Node[] = (x ? x.heritageClauses : []) || []
-
-    domainInterface.inheritsFromUnresolved = heritageClauses
-      .flatMap(c => ((c as any).types || []) as ts.Node[])
-      .reduce((c, node) => {
-        const expression = ((node as any).expression as ts.Identifier)
-        const name = expression.text
-        // const typeRef = this.checker.getTypeFromTypeNode(node as ts.TypeNode) as ts.TypeReference;
-        const typeRef = node as ts.TypeReferenceNode;
-        if (!typeRef.typeArguments) {
-          const type = !typeRef.typeName
-            ? this.visitTypeNode(node)
-            : this.visitTypeReference(typeRef);
-          c[name] = [type];
-        } else {
-          c[name] = (typeRef.typeArguments).map(g => {
-            const typeArgRef = g as ts.TypeReferenceNode
-            return !typeArgRef.typeName
-              ? this.visitTypeNode(g)
-              : this.visitTypeReference(typeArgRef);
-          });
-        }
-        return c;
-      }, {});
-    return domainInterface;
   }
 
-  public static createGeneratorHints(jsDocs: ts.JSDoc[]): Domain.GeneratorDocumentation {
+  static createGeneratorHints(jsDocs: ts.JSDoc[]): Domain.GeneratorDocumentation {
     const description = jsDocs.map(j => j.comment || "").join("\n");
     const keyValues = jsDocs.flatMap(j => (j.tags || [])).reduce((o, p) => ({...o, [p.tagName.escapedText]: p.comment}), {});
 
@@ -247,7 +266,7 @@ class InterfaceVisitor extends Visitor {
 export class TypeReader {
   private checker: ts.TypeChecker;
 
-  interfaces: (Domain.Interface | Domain.RequestInterface)[] = [];
+  interfaces: (Domain.TypeDeclaration)[] = [];
   enums: Domain.Enum[] = [];
   // TS1337 :( https://github.com/Microsoft/TypeScript/issues/1778
   /** @type {Object.<RestSpecName, TypeName>} */
@@ -262,29 +281,42 @@ export class TypeReader {
         .replace(/.*specification[\/\\]specs[\/\\]?/, "")
         .replace(/[\/\\]/g, ".");
       if (ns === "") ns = "internal";
-      this.visit(f, ns);
+      try {
+        this.visit(f, ns);
+      }
+      catch (e) {
+        // tslint:disable-next-line:no-console
+        console.log(f.fileName)
+        throw e
+      }
     }
   }
 
   private visit(node: ts.Node, namespace: string) {
-      switch (node.kind) {
-        case ts.SyntaxKind.ClassDeclaration:
-          const cv = new InterfaceVisitor(node as ts.ClassDeclaration, this.checker, namespace);
-          const c = cv.visit();
-          if (cv.specMapping) this.restSpecMapping[cv.specMapping.spec] = cv.specMapping;
-          this.interfaces.push(c);
-          break;
-        case ts.SyntaxKind.InterfaceDeclaration:
-          const iv = new InterfaceVisitor(node as ts.InterfaceDeclaration, this.checker, namespace);
-          const i = iv.visit();
-          this.interfaces.push(i);
-          break;
+    let visitChildren = true;
+    switch (node.kind) {
+      case ts.SyntaxKind.ClassDeclaration:
+        const cv = new InterfaceVisitor(node as ts.ClassDeclaration, this.checker, namespace);
+        const c = cv.visit();
+        if (cv.specMapping) this.restSpecMapping[cv.specMapping.spec] = cv.specMapping;
+        this.interfaces.push(c);
+        break;
+      case ts.SyntaxKind.InterfaceDeclaration:
+        const iv = new InterfaceVisitor(node as ts.InterfaceDeclaration, this.checker, namespace);
+        const i = iv.visit();
+        this.interfaces.push(i);
+        break;
 
-        case ts.SyntaxKind.EnumDeclaration:
-          const ev = new EnumVisitor(node as ts.EnumDeclaration, this.checker, namespace);
-          this.enums.push(ev.visit());
-          break;
-      }
-      ts.forEachChild(node, c => this.visit(c, namespace));
+      case ts.SyntaxKind.EnumDeclaration:
+        const ev = new EnumVisitor(node as ts.EnumDeclaration, this.checker, namespace);
+        this.enums.push(ev.visit());
+        break;
+      case ts.SyntaxKind.TypeAliasDeclaration:
+        const av = new InterfaceVisitor(node as ts.TypeAliasDeclaration, this.checker, namespace);
+        this.interfaces.push(av.visit());
+        visitChildren = false;
+        break;
+    }
+    if (visitChildren) ts.forEachChild(node, c => this.visit(c, namespace));
   }
 }


### PR DESCRIPTION
`TypeDeclaration` now has two more implementations

### `UnionAlias`

this allows us to reuse unions more purposefully in the
spec.

```ts
type X = Y | Z
```

This allows us to reuse a union in multiple places as well as name the
union explicitly and provide it with its own documentation. See e.g
`MinimumShouldMatch` which is on its own a union of `int` and `string`
which on its own is very nondescript.

### `StringAlias`

In many cases rather then documenting something is just a `string` we
can do better. e.g we know the string is functionally a `NodeId` or
`Field` reference.

```ts
type Field = string
```

Now suffices to strongly type strings. Added benefits to documentation
apply as well.

------

Type aliases ONLY work for string or unions the following is not valid:

```ts
type X = number
type Z = { A : B }
```

generators will need to update their instanceof checks when iterating over `specification.types`