### PR TITLE
Simplify SearchRequest's sort and _source field

### DIFF
--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -52,7 +52,8 @@ type ScrollIds = string
 type CategoryId = string
 type ActionIds = string
 type Field = string
-type Fields = string
+/** Wildcard (*) pattern or array of patterns containing source fields to return */
+type Fields = Field | Field[]
 type Id = string | number
 type Ids = string | number | string[]
 type IndexName = string

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -52,7 +52,7 @@ type ScrollIds = string
 type CategoryId = string
 type ActionIds = string
 type Field = string
-/** Wildcard (*) pattern or array of patterns containing source fields to return */
+/** Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.  */
 type Fields = Field | Field[]
 type Id = string | number
 type Ids = string | number | string[]

--- a/specification/specs/search/search/SearchRequest.ts
+++ b/specification/specs/search/search/SearchRequest.ts
@@ -62,8 +62,8 @@ class SearchRequest extends RequestBase {
     search_after: Array<integer | string>;
     size: integer;
     slice: SlicedScroll;
-    sort: Array<SingleKeyDictionary<Sort | SortOrder> | string>;
-    _source: Union<Union<boolean, Field>, Union<Field[], SourceFilter>>;
+    sort: SingleKeyDictionary<Sort | SortOrder>[];
+    _source: boolean | Fields | SourceFilter;
     suggest: Dictionary<string, SuggestBucket>;
     terminate_after: long;
     timeout: string;

--- a/specification/specs/search/search/source_filtering/SourceFilter.ts
+++ b/specification/specs/search/search/source_filtering/SourceFilter.ts
@@ -1,7 +1,7 @@
 @class_serializer("SourceFilterFormatter")
 class SourceFilter {
-  excludes: Union<Field, Field[]>;
-  includes: Union<Field, Field[]>;
+  excludes: Fields;
+  includes: Fields;
 }
 
 class DocValueField {


### PR DESCRIPTION
Simplification of `sort`: the `string` variant does not exist in the request body, but only as a query parameter

Simplification of `source`:
- rather than considering that there only exists a 2-variant `Union` (aka `Either`), we should let code generators handle unions of arbitrary length (we can have `Union2`, `Union3`, `Union4`, etc in languages missing proper tagged unions).
- Usage of `Fields` instead of `Field | Field[]` may help generators understand that these two variants are related and provide more ergonomic builder methods (although this could also be inferred from the `TypeA | TypeA[]` pattern).

Additional questions:
- `sort` and `_source` are also defined as query parameters in `search.json` (the Rest API spec) but only exist as a body parameters in `SearchRequest.ts`. Is this a general policy to only keep parameters in the body when they exist as both query and body parameters?

  If we do this, this means we close the door to using the TypeScript specs to generate server-side code for existing APIs (code modernization). So maybe we should keep them with a `@server-only` annotation so that they are ignored when generating clients but not forgotten when we want to use them to produce server code?

- if we remove `_source` as a query parameter we should also remove `_source_excludes` and `_source_includes` that go hand in hand with it (and are expressed in the `_source` body parameter).