### PR TITLE
Update search response with optionalibility

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -57478,7 +57478,14 @@
                     "kind": "instance_of",
                     "type": {
                       "namespace": "internal",
-                      "name": "number"
+                      "name": "long"
+                    }
+                  },
+                  {
+                    "kind": "instance_of",
+                    "type": {
+                      "namespace": "internal",
+                      "name": "double"
                     }
                   },
                   {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -18,6 +18,13 @@
           "kind": "instance_of",
           "type": {
             "namespace": "aggregations",
+            "name": "DocCountAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
             "name": "AutoDateHistogramAggregate"
           }
         },
@@ -219,7 +226,7 @@
               "kind": "user_defined_value"
             }
           },
-          "required": true
+          "required": false
         }
       ]
     },
@@ -1370,6 +1377,34 @@
       "kind": "interface",
       "name": {
         "namespace": "aggregations",
+        "name": "DocCountAggregate"
+      },
+      "inherits": [
+        {
+          "type": {
+            "namespace": "aggregations",
+            "name": "AggregateBase"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "doc_count",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "double"
+            }
+          },
+          "required": true
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "namespace": "aggregations",
         "name": "ExtendedStatsAggregate"
       },
       "inherits": [
@@ -1489,14 +1524,36 @@
         {
           "name": "buckets",
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "FiltersBucketItem"
+            "kind": "union_of",
+            "items": [
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "namespace": "aggregations",
+                    "name": "FiltersBucketItem"
+                  }
+                }
+              },
+              {
+                "kind": "dictionary_of",
+                "key": {
+                  "kind": "instance_of",
+                  "type": {
+                    "namespace": "internal",
+                    "name": "string"
+                  }
+                },
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "namespace": "aggregations",
+                    "name": "FiltersBucketItem"
+                  }
+                }
               }
-            }
+            ]
           },
           "required": true
         }
@@ -2569,7 +2626,7 @@
               "name": "string"
             }
           },
-          "required": true
+          "required": false
         }
       ]
     },
@@ -21960,7 +22017,7 @@
               "name": "string"
             }
           },
-          "required": true
+          "required": false
         }
       ]
     },
@@ -55722,68 +55779,34 @@
       ],
       "properties": [
         {
-          "name": "aggregations",
+          "name": "took",
           "type": {
-            "kind": "dictionary_of",
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "string"
-              }
-            },
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "Aggregate"
-              }
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "long"
             }
           },
           "required": true
         },
         {
-          "name": "_clusters",
+          "name": "timed_out",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "boolean"
+            }
+          },
+          "required": true
+        },
+        {
+          "name": "_shards",
           "type": {
             "kind": "instance_of",
             "type": {
               "namespace": "common_options.hit",
-              "name": "ClusterStatistics"
-            }
-          },
-          "required": true
-        },
-        {
-          "name": "documents",
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "generic",
-                "name": "TDocument"
-              }
-            }
-          },
-          "required": true
-        },
-        {
-          "name": "fields",
-          "type": {
-            "kind": "dictionary_of",
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "string"
-              }
-            },
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "common_abstractions.lazy_document",
-                "name": "LazyDocument"
-              }
+              "name": "ShardStatistics"
             }
           },
           "required": true
@@ -55809,6 +55832,73 @@
           "required": true
         },
         {
+          "name": "aggregations",
+          "type": {
+            "kind": "dictionary_of",
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "string"
+              }
+            },
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          },
+          "required": false
+        },
+        {
+          "name": "_clusters",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "common_options.hit",
+              "name": "ClusterStatistics"
+            }
+          },
+          "required": false
+        },
+        {
+          "name": "documents",
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "generic",
+                "name": "TDocument"
+              }
+            }
+          },
+          "required": false
+        },
+        {
+          "name": "fields",
+          "type": {
+            "kind": "dictionary_of",
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "string"
+              }
+            },
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "common_abstractions.lazy_document",
+                "name": "LazyDocument"
+              }
+            }
+          },
+          "required": false
+        },
+        {
           "name": "max_score",
           "type": {
             "kind": "instance_of",
@@ -55817,7 +55907,7 @@
               "name": "double"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "num_reduce_phases",
@@ -55828,7 +55918,7 @@
               "name": "long"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "profile",
@@ -55839,7 +55929,7 @@
               "name": "Profile"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "pit_id",
@@ -55850,7 +55940,7 @@
               "name": "string"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_scroll_id",
@@ -55861,18 +55951,7 @@
               "name": "string"
             }
           },
-          "required": true
-        },
-        {
-          "name": "_shards",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "common_options.hit",
-              "name": "ShardStatistics"
-            }
-          },
-          "required": true
+          "required": false
         },
         {
           "name": "suggest",
@@ -55892,7 +55971,7 @@
               }
             ]
           },
-          "required": true
+          "required": false
         },
         {
           "name": "terminated_early",
@@ -55903,40 +55982,7 @@
               "name": "boolean"
             }
           },
-          "required": true
-        },
-        {
-          "name": "timed_out",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "internal",
-              "name": "boolean"
-            }
-          },
-          "required": true
-        },
-        {
-          "name": "took",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "internal",
-              "name": "long"
-            }
-          },
-          "required": true
-        },
-        {
-          "name": "total",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "internal",
-              "name": "long"
-            }
-          },
-          "required": true
+          "required": false
         }
       ]
     },
@@ -57177,6 +57223,50 @@
       ],
       "properties": [
         {
+          "name": "_index",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "IndexName"
+            }
+          },
+          "required": true
+        },
+        {
+          "name": "_id",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "Id"
+            }
+          },
+          "required": true
+        },
+        {
+          "name": "_score",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "double"
+            }
+          },
+          "required": false
+        },
+        {
+          "name": "_type",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "TypeName"
+            }
+          },
+          "required": false
+        },
+        {
           "name": "_explanation",
           "type": {
             "kind": "instance_of",
@@ -57185,7 +57275,7 @@
               "name": "Explanation"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "fields",
@@ -57206,7 +57296,7 @@
               }
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "highlight",
@@ -57230,7 +57320,7 @@
               }
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "inner_hits",
@@ -57251,7 +57341,7 @@
               }
             }
           },
-          "required": true,
+          "required": false,
           "annotations": {
             "prop_serializer": "VerbatimInterfaceReadOnlyDictionaryKeysFormatter`2"
           }
@@ -57268,7 +57358,7 @@
               }
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_nested",
@@ -57279,7 +57369,7 @@
               "name": "NestedIdentity"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_ignored",
@@ -57293,29 +57383,7 @@
               }
             }
           },
-          "required": true
-        },
-        {
-          "name": "_index",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "internal",
-              "name": "IndexName"
-            }
-          },
-          "required": true
-        },
-        {
-          "name": "_id",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "internal",
-              "name": "Id"
-            }
-          },
-          "required": true
+          "required": false
         },
         {
           "name": "_shard",
@@ -57326,7 +57394,7 @@
               "name": "string"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_node",
@@ -57337,7 +57405,18 @@
               "name": "string"
             }
           },
-          "required": true
+          "required": false
+        },
+        {
+          "name": "_routing",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "string"
+            }
+          },
+          "required": false
         },
         {
           "name": "_source",
@@ -57348,7 +57427,7 @@
               "name": "TDocument"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_seq_no",
@@ -57359,7 +57438,7 @@
               "name": "long"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_primary_term",
@@ -57370,18 +57449,7 @@
               "name": "long"
             }
           },
-          "required": true
-        },
-        {
-          "name": "_score",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "internal",
-              "name": "double"
-            }
-          },
-          "required": true
+          "required": false
         },
         {
           "name": "_version",
@@ -57392,7 +57460,7 @@
               "name": "long"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "sort",
@@ -57424,7 +57492,7 @@
               }
             ]
           },
-          "required": true
+          "required": false
         }
       ]
     },
@@ -57438,6 +57506,29 @@
         "T"
       ],
       "properties": [
+        {
+          "name": "total",
+          "type": {
+            "kind": "union_of",
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "namespace": "search.search.hits",
+                  "name": "TotalHits"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "namespace": "internal",
+                  "name": "long"
+                }
+              }
+            ]
+          },
+          "required": true
+        },
         {
           "name": "hits",
           "type": {
@@ -57470,8 +57561,17 @@
               "name": "double"
             }
           },
-          "required": true
-        },
+          "required": false
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "namespace": "search.search.hits",
+        "name": "InnerHitsMetadata"
+      },
+      "properties": [
         {
           "name": "total",
           "type": {
@@ -57494,16 +57594,7 @@
             ]
           },
           "required": true
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "namespace": "search.search.hits",
-        "name": "InnerHitsMetadata"
-      },
-      "properties": [
+        },
         {
           "name": "hits",
           "type": {
@@ -57536,30 +57627,7 @@
               "name": "double"
             }
           },
-          "required": true
-        },
-        {
-          "name": "total",
-          "type": {
-            "kind": "union_of",
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "namespace": "search.search.hits",
-                  "name": "TotalHits"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "namespace": "internal",
-                  "name": "long"
-                }
-              }
-            ]
-          },
-          "required": true
+          "required": false
         }
       ]
     },
@@ -57602,17 +57670,6 @@
           "required": true
         },
         {
-          "name": "_nested",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "search.search.hits",
-              "name": "NestedIdentity"
-            }
-          },
-          "required": true
-        },
-        {
           "name": "offset",
           "type": {
             "kind": "instance_of",
@@ -57622,6 +57679,17 @@
             }
           },
           "required": true
+        },
+        {
+          "name": "_nested",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "search.search.hits",
+              "name": "NestedIdentity"
+            }
+          },
+          "required": false
         }
       ]
     },
@@ -58110,7 +58178,7 @@
               }
             }
           },
-          "required": true
+          "required": false
         }
       ]
     },
@@ -58129,20 +58197,6 @@
         "name": "Collector"
       },
       "properties": [
-        {
-          "name": "children",
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "search.search.profile",
-                "name": "Collector"
-              }
-            }
-          },
-          "required": true
-        },
         {
           "name": "name",
           "type": {
@@ -58175,6 +58229,20 @@
             }
           },
           "required": true
+        },
+        {
+          "name": "children",
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "search.search.profile",
+                "name": "Collector"
+              }
+            }
+          },
+          "required": false
         }
       ]
     },
@@ -58427,20 +58495,6 @@
           "required": true
         },
         {
-          "name": "children",
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "search.search.profile",
-                "name": "QueryProfile"
-              }
-            }
-          },
-          "required": true
-        },
-        {
           "name": "description",
           "type": {
             "kind": "instance_of",
@@ -58472,6 +58526,20 @@
             }
           },
           "required": true
+        },
+        {
+          "name": "children",
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "search.search.profile",
+                "name": "QueryProfile"
+              }
+            }
+          },
+          "required": false
         }
       ]
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6156,7 +6156,7 @@ export interface Hit<TDocument = unknown> {
   _seq_no?: long
   _primary_term?: long
   _version?: long
-  sort?: Array<number | string>
+  sort?: Array<long | double | string>
 }
 
 export interface HitsMetadata<T = unknown> {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -19,9 +19,9 @@
 
 import { Readable as ReadableStream } from 'stream'
 
-export type Aggregate = ValueAggregate | AutoDateHistogramAggregate | FiltersAggregate | SignificantTermsAggregate<object> | TermsAggregate<object> | BucketAggregate | CompositeBucketAggregate | MultiBucketAggregate<object> | SingleBucketAggregate | MatrixStatsAggregate | BoxPlotAggregate | ExtendedStatsAggregate | GeoBoundsAggregate | GeoCentroidAggregate | PercentilesAggregate | ScriptedMetricAggregate | StatsAggregate | StringStatsAggregate | TopHitsAggregate | TopMetricsAggregate | KeyedValueAggregate | TDigestPercentilesAggregate | HdrPercentilesAggregate
+export type Aggregate = ValueAggregate | DocCountAggregate | AutoDateHistogramAggregate | FiltersAggregate | SignificantTermsAggregate<object> | TermsAggregate<object> | BucketAggregate | CompositeBucketAggregate | MultiBucketAggregate<object> | SingleBucketAggregate | MatrixStatsAggregate | BoxPlotAggregate | ExtendedStatsAggregate | GeoBoundsAggregate | GeoCentroidAggregate | PercentilesAggregate | ScriptedMetricAggregate | StatsAggregate | StringStatsAggregate | TopHitsAggregate | TopMetricsAggregate | KeyedValueAggregate | TDigestPercentilesAggregate | HdrPercentilesAggregate
 export interface AggregateBase {
-  meta: Record<string, any>
+  meta?: Record<string, any>
 }
 
 export interface AggregationContainer {
@@ -127,6 +127,10 @@ export interface CompositeBucketAggregate extends MultiBucketAggregate<Record<st
 export interface DateHistogramBucket extends BucketBase {
 }
 
+export interface DocCountAggregate extends AggregateBase {
+  doc_count: double
+}
+
 export interface ExtendedStatsAggregate extends StatsAggregate {
   sum_of_squares: double
   variance: double
@@ -139,7 +143,7 @@ export interface ExtendedStatsAggregate extends StatsAggregate {
 }
 
 export interface FiltersAggregate extends AggregateBase {
-  buckets: Array<FiltersBucketItem>
+  buckets: Array<FiltersBucketItem> | Record<string, FiltersBucketItem>
 }
 
 export interface FiltersBucketItem extends BucketBase {
@@ -269,7 +273,7 @@ export interface TopMetricsAggregate extends AggregateBase {
 
 export interface ValueAggregate extends AggregateBase {
   value: double
-  value_as_string: string
+  value_as_string?: string
 }
 
 export interface AdjacencyMatrixAggregation {
@@ -2402,7 +2406,7 @@ export interface ShardFailure {
   node: string
   reason: ErrorCause
   shard: integer
-  status: string
+  status?: string
 }
 
 export type Size = 'Raw' | 'k' | 'm' | 'g' | 't' | 'p'
@@ -5988,22 +5992,21 @@ export interface SearchRequest extends RequestBase {
 }
 
 export interface SearchResponse<TDocument = unknown> extends ResponseBase {
-  aggregations: Record<string, Aggregate>
-  _clusters: ClusterStatistics
-  documents: Array<TDocument>
-  fields: Record<string, LazyDocument>
-  hits: HitsMetadata<TDocument>
-  max_score: double
-  num_reduce_phases: long
-  profile: Profile
-  pit_id: string
-  _scroll_id: string
-  _shards: ShardStatistics
-  suggest: SuggestDictionary<TDocument>
-  terminated_early: boolean
-  timed_out: boolean
   took: long
-  total: long
+  timed_out: boolean
+  _shards: ShardStatistics
+  hits: HitsMetadata<TDocument>
+  aggregations?: Record<string, Aggregate>
+  _clusters?: ClusterStatistics
+  documents?: Array<TDocument>
+  fields?: Record<string, LazyDocument>
+  max_score?: double
+  num_reduce_phases?: long
+  profile?: Profile
+  pit_id?: string
+  _scroll_id?: string
+  suggest?: SuggestDictionary<TDocument>
+  terminated_early?: boolean
 }
 
 export interface SearchNode {
@@ -6135,35 +6138,37 @@ export interface HighlightField {
 }
 
 export interface Hit<TDocument = unknown> {
-  _explanation: Explanation
-  fields: Record<string, LazyDocument>
-  highlight: Record<string, Array<string>>
-  inner_hits: Record<string, InnerHitsResult>
-  matched_queries: Array<string>
-  _nested: NestedIdentity
-  _ignored: Array<string>
   _index: IndexName
   _id: Id
-  _shard: string
-  _node: string
-  _source: TDocument
-  _seq_no: long
-  _primary_term: long
-  _score: double
-  _version: long
-  sort: Array<number | string>
+  _score?: double
+  _type?: TypeName
+  _explanation?: Explanation
+  fields?: Record<string, LazyDocument>
+  highlight?: Record<string, Array<string>>
+  inner_hits?: Record<string, InnerHitsResult>
+  matched_queries?: Array<string>
+  _nested?: NestedIdentity
+  _ignored?: Array<string>
+  _shard?: string
+  _node?: string
+  _routing?: string
+  _source?: TDocument
+  _seq_no?: long
+  _primary_term?: long
+  _version?: long
+  sort?: Array<number | string>
 }
 
 export interface HitsMetadata<T = unknown> {
-  hits: Array<Hit<T>>
-  max_score: double
   total: TotalHits | long
+  hits: Array<Hit<T>>
+  max_score?: double
 }
 
 export interface InnerHitsMetadata {
-  hits: Array<Hit<LazyDocument>>
-  max_score: double
   total: TotalHits | long
+  hits: Array<Hit<LazyDocument>>
+  max_score?: double
 }
 
 export interface InnerHitsResult {
@@ -6172,8 +6177,8 @@ export interface InnerHitsResult {
 
 export interface NestedIdentity {
   field: Field
-  _nested: NestedIdentity
   offset: integer
+  _nested?: NestedIdentity
 }
 
 export interface TotalHits {
@@ -6224,17 +6229,17 @@ export interface AggregationProfile {
   time_in_nanos: long
   type: string
   debug: AggregationProfileDebug
-  children: Array<AggregationProfileDebug>
+  children?: Array<AggregationProfileDebug>
 }
 
 export interface AggregationProfileDebug {
 }
 
 export interface Collector {
-  children: Array<Collector>
   name: string
   reason: string
   time_in_nanos: long
+  children?: Array<Collector>
 }
 
 export interface Profile {
@@ -6264,10 +6269,10 @@ export interface QueryBreakdown {
 
 export interface QueryProfile {
   breakdown: QueryBreakdown
-  children: Array<QueryProfile>
   description: string
   time_in_nanos: long
   type: string
+  children?: Array<QueryProfile>
 }
 
 export interface SearchProfile {

--- a/specification/specs/aggregations/Aggregate.ts
+++ b/specification/specs/aggregations/Aggregate.ts
@@ -22,6 +22,7 @@ class SignificantTermsBucket<TKey> extends BucketBase {}
 class KeyedBucket<TKey> extends BucketBase {}
 
 type Aggregate  = ValueAggregate
+  | DocCountAggregate
   | AutoDateHistogramAggregate
   | FiltersAggregate
   | SignificantTermsAggregate<any>
@@ -46,7 +47,7 @@ type Aggregate  = ValueAggregate
   | HdrPercentilesAggregate
 
 class AggregateBase {
-  meta: Dictionary<string, UserDefinedValue>;
+  meta?: Dictionary<string, UserDefinedValue>;
 }
 
 class MultiBucketAggregate<TBucket> extends AggregateBase {
@@ -54,8 +55,12 @@ class MultiBucketAggregate<TBucket> extends AggregateBase {
 }
 
 class ValueAggregate extends AggregateBase {
-  value: double
-  value_as_string: string
+  value: double;
+  value_as_string?: string;
+}
+
+class DocCountAggregate extends AggregateBase {
+  doc_count: double;
 }
 class KeyedValueAggregate extends ValueAggregate {
   keys:string[]
@@ -67,7 +72,7 @@ class AutoDateHistogramAggregate extends AggregateBase {
 }
 
 class FiltersAggregate extends AggregateBase {
-  buckets:FiltersBucketItem[];
+  buckets:FiltersBucketItem[] | Dictionary<string, FiltersBucketItem>;
 }
 
 class SignificantTermsAggregate<TKey> extends MultiBucketAggregate<TKey> {

--- a/specification/specs/aggregations/Aggregate.ts
+++ b/specification/specs/aggregations/Aggregate.ts
@@ -72,7 +72,7 @@ class AutoDateHistogramAggregate extends AggregateBase {
 }
 
 class FiltersAggregate extends AggregateBase {
-  buckets:FiltersBucketItem[] | Dictionary<string, FiltersBucketItem>;
+  buckets: FiltersBucketItem[] | Dictionary<string, FiltersBucketItem>;
 }
 
 class SignificantTermsAggregate<TKey> extends MultiBucketAggregate<TKey> {
@@ -201,4 +201,3 @@ class TopMetricsAggregate extends AggregateBase {
   sort: double[];
   metrics: double[];
 }
-

--- a/specification/specs/common/ShardFailure.ts
+++ b/specification/specs/common/ShardFailure.ts
@@ -3,5 +3,5 @@ class ShardFailure {
   node: string;
   reason: ErrorCause;
   shard: integer;
-  status: string;
+  status?: string;
 }

--- a/specification/specs/search/search/SearchResponse.ts
+++ b/specification/specs/search/search/SearchResponse.ts
@@ -1,18 +1,18 @@
 class SearchResponse<TDocument> extends ResponseBase {
-  aggregations: Dictionary<string, Aggregate>;
-  _clusters: ClusterStatistics;
-  documents: TDocument[];
-  fields: Dictionary<string, LazyDocument>;
-  hits: HitsMetadata<TDocument>;
-  max_score: double;
-  num_reduce_phases: long;
-  profile: Profile;
-  pit_id: string;
-  _scroll_id: string;
-  _shards: ShardStatistics;
-  suggest: SuggestDictionary<TDocument>;
-  terminated_early: boolean;
-  timed_out: boolean;
   took: long;
-  total: long;
+  timed_out: boolean;
+  _shards: ShardStatistics;
+  hits: HitsMetadata<TDocument>;
+
+  aggregations?: Dictionary<string, Aggregate>;
+  _clusters?: ClusterStatistics;
+  documents?: TDocument[];
+  fields?: Dictionary<string, LazyDocument>;
+  max_score?: double;
+  num_reduce_phases?: long;
+  profile?: Profile;
+  pit_id?: string;
+  _scroll_id?: string;
+  suggest?: SuggestDictionary<TDocument>;
+  terminated_early?: boolean;
 }

--- a/specification/specs/search/search/hits/Hit.ts
+++ b/specification/specs/search/search/hits/Hit.ts
@@ -21,5 +21,5 @@ class Hit<TDocument> {
   _seq_no?: long;
   _primary_term?: long;
   _version?: long;
-  sort?: Array<number | string>;
+  sort?: Array<long | double | string>;
 }

--- a/specification/specs/search/search/hits/Hit.ts
+++ b/specification/specs/search/search/hits/Hit.ts
@@ -1,21 +1,25 @@
 class Hit<TDocument> {
-  _explanation: Explanation;
-  fields: Dictionary<string, LazyDocument>;
-  highlight: Dictionary<string, string[]>;
-  /** @prop_serializer VerbatimInterfaceReadOnlyDictionaryKeysFormatter`2 */
-  inner_hits: Dictionary<string, InnerHitsResult>;
-  matched_queries: string[];
-  _nested: NestedIdentity;
-  _ignored: string[];
-
   _index: IndexName;
   _id: Id;
-  _shard: string;
-  _node: string;
-  _source: TDocument;
-  _seq_no: long;
-  _primary_term: long;
-  _score: double;
-  _version: long;
-  sort: Array<number | string>;
+
+  _score?: double;
+  _type?: TypeName;
+
+  _explanation?: Explanation;
+  fields?: Dictionary<string, LazyDocument>;
+  highlight?: Dictionary<string, string[]>;
+  /** @prop_serializer VerbatimInterfaceReadOnlyDictionaryKeysFormatter`2 */
+  inner_hits?: Dictionary<string, InnerHitsResult>;
+  matched_queries?: string[];
+  _nested?: NestedIdentity;
+  _ignored?: string[];
+
+  _shard?: string;
+  _node?: string;
+  _routing?: string;
+  _source?: TDocument;
+  _seq_no?: long;
+  _primary_term?: long;
+  _version?: long;
+  sort?: Array<number | string>;
 }

--- a/specification/specs/search/search/hits/HitsMetadata.ts
+++ b/specification/specs/search/search/hits/HitsMetadata.ts
@@ -1,5 +1,6 @@
 class HitsMetadata<T> {
-  hits: Hit<T>[];
-  max_score: double;
   total: TotalHits | long;
+  hits: Hit<T>[];
+
+  max_score?: double;
 }

--- a/specification/specs/search/search/hits/InnerHitsMetadata.ts
+++ b/specification/specs/search/search/hits/InnerHitsMetadata.ts
@@ -1,5 +1,6 @@
 class InnerHitsMetadata {
-  hits: Hit<LazyDocument>[];
-  max_score: double;
   total: TotalHits | long;
+  hits: Hit<LazyDocument>[];
+
+  max_score?: double;
 }

--- a/specification/specs/search/search/hits/NestedIdentity.ts
+++ b/specification/specs/search/search/hits/NestedIdentity.ts
@@ -1,5 +1,5 @@
 class NestedIdentity {
   field: Field;
-  _nested: NestedIdentity;
   offset: integer;
+  _nested?: NestedIdentity;
 }

--- a/specification/specs/search/search/profile/AggregationProfile.ts
+++ b/specification/specs/search/search/profile/AggregationProfile.ts
@@ -7,6 +7,6 @@ class AggregationProfile {
   time_in_nanos: long;
   type: string;
   debug: AggregationProfileDebug;
-  children: AggregationProfileDebug[];
+  children?: AggregationProfileDebug[];
 }
 

--- a/specification/specs/search/search/profile/Collector.ts
+++ b/specification/specs/search/search/profile/Collector.ts
@@ -1,6 +1,7 @@
 class Collector {
-  children: Collector[];
   name: string;
   reason: string;
   time_in_nanos: long;
+
+  children?: Collector[];
 }

--- a/specification/specs/search/search/profile/QueryProfile.ts
+++ b/specification/specs/search/search/profile/QueryProfile.ts
@@ -1,7 +1,8 @@
 class QueryProfile {
   breakdown: QueryBreakdown;
-  children: QueryProfile[];
   description: string;
   time_in_nanos: long;
   type: string;
+
+  children?: QueryProfile[];
 }


### PR DESCRIPTION
Reduces failures down to 15 locally.

The remainder are aggregations N level deep for which we need to
formulate a battle plan.
