### PR TITLE
Add missing 'require_alias' query param on 'update' API

### DIFF
--- a/specification/specs/document/single/update/UpdateRequest.ts
+++ b/specification/specs/document/single/update/UpdateRequest.ts
@@ -8,6 +8,7 @@ class UpdateRequest<TDocument, TPartialDocument> extends RequestBase {
     if_seq_no: long;
     lang: string;
     refresh: Refresh;
+    require_alias: boolean;
     retry_on_conflict: long;
     routing: Routing;
     source_enabled: boolean;


### PR DESCRIPTION
Part of https://github.com/elastic/clients-team/issues/326