### PR TITLE
Seperate extends and implements

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1201,7 +1201,6 @@
       },
       "implements": [
         {
-          "depth": 0,
           "type": {
             "namespace": "common",
             "name": "IDictionary"
@@ -1223,6 +1222,9 @@
             }
           ]
         }
+      ],
+      "traits": [
+        "IDictionary"
       ],
       "properties": []
     },
@@ -1240,30 +1242,8 @@
           }
         }
       ],
-      "implements": [
-        {
-          "depth": 1,
-          "type": {
-            "namespace": "common",
-            "name": "IDictionary"
-          },
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "AggregateName"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "Aggregate"
-              }
-            }
-          ]
-        }
+      "traits": [
+        "IDictionary"
       ],
       "properties": []
     },
@@ -1330,30 +1310,8 @@
           }
         }
       ],
-      "implements": [
-        {
-          "depth": 1,
-          "type": {
-            "namespace": "common",
-            "name": "IDictionary"
-          },
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "AggregateName"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "Aggregate"
-              }
-            }
-          ]
-        }
+      "traits": [
+        "IDictionary"
       ],
       "properties": []
     },
@@ -1529,30 +1487,8 @@
           }
         }
       ],
-      "implements": [
-        {
-          "depth": 1,
-          "type": {
-            "namespace": "common",
-            "name": "IDictionary"
-          },
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "AggregateName"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "Aggregate"
-              }
-            }
-          ]
-        }
+      "traits": [
+        "IDictionary"
       ],
       "properties": [
         {
@@ -1742,30 +1678,8 @@
           }
         }
       ],
-      "implements": [
-        {
-          "depth": 1,
-          "type": {
-            "namespace": "common",
-            "name": "IDictionary"
-          },
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "AggregateName"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "Aggregate"
-              }
-            }
-          ]
-        }
+      "traits": [
+        "IDictionary"
       ],
       "properties": []
     },
@@ -1786,30 +1700,8 @@
           }
         }
       ],
-      "implements": [
-        {
-          "depth": 1,
-          "type": {
-            "namespace": "common",
-            "name": "IDictionary"
-          },
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "AggregateName"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "Aggregate"
-              }
-            }
-          ]
-        }
+      "traits": [
+        "IDictionary"
       ],
       "properties": []
     },
@@ -2209,30 +2101,8 @@
           }
         }
       ],
-      "implements": [
-        {
-          "depth": 1,
-          "type": {
-            "namespace": "common",
-            "name": "IDictionary"
-          },
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "AggregateName"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "Aggregate"
-              }
-            }
-          ]
-        }
+      "traits": [
+        "IDictionary"
       ],
       "properties": []
     },
@@ -2253,30 +2123,8 @@
           }
         }
       ],
-      "implements": [
-        {
-          "depth": 1,
-          "type": {
-            "namespace": "common",
-            "name": "IDictionary"
-          },
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "AggregateName"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "Aggregate"
-              }
-            }
-          ]
-        }
+      "traits": [
+        "IDictionary"
       ],
       "properties": []
     },
@@ -2364,30 +2212,8 @@
           }
         }
       ],
-      "implements": [
-        {
-          "depth": 1,
-          "type": {
-            "namespace": "common",
-            "name": "IDictionary"
-          },
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "AggregateName"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "aggregations",
-                "name": "Aggregate"
-              }
-            }
-          ]
-        }
+      "traits": [
+        "IDictionary"
       ],
       "properties": []
     },
@@ -2407,7 +2233,6 @@
       ],
       "implements": [
         {
-          "depth": 0,
           "type": {
             "namespace": "common",
             "name": "IDictionary"
@@ -2429,6 +2254,9 @@
             }
           ]
         }
+      ],
+      "traits": [
+        "IDictionary"
       ],
       "properties": [
         {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -45945,27 +45945,6 @@
             }
           },
           "required": true
-        },
-        {
-          "name": "properties",
-          "type": {
-            "kind": "dictionary_of",
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "PropertyName"
-              }
-            },
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "mapping.types",
-                "name": "IProperty"
-              }
-            }
-          },
-          "required": false
         }
       ]
     },

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -6621,27 +6621,7 @@
               "name": "string"
             }
           },
-          "required": false
-        },
-        {
-          "name": "stopwords",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "internal",
-              "name": "Array"
-            },
-            "generics": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "namespace": "internal",
-                  "name": "string"
-                }
-              }
-            ]
-          },
-          "required": false
+          "required": true
         }
       ]
     },

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1199,11 +1199,11 @@
         "namespace": "aggregations",
         "name": "BucketBase"
       },
-      "implements": [
+      "behaviors": [
         {
           "type": {
-            "namespace": "common",
-            "name": "IDictionary"
+            "namespace": "internal",
+            "name": "AdditionalProperties"
           },
           "generics": [
             {
@@ -1223,8 +1223,8 @@
           ]
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": []
     },
@@ -1242,8 +1242,8 @@
           }
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": []
     },
@@ -1310,8 +1310,8 @@
           }
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": []
     },
@@ -1487,8 +1487,8 @@
           }
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": [
         {
@@ -1678,8 +1678,8 @@
           }
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": []
     },
@@ -1700,8 +1700,8 @@
           }
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": []
     },
@@ -2101,8 +2101,8 @@
           }
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": []
     },
@@ -2123,8 +2123,8 @@
           }
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": []
     },
@@ -2212,8 +2212,8 @@
           }
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": []
     },
@@ -2231,11 +2231,11 @@
           }
         }
       ],
-      "implements": [
+      "behaviors": [
         {
           "type": {
-            "namespace": "common",
-            "name": "IDictionary"
+            "namespace": "internal",
+            "name": "AdditionalProperties"
           },
           "generics": [
             {
@@ -2255,8 +2255,8 @@
           ]
         }
       ],
-      "traits": [
-        "IDictionary"
+      "attachedBehaviors": [
+        "AdditionalProperties"
       ],
       "properties": [
         {
@@ -22261,18 +22261,6 @@
           ]
         }
       ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "namespace": "common",
-        "name": "IDictionary"
-      },
-      "generics": [
-        "TKey",
-        "TValue"
-      ],
-      "properties": []
     },
     {
       "kind": "enum",
@@ -44393,6 +44381,18 @@
           "required": true
         }
       ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "namespace": "internal",
+        "name": "AdditionalProperties"
+      },
+      "generics": [
+        "TKey",
+        "TValue"
+      ],
+      "properties": []
     },
     {
       "kind": "type_alias",

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -11,14 +11,7 @@
           "kind": "instance_of",
           "type": {
             "namespace": "aggregations",
-            "name": "ValueAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "DocCountAggregate"
+            "name": "SingleBucketAggregate"
           }
         },
         {
@@ -101,84 +94,7 @@
           "kind": "instance_of",
           "type": {
             "namespace": "aggregations",
-            "name": "SingleBucketAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
             "name": "MatrixStatsAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "BoxPlotAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "ExtendedStatsAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "GeoBoundsAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "GeoCentroidAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "PercentilesAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "ScriptedMetricAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "StatsAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "StringStatsAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "TopHitsAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "TopMetricsAggregate"
           }
         },
         {
@@ -192,14 +108,7 @@
           "kind": "instance_of",
           "type": {
             "namespace": "aggregations",
-            "name": "TDigestPercentilesAggregate"
-          }
-        },
-        {
-          "kind": "instance_of",
-          "type": {
-            "namespace": "aggregations",
-            "name": "HdrPercentilesAggregate"
+            "name": "MetricAggregate"
           }
         }
       ]
@@ -1290,6 +1199,31 @@
         "namespace": "aggregations",
         "name": "BucketBase"
       },
+      "implements": [
+        {
+          "depth": 0,
+          "type": {
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
+        }
+      ],
       "properties": []
     },
     {
@@ -1304,6 +1238,31 @@
             "namespace": "aggregations",
             "name": "BucketBase"
           }
+        }
+      ],
+      "implements": [
+        {
+          "depth": 1,
+          "type": {
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
         }
       ],
       "properties": []
@@ -1371,35 +1330,32 @@
           }
         }
       ],
-      "properties": []
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "namespace": "aggregations",
-        "name": "DocCountAggregate"
-      },
-      "inherits": [
+      "implements": [
         {
+          "depth": 1,
           "type": {
-            "namespace": "aggregations",
-            "name": "AggregateBase"
-          }
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
         }
       ],
-      "properties": [
-        {
-          "name": "doc_count",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "internal",
-              "name": "double"
-            }
-          },
-          "required": true
-        }
-      ]
+      "properties": []
     },
     {
       "kind": "interface",
@@ -1571,6 +1527,31 @@
             "namespace": "aggregations",
             "name": "BucketBase"
           }
+        }
+      ],
+      "implements": [
+        {
+          "depth": 1,
+          "type": {
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
         }
       ],
       "properties": [
@@ -1761,6 +1742,31 @@
           }
         }
       ],
+      "implements": [
+        {
+          "depth": 1,
+          "type": {
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
+        }
+      ],
       "properties": []
     },
     {
@@ -1778,6 +1784,31 @@
             "namespace": "aggregations",
             "name": "BucketBase"
           }
+        }
+      ],
+      "implements": [
+        {
+          "depth": 1,
+          "type": {
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
         }
       ],
       "properties": []
@@ -1942,6 +1973,106 @@
       "kind": "union",
       "name": {
         "namespace": "aggregations",
+        "name": "MetricAggregate"
+      },
+      "items": [
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "ValueAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "BoxPlotAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "GeoBoundsAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "GeoCentroidAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "PercentilesAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "ScriptedMetricAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "StatsAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "StringStatsAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "TopHitsAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "TopMetricsAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "ExtendedStatsAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "TDigestPercentilesAggregate"
+          }
+        },
+        {
+          "kind": "instance_of",
+          "type": {
+            "namespace": "aggregations",
+            "name": "HdrPercentilesAggregate"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "union",
+      "name": {
+        "namespace": "aggregations",
         "name": "Missing"
       },
       "items": [
@@ -2078,6 +2209,31 @@
           }
         }
       ],
+      "implements": [
+        {
+          "depth": 1,
+          "type": {
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
+        }
+      ],
       "properties": []
     },
     {
@@ -2095,6 +2251,31 @@
             "namespace": "aggregations",
             "name": "BucketBase"
           }
+        }
+      ],
+      "implements": [
+        {
+          "depth": 1,
+          "type": {
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
         }
       ],
       "properties": []
@@ -2183,6 +2364,31 @@
           }
         }
       ],
+      "implements": [
+        {
+          "depth": 1,
+          "type": {
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
+        }
+      ],
       "properties": []
     },
     {
@@ -2199,7 +2405,44 @@
           }
         }
       ],
-      "properties": []
+      "implements": [
+        {
+          "depth": 0,
+          "type": {
+            "namespace": "common",
+            "name": "IDictionary"
+          },
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "AggregateName"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "aggregations",
+                "name": "Aggregate"
+              }
+            }
+          ]
+        }
+      ],
+      "properties": [
+        {
+          "name": "doc_count",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "double"
+            }
+          },
+          "required": true
+        }
+      ]
     },
     {
       "kind": "interface",
@@ -6496,7 +6739,7 @@
       "kind": "interface",
       "name": {
         "namespace": "analysis.char_filters",
-        "name": "ICharFilter"
+        "name": "CharFilterBase"
       },
       "properties": [
         {
@@ -6527,7 +6770,7 @@
       "kind": "interface",
       "name": {
         "namespace": "analysis.token_filters",
-        "name": "ITokenFilter"
+        "name": "TokenFilterBase"
       },
       "properties": [
         {
@@ -6578,7 +6821,7 @@
       "kind": "interface",
       "name": {
         "namespace": "analysis.tokenizers",
-        "name": "ITokenizer"
+        "name": "TokenizerBase"
       },
       "properties": [
         {
@@ -22192,6 +22435,18 @@
       ]
     },
     {
+      "kind": "interface",
+      "name": {
+        "namespace": "common",
+        "name": "IDictionary"
+      },
+      "generics": [
+        "TKey",
+        "TValue"
+      ],
+      "properties": []
+    },
+    {
       "kind": "enum",
       "name": {
         "namespace": "common",
@@ -32723,7 +32978,7 @@
                     "kind": "instance_of",
                     "type": {
                       "namespace": "analysis.char_filters",
-                      "name": "ICharFilter"
+                      "name": "CharFilterBase"
                     }
                   }
                 ]
@@ -32771,7 +33026,7 @@
                     "kind": "instance_of",
                     "type": {
                       "namespace": "analysis.token_filters",
-                      "name": "ITokenFilter"
+                      "name": "TokenFilterBase"
                     }
                   }
                 ]
@@ -32838,7 +33093,7 @@
                   "kind": "instance_of",
                   "type": {
                     "namespace": "analysis.tokenizers",
-                    "name": "ITokenizer"
+                    "name": "TokenizerBase"
                   }
                 }
               ]
@@ -36682,7 +36937,7 @@
                 "kind": "instance_of",
                 "type": {
                   "namespace": "mapping.types",
-                  "name": "IProperty"
+                  "name": "PropertyBase"
                 }
               }
             },
@@ -44315,6 +44570,20 @@
       "kind": "type_alias",
       "name": {
         "namespace": "internal",
+        "name": "AggregateName"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "namespace": "internal",
+          "name": "string"
+        }
+      }
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "namespace": "internal",
         "name": "CategoryId"
       },
       "type": {
@@ -45363,7 +45632,7 @@
               "kind": "instance_of",
               "type": {
                 "namespace": "mapping.types",
-                "name": "IProperty"
+                "name": "PropertyBase"
               }
             }
           },
@@ -45417,7 +45686,7 @@
             "kind": "instance_of",
             "type": {
               "namespace": "mapping.types",
-              "name": "IProperty"
+              "name": "PropertyBase"
             }
           },
           "required": true
@@ -45786,7 +46055,7 @@
       "kind": "interface",
       "name": {
         "namespace": "mapping.types",
-        "name": "IProperty"
+        "name": "PropertyBase"
       },
       "properties": [
         {
@@ -45804,7 +46073,7 @@
               "kind": "user_defined_value"
             }
           },
-          "required": false
+          "required": true
         },
         {
           "name": "meta",
@@ -45825,7 +46094,7 @@
               }
             }
           },
-          "required": false
+          "required": true
         },
         {
           "name": "name",
@@ -45836,7 +46105,7 @@
               "name": "PropertyName"
             }
           },
-          "required": false
+          "required": true
         },
         {
           "name": "type",
@@ -56732,7 +57001,7 @@
               "kind": "instance_of",
               "type": {
                 "namespace": "internal",
-                "name": "string"
+                "name": "AggregateName"
               }
             },
             "value": {
@@ -75005,7 +75274,7 @@
               "kind": "instance_of",
               "type": {
                 "namespace": "analysis.token_filters",
-                "name": "ITokenFilter"
+                "name": "TokenFilterBase"
               }
             }
           },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -114,7 +114,7 @@ export interface BucketAggregate extends AggregateBase {
   items: Bucket
 }
 
-export interface BucketBase extends IDictionary<AggregateName, Aggregate> {
+export interface BucketBase {
 }
 
 export interface CompositeBucket extends BucketBase {
@@ -222,7 +222,7 @@ export interface SignificantTermsAggregate<TKey = unknown> extends MultiBucketAg
 export interface SignificantTermsBucket<TKey = unknown> extends BucketBase {
 }
 
-export interface SingleBucketAggregate extends AggregateBase, IDictionary<AggregateName, Aggregate> {
+export interface SingleBucketAggregate extends AggregateBase {
   doc_count: double
 }
 
@@ -746,18 +746,17 @@ export interface SumBucketAggregation {
 }
 
 export type StopWords = string | Array<string>
-export interface ICharFilter {
+export interface CharFilterBase {
   type: string
   version: string
 }
 
-export interface ITokenFilter {
+export interface TokenFilterBase {
   type: string
-  version?: string
-  stopwords?: Array<string>
+  version: string
 }
 
-export interface ITokenizer {
+export interface TokenizerBase {
   type: string
   version: string
 }
@@ -916,15 +915,15 @@ export interface CatHelpRequest extends CatRequestBase {
 export type CatHelpResponse = CatHelpRecord[]
 
 export interface CatIndicesRecord {
-  'docs.count': string
-  'docs.deleted': string
+  'docs.count': long
+  'docs.deleted': long
   health: string
   index: string
   pri: string
-  'pri.store.size': string
+  'pri.store.size': long
   rep: string
   status: string
-  'store.size': string
+  'store.size': long
   tm: string
   uuid: string
 }
@@ -1476,41 +1475,33 @@ export interface ClusterAllocationExplainRequest extends RequestBase {
     index?: IndexName
     primary?: boolean
     shard?: integer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ClusterAllocationExplainResponse extends ResponseBase {
-  allocate_explanation?: string
-  allocation_delay?: string
-  allocation_delay_in_millis?: long
-  can_allocate?: Decision
-  can_move_to_other_node?: Decision
-  can_rebalance_cluster?: Decision
-  can_rebalance_cluster_decisions?: Array<AllocationDecision>
-  can_rebalance_to_other_node?: Decision
-  can_remain_decisions?: Array<AllocationDecision>
-  can_remain_on_current_node?: Decision
-  cluster_info?: ClusterInfo
-  configured_delay?: string
-  configured_delay_in_mills?: long
-  current_node?: CurrentNode
+  allocate_explanation: string
+  allocation_delay: string
+  allocation_delay_in_millis: long
+  can_allocate: Decision
+  can_move_to_other_node: Decision
+  can_rebalance_cluster: Decision
+  can_rebalance_cluster_decisions: Array<AllocationDecision>
+  can_rebalance_to_other_node: Decision
+  can_remain_decisions: Array<AllocationDecision>
+  can_remain_on_current_node: Decision
+  configured_delay: string
+  configured_delay_in_mills: long
+  current_node: CurrentNode
   current_state: string
   index: string
-  move_explanation?: string
-  node_allocation_decisions?: Array<NodeAllocationExplanation>
+  move_explanation: string
+  node_allocation_decisions: Array<NodeAllocationExplanation>
   primary: boolean
-  rebalance_explanation?: string
-  remaining_delay?: string
-  remaining_delay_in_millis?: long
+  rebalance_explanation: string
+  remaining_delay: string
+  remaining_delay_in_millis: long
   shard: integer
-  unassigned_info?: UnassignedInformation
-}
-
-export interface ClusterInfo {
-  nodes: Record<string, NodeDiskUsage>
-  shard_sizes: Record<string, long>
-  shard_paths: Record<string, string>
-  reserved_sizes: Array<ReservedSize>
+  unassigned_info: UnassignedInformation
 }
 
 export interface CurrentNode {
@@ -1523,45 +1514,21 @@ export interface CurrentNode {
 
 export type Decision = 'yes' | 'no' | 'worse_balance' | 'throttled' | 'awaiting_info' | 'allocation_delayed' | 'no_valid_shard_copy' | 'no_attempt'
 
-export interface DiskUsage {
-  path: string
-  total_bytes: long
-  used_bytes: long
-  free_bytes: long
-  free_disk_percent: double
-  used_disk_percent: double
-}
-
 export interface NodeAllocationExplanation {
   deciders: Array<AllocationDecision>
   node_attributes: Record<string, string>
   node_decision: Decision
   node_id: string
   node_name: string
-  store?: AllocationStore
+  store: AllocationStore
   transport_address: string
   weight_ranking: integer
-}
-
-export interface NodeDiskUsage {
-  node_name: string
-  least_available: DiskUsage
-  most_available: DiskUsage
-}
-
-export interface ReservedSize {
-  node_id: string
-  path: string
-  total: long
-  shards: Array<string>
 }
 
 export interface UnassignedInformation {
   at: Date
   last_allocation_status: string
   reason: UnassignedInformationReason
-  details?: string
-  failed_allocation_attempts?: integer
 }
 
 export type UnassignedInformationReason = 'INDEX_CREATED' | 'CLUSTER_RECOVERED' | 'INDEX_REOPENED' | 'DANGLING_INDEX_IMPORTED' | 'NEW_INDEX_RESTORED' | 'EXISTING_INDEX_RESTORED' | 'REPLICA_ADDED' | 'ALLOCATION_FAILED' | 'NODE_LEFT' | 'REROUTE_CANCELLED' | 'REINITIALIZED' | 'REALLOCATED_REPLICA' | 'PRIMARY_FAILED' | 'FORCED_EMPTY_PRIMARY' | 'MANUAL_ALLOCATION'
@@ -1668,7 +1635,7 @@ export interface ClusterRerouteRequest extends RequestBase {
   timeout?: Time
   body?: {
     commands?: Array<ClusterRerouteCommand>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ClusterRerouteResponse extends ResponseBase {
@@ -1699,7 +1666,7 @@ export interface ClusterPutSettingsRequest extends RequestBase {
   body: {
     persistent?: Record<string, any>
     transient?: Record<string, any>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ClusterPutSettingsResponse extends ResponseBase {
@@ -2567,7 +2534,6 @@ export type ShapeRelation = 'intersects' | 'disjoint' | 'within'
 
 export interface CompletionStats {
   size_in_bytes: long
-  fields?: Record<Field, CompletionStats>
 }
 
 export interface DocStats {
@@ -2576,27 +2542,26 @@ export interface DocStats {
 }
 
 export interface FielddataStats {
-  evictions?: long
+  evictions: long
   memory_size_in_bytes: long
-  fields?: Record<Field, FielddataStats>
 }
 
 export interface FlushStats {
   periodic: long
   total: long
-  total_time?: string
+  total_time: string
   total_time_in_millis: long
 }
 
 export interface GetStats {
   current: long
-  exists_time?: string
+  exists_time: string
   exists_time_in_millis: long
   exists_total: long
-  missing_time?: string
+  missing_time: string
   missing_time_in_millis: long
   missing_total: long
-  time?: string
+  time: string
   time_in_millis: long
   total: long
 }
@@ -2604,36 +2569,35 @@ export interface GetStats {
 export interface IndexingStats {
   index_current: long
   delete_current: long
-  delete_time?: string
+  delete_time: string
   delete_time_in_millis: long
   delete_total: long
   is_throttled: boolean
   noop_update_total: long
-  throttle_time?: string
+  throttle_time: string
   throttle_time_in_millis: long
-  index_time?: string
+  index_time: string
   index_time_in_millis: long
   index_total: long
-  index_failed: long
-  types?: Record<string, IndexingStats>
+  types: Record<string, IndexingStats>
 }
 
 export interface MergesStats {
   current: long
   current_docs: long
-  current_size?: string
+  current_size: string
   current_size_in_bytes: long
   total: long
-  total_auto_throttle?: string
+  total_auto_throttle: string
   total_auto_throttle_in_bytes: long
   total_docs: long
-  total_size?: string
+  total_size: string
   total_size_in_bytes: long
-  total_stopped_time?: string
-  total_stopped_time_in_millis: long
-  total_throttled_time?: string
+  total_stopped_time: string
+  total__stopped_time_in_millis: long
+  total_throttled_time: string
   total_throttled_time_in_millis: long
-  total_time?: string
+  total_time: string
   total_time_in_millis: long
 }
 
@@ -2661,23 +2625,22 @@ export interface QueryCacheStats {
 export interface RecoveryStats {
   current_as_source: long
   current_as_target: long
-  throttle_time?: string
+  throttle_time: string
   throttle_time_in_millis: long
 }
 
 export interface RefreshStats {
   external_total: long
   external_total_time_in_millis: long
-  listeners: long
   total: long
-  total_time?: string
+  total_time: string
   total_time_in_millis: long
 }
 
 export interface RequestCacheStats {
   evictions: long
   hit_count: long
-  memory_size?: string
+  memory_size: string
   memory_size_in_bytes: long
   miss_count: long
 }
@@ -2686,7 +2649,7 @@ export interface SearchStats {
   fetch_current: long
   fetch_time_in_millis: long
   fetch_total: long
-  open_contexts?: long
+  open_contexts: long
   query_current: long
   query_time_in_millis: long
   query_total: long
@@ -2696,7 +2659,6 @@ export interface SearchStats {
   suggest_current: long
   suggest_time_in_millis: long
   suggest_total: long
-  groups?: Record<string, SearchStats>
 }
 
 export interface SegmentsStats {
@@ -2704,7 +2666,7 @@ export interface SegmentsStats {
   doc_values_memory_in_bytes: long
   file_sizes: Record<string, ShardFileSizeInfo>
   fixed_bit_set_memory_in_bytes: long
-  index_writer_max_memory_in_bytes?: long
+  index_writer_max_memory_in_bytes: long
   index_writer_memory_in_bytes: long
   max_unsafe_auto_id_timestamp: long
   memory_in_bytes: long
@@ -2717,25 +2679,24 @@ export interface SegmentsStats {
 }
 
 export interface StoreStats {
-  size?: string
+  size: string
   size_in_bytes: double
-  reserved_in_bytes: double
 }
 
 export interface TranslogStats {
   earliest_last_modified_age: long
   operations: long
-  size?: string
+  size: string
   size_in_bytes: long
   uncommitted_operations: integer
-  uncommitted_size?: string
+  uncommitted_size: string
   uncommitted_size_in_bytes: long
 }
 
 export interface WarmerStats {
   current: long
   total: long
-  total_time?: string
+  total_time: string
   total_time_in_millis: long
 }
 
@@ -2768,7 +2729,7 @@ export interface BulkRequest<TSource = unknown> extends RequestBase {
   type_query_string?: string
   wait_for_active_shards?: string
   require_alias?: boolean
-  body: Array<BulkOperationContainer | TSource>
+  body: Array<BulkOperationContainer | TSource> | string | Buffer | ReadableStream
 }
 
 export interface BulkResponse extends ResponseBase {
@@ -2879,7 +2840,7 @@ export interface DeleteByQueryRequest extends RequestBase {
     max_docs?: long
     query?: QueryContainer
     slice?: SlicedScroll
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface DeleteByQueryResponse extends ResponseBase {
@@ -2931,23 +2892,24 @@ export interface MultiGetRequest extends RequestBase {
   stored_fields?: Array<Field>
   body: {
     docs?: Array<MultiGetOperation>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface MultiGetHit<TDocument = unknown> {
+  error: MainError
   found: boolean
-  _id: string
-  _index: string
-  _primary_term: long
-  _routing: string
-  _seq_no: long
-  _source: TDocument
-  _type: string
-  _version: long
+  id: string
+  index: string
+  primary_term: long
+  routing: string
+  sequence_number: long
+  source: TDocument
+  type: string
+  version: long
 }
 
-export interface MultiGetResponse<TDocument = unknown> extends ResponseBase {
-  docs: Array<MultiGetHit<TDocument>>
+export interface MultiGetResponse extends ResponseBase {
+  docs: Array<MultiGetHit<object>>
 }
 
 export interface MultiTermVectorOperation {
@@ -2983,7 +2945,7 @@ export interface MultiTermVectorsRequest extends RequestBase {
   body?: {
     docs?: Array<MultiTermVectorOperation>
     ids?: Array<Id>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface MultiTermVectorsResponse extends ResponseBase {
@@ -3006,7 +2968,6 @@ export interface ReindexRequest extends RequestBase {
   timeout?: Time
   wait_for_active_shards?: string
   wait_for_completion?: boolean
-  require_alias?: boolean
   body: {
     conflicts?: Conflicts
     dest?: ReindexDestination
@@ -3014,7 +2975,7 @@ export interface ReindexRequest extends RequestBase {
     script?: Script
     size?: long
     source?: ReindexSource
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ReindexResponse extends ResponseBase {
@@ -3140,7 +3101,7 @@ export interface UpdateByQueryRequest extends RequestBase {
     query?: QueryContainer
     script?: Script
     slice?: SlicedScroll
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface UpdateByQueryResponse extends ResponseBase {
@@ -3155,11 +3116,6 @@ export interface UpdateByQueryResponse extends ResponseBase {
   total: long
   updated: long
   version_conflicts: long
-}
-
-export interface UpdateByQueryRethrottleRequest extends RequestBase {
-  task_id: Id
-  requests_per_second?: long
 }
 
 export interface WriteResponseBase extends ResponseBase {
@@ -3185,7 +3141,7 @@ export interface CreateRequest<TDocument = unknown> extends RequestBase {
   version?: long
   version_type?: VersionType
   wait_for_active_shards?: string
-  body: TDocument
+  body: TDocument | string | Buffer | ReadableStream
 }
 
 export interface CreateResponse extends WriteResponseBase {
@@ -3269,7 +3225,7 @@ export interface IndexRequest<TDocument = unknown> extends RequestBase {
   version_type?: VersionType
   wait_for_active_shards?: string
   require_alias?: boolean
-  body: TDocument
+  body: TDocument | string | Buffer | ReadableStream
 }
 
 export interface IndexResponse extends WriteResponseBase {
@@ -3349,7 +3305,7 @@ export interface TermVectorsRequest<TDocument = unknown> extends RequestBase {
     doc?: TDocument
     filter?: TermVectorFilter
     per_field_analyzer?: Record<Field, string>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface TermVectorsResponse extends ResponseBase {
@@ -3411,7 +3367,7 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
     scripted_upsert?: boolean
     _source?: boolean | SourceFilter
     upsert?: TDocument
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface UpdateResponse<TDocument = unknown> extends WriteResponseBase {
@@ -3419,8 +3375,8 @@ export interface UpdateResponse<TDocument = unknown> extends WriteResponseBase {
 }
 
 export interface IndexState {
-  aliases?: Record<IndexName, Alias>
-  mappings?: TypeMapping
+  aliases: Record<IndexName, Alias>
+  mappings: TypeMapping
   settings: Record<string, any>
 }
 
@@ -3434,11 +3390,11 @@ export interface Alias {
 }
 
 export interface AliasDefinition {
-  filter?: QueryContainer
-  index_routing?: string
-  is_write_index?: boolean
-  routing?: string
-  search_routing?: string
+  filter: QueryContainer
+  index_routing: string
+  is_write_index: boolean
+  routing: string
+  search_routing: string
 }
 
 export interface BulkAliasRequest extends RequestBase {
@@ -3446,7 +3402,7 @@ export interface BulkAliasRequest extends RequestBase {
   timeout?: Time
   body: {
     actions?: Array<AliasAction>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface BulkAliasResponse extends AcknowledgedResponseBase {
@@ -3501,23 +3457,17 @@ export interface PutAliasRequest extends RequestBase {
     is_write_index?: boolean
     routing?: Routing
     search_routing?: Routing
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutAliasResponse extends ResponseBase {
 }
 
 export interface AnalyzeDetail {
-  analyzer?: AnalyzerDetail
-  charfilters?: Array<CharFilterDetail>
+  charfilters: Array<CharFilterDetail>
   custom_analyzer: boolean
-  tokenfilters?: Array<TokenDetail>
-  tokenizer?: TokenDetail
-}
-
-export interface AnalyzerDetail {
-  name: string
-  tokens: Array<ExplainAnalyzeToken>
+  tokenfilters: Array<TokenDetail>
+  tokenizer: TokenDetail
 }
 
 export interface AnalyzeRequest extends RequestBase {
@@ -3525,25 +3475,25 @@ export interface AnalyzeRequest extends RequestBase {
   body?: {
     analyzer?: string
     attributes?: Array<string>
-    char_filter?: Array<string | ICharFilter>
+    char_filter?: Array<string | CharFilterBase>
     explain?: boolean
     field?: Field
-    filter?: Array<string | ITokenFilter>
+    filter?: Array<string | TokenFilterBase>
     normalizer?: string
-    text?: string | Array<string>
-    tokenizer?: string | ITokenizer
-  }
+    text?: Array<string>
+    tokenizer?: string | TokenizerBase
+  } | string | Buffer | ReadableStream
 }
 
 export interface AnalyzeResponse extends ResponseBase {
-  detail?: AnalyzeDetail
-  tokens?: Array<AnalyzeToken>
+  detail: AnalyzeDetail
+  tokens: Array<AnalyzeToken>
 }
 
 export interface AnalyzeToken {
   end_offset: long
   position: long
-  position_length?: long
+  position_length: long
   start_offset: long
   token: string
   type: string
@@ -3557,7 +3507,7 @@ export interface CharFilterDetail {
 export interface ExplainAnalyzeToken {
   bytes: string
   end_offset: long
-  keyword?: boolean
+  keyword: boolean
   position: long
   positionLength: long
   start_offset: long
@@ -3576,11 +3526,11 @@ export interface CloneIndexRequest extends RequestBase {
   target: Name
   master_timeout?: Time
   timeout?: Time
-  wait_for_active_shards?: string | number
+  wait_for_active_shards?: string
   body?: {
     aliases?: Record<IndexName, Alias>
     settings?: Record<string, any>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface CloneIndexResponse extends AcknowledgedResponseBase {
@@ -3598,7 +3548,7 @@ export interface CreateIndexRequest extends RequestBase {
     aliases?: Record<IndexName, Alias>
     mappings?: TypeMapping
     settings?: Record<string, any>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface CreateIndexResponse extends AcknowledgedResponseBase {
@@ -3717,7 +3667,7 @@ export interface RolloverIndexRequest extends RequestBase {
     conditions?: RolloverConditions
     mappings?: TypeMapping
     settings?: Record<string, any>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface RolloverIndexResponse extends AcknowledgedResponseBase {
@@ -3738,7 +3688,7 @@ export interface ShrinkIndexRequest extends RequestBase {
   body?: {
     aliases?: Record<IndexName, Alias>
     settings?: Record<string, any>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ShrinkIndexResponse extends AcknowledgedResponseBase {
@@ -3754,7 +3704,7 @@ export interface SplitIndexRequest extends RequestBase {
   body?: {
     aliases?: Record<IndexName, Alias>
     settings?: Record<string, any>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface SplitIndexResponse extends AcknowledgedResponseBase {
@@ -3849,7 +3799,7 @@ export interface PutIndexTemplateRequest extends RequestBase {
     order?: integer
     settings?: Record<string, any>
     version?: integer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutIndexTemplateResponse extends AcknowledgedResponseBase {
@@ -3866,7 +3816,7 @@ export interface UpdateIndexSettingsRequest extends RequestBase {
   timeout?: Time
   body: {
     index?: Record<string, any>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface UpdateIndexSettingsResponse extends AcknowledgedResponseBase {
@@ -3929,11 +3879,11 @@ export interface PutMappingRequest extends RequestBase {
     index_field?: IndexField
     meta?: Record<string, any>
     numeric_detection?: boolean
-    properties?: Record<PropertyName, IProperty>
+    properties?: Record<PropertyName, PropertyBase>
     routing_field?: RoutingField
     size_field?: SizeField
     source_field?: SourceField
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutMappingResponse extends IndicesResponseBase {
@@ -4106,48 +4056,47 @@ export interface ShardStoreWrapper {
 }
 
 export interface IndexStats {
-  completion?: CompletionStats
-  docs?: DocStats
-  fielddata?: FielddataStats
-  flush?: FlushStats
-  get?: GetStats
-  indexing?: IndexingStats
-  merges?: MergesStats
-  query_cache?: QueryCacheStats
-  recovery?: RecoveryStats
-  refresh?: RefreshStats
-  request_cache?: RequestCacheStats
-  search?: SearchStats
-  segments?: SegmentsStats
-  store?: StoreStats
-  translog?: TranslogStats
-  warmer?: WarmerStats
+  completion: CompletionStats
+  docs: DocStats
+  fielddata: FielddataStats
+  flush: FlushStats
+  get: GetStats
+  indexing: IndexingStats
+  merges: MergesStats
+  query_cache: QueryCacheStats
+  recovery: RecoveryStats
+  refresh: RefreshStats
+  request_cache: RequestCacheStats
+  search: SearchStats
+  segments: SegmentsStats
+  store: StoreStats
+  translog: TranslogStats
+  warmer: WarmerStats
 }
 
 export interface IndicesStats {
   primaries: IndexStats
-  shards?: Record<string, Array<ShardStats>>
+  shards: Record<string, Array<ShardStats>>
   total: IndexStats
-  uuid?: string
+  uuid: string
 }
 
 export interface IndicesStatsRequest extends RequestBase {
   metric?: Metrics
   index?: Indices
-  completion_fields?: Fields
+  completion_fields?: Array<Field>
   expand_wildcards?: ExpandWildcards
-  fielddata_fields?: Fields
-  fields?: Fields
+  fielddata_fields?: Array<Field>
+  fields?: Array<Field>
   forbid_closed_indices?: boolean
-  groups?: string | Array<string>
+  groups?: Array<string>
   include_segment_file_sizes?: boolean
   include_unloaded_segments?: boolean
   level?: Level
-  types?: TypeNames
 }
 
 export interface IndicesStatsResponse extends ResponseBase {
-  indices?: Record<string, IndicesStats>
+  indices: Record<string, IndicesStats>
   _shards: ShardStatistics
   _all: IndicesStats
 }
@@ -4180,7 +4129,6 @@ export interface ShardFileSizeInfo {
 
 export interface ShardFlush {
   total: long
-  periodic: long
   total_time_in_millis: long
 }
 
@@ -4205,13 +4153,6 @@ export interface ShardIndexing {
   is_throttled: boolean
   noop_update_total: long
   throttle_time_in_millis: long
-}
-
-export interface ShardLease {
-  id: string
-  retaining_seq_no: long
-  timestamp: long
-  source: string
 }
 
 export interface ShardMerges {
@@ -4247,8 +4188,6 @@ export interface ShardRefresh {
   listeners: long
   total: long
   total_time_in_millis: long
-  external_total: long
-  external_total_time_in_millis: long
 }
 
 export interface ShardRequestCache {
@@ -4258,16 +4197,10 @@ export interface ShardRequestCache {
   miss_count: long
 }
 
-export interface ShardRetentionLeases {
-  primary_term: long
-  version: long
-  leases: Array<ShardLease>
-}
-
 export interface ShardRouting {
   node: string
   primary: boolean
-  relocating_node?: string
+  relocating_node: string
   state: ShardRoutingState
 }
 
@@ -4325,7 +4258,6 @@ export interface ShardStats {
   recovery: ShardStatsRecovery
   refresh: ShardRefresh
   request_cache: ShardRequestCache
-  retention_leases: ShardRetentionLeases
   routing: ShardRouting
   search: ShardSearch
   segments: ShardSegments
@@ -4342,12 +4274,10 @@ export interface ShardStatsRecovery {
 }
 
 export interface ShardStatsStore {
-  reserved_in_bytes: long
   size_in_bytes: long
 }
 
 export interface ShardTransactionLog {
-  earliest_last_modified_age: long
   operations: long
   size_in_bytes: long
   uncommitted_operations: long
@@ -4754,7 +4684,7 @@ export interface PutPipelineRequest extends RequestBase {
     description?: string
     on_failure?: Array<ProcessorContainer>
     processors?: Array<ProcessorContainer>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutPipelineResponse extends AcknowledgedResponseBase {
@@ -4792,7 +4722,7 @@ export interface SimulatePipelineRequest extends RequestBase {
   body: {
     docs?: Array<SimulatePipelineDocument>
     pipeline?: Pipeline
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface SimulatePipelineResponse extends ResponseBase {
@@ -4899,18 +4829,18 @@ export interface TypeMapping {
   dynamic?: boolean | DynamicMapping
   dynamic_date_formats?: Array<string>
   dynamic_templates?: Record<string, DynamicTemplate>
-  _field_names?: FieldNamesField
+  _field_names: FieldNamesField
   index_field?: IndexField
-  _meta?: Record<string, any>
+  _meta: Record<string, any>
   numeric_detection?: boolean
-  properties: Record<PropertyName, IProperty>
-  _routing?: RoutingField
-  _size?: SizeField
-  _source?: SourceField
+  properties: Record<PropertyName, PropertyBase>
+  _routing: RoutingField
+  _size: SizeField
+  _source: SourceField
 }
 
 export interface DynamicTemplate {
-  mapping: IProperty
+  mapping: PropertyBase
   match: string
   match_mapping_type: string
   match_pattern: MatchType
@@ -4961,12 +4891,11 @@ export interface SourceField {
   includes: Array<string>
 }
 
-export interface IProperty {
-  local_metadata?: Record<string, any>
-  meta?: Record<string, string>
-  name?: PropertyName
+export interface PropertyBase {
+  local_metadata: Record<string, any>
+  meta: Record<string, string>
+  name: PropertyName
   type: string
-  properties?: Record<PropertyName, IProperty>
 }
 
 export interface StoredScript {
@@ -4988,7 +4917,7 @@ export interface ExecutePainlessScriptRequest extends RequestBase {
     context?: string
     context_setup?: PainlessContextSetup
     script?: InlineScript
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ExecutePainlessScriptResponse<TResult = unknown> extends ResponseBase {
@@ -5017,7 +4946,7 @@ export interface PutScriptRequest extends RequestBase {
   timeout?: Time
   body: {
     script?: StoredScript
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutScriptResponse extends AcknowledgedResponseBase {
@@ -5049,7 +4978,7 @@ export interface CreateRepositoryRequest extends RequestBase {
   verify?: boolean
   body: {
     repository?: SnapshotRepository
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface CreateRepositoryResponse extends AcknowledgedResponseBase {
@@ -5103,7 +5032,7 @@ export interface RestoreRequest extends RequestBase {
     partial?: boolean
     rename_pattern?: string
     rename_replacement?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface RestoreResponse extends ResponseBase {
@@ -5170,7 +5099,7 @@ export interface SnapshotRequest extends RequestBase {
     indices?: Indices
     metadata?: Record<string, any>
     partial?: boolean
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface SnapshotResponse extends ResponseBase {
@@ -5857,7 +5786,7 @@ export interface CountRequest extends RequestBase {
   terminate_after?: long
   body?: {
     query?: QueryContainer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface CountResponse extends ResponseBase {
@@ -5883,7 +5812,7 @@ export interface ExplainRequest extends RequestBase {
   stored_fields?: Array<Field>
   body?: {
     query?: QueryContainer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ExplainResponse<TDocument = unknown> extends ResponseBase {
@@ -5946,31 +5875,18 @@ export interface MultiSearchRequest extends RequestBase {
   typed_keys?: boolean
   body: {
     operations?: Record<string, SearchRequest>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface MultiSearchResponse extends ResponseBase {
   responses: Array<SearchResponse<any>>
 }
 
-export interface MultiSearchTemplateRequest extends RequestBase {
-  index?: Indices
-  type?: TypeNames
-  ccs_minimize_roundtrips?: boolean
-  max_concurrent_searches?: long
-  search_type?: SearchType
-  total_hits_as_integer?: boolean
-  typed_keys?: boolean
-  body: {
-    operations?: Record<string, SearchTemplateRequest>
-  }
-}
-
 export interface ClearScrollRequest extends RequestBase {
   scroll_id?: Ids
   body?: {
     scroll_id?: Array<string>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ClearScrollResponse extends ResponseBase {
@@ -5979,11 +5895,10 @@ export interface ClearScrollResponse extends ResponseBase {
 export interface ScrollRequest extends RequestBase {
   scroll_id?: Id
   total_hits_as_integer?: boolean
-  scroll?: Time
   body?: {
     scroll?: Time
     scroll_id?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ScrollResponse<TDocument = unknown> extends SearchResponse<TDocument> {
@@ -6067,7 +5982,7 @@ export interface SearchRequest extends RequestBase {
     seq_no_primary_term?: boolean
     stored_fields?: Field | Array<Field>
     pit?: PointInTimeReference
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface SearchResponse<TDocument = unknown> extends ResponseBase {
@@ -6133,11 +6048,11 @@ export interface SearchTemplateRequest extends RequestBase {
   search_type?: SearchType
   total_hits_as_integer?: boolean
   typed_keys?: boolean
-  body: {
+  body?: {
     id?: string
     params?: Record<string, any>
     source?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface RenderSearchTemplateRequest extends RequestBase {
@@ -6145,7 +6060,7 @@ export interface RenderSearchTemplateRequest extends RequestBase {
     file?: string
     params?: Record<string, any>
     source?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface RenderSearchTemplateResponse extends ResponseBase {
@@ -6230,7 +6145,7 @@ export interface Hit<TDocument = unknown> {
   _shard?: string
   _node?: string
   _routing?: string
-  _source: TDocument
+  _source?: TDocument
   _seq_no?: long
   _primary_term?: long
   _version?: long
@@ -6577,7 +6492,7 @@ export interface ValidateQueryRequest extends RequestBase {
   rewrite?: boolean
   body?: {
     query?: QueryContainer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ValidateQueryResponse extends ResponseBase {
@@ -6606,7 +6521,7 @@ export interface AsyncSearchGetRequest extends RequestBase {
     keep_alive?: Time
     typed_keys?: boolean
     wait_for_completion_timeout?: Time
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface AsyncSearchGetResponse<TDocument = unknown> extends ResponseBase {
@@ -6666,7 +6581,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     typed_keys?: boolean
     version?: boolean
     wait_for_completion_timeout?: Time
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface AsyncSearchSubmitResponse<TDocument = unknown> extends ResponseBase {
@@ -6688,7 +6603,7 @@ export interface CreateAutoFollowPatternRequest extends RequestBase {
     max_write_request_operation_count?: integer
     max_write_request_size?: string
     remote_cluster?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface CreateAutoFollowPatternResponse extends AcknowledgedResponseBase {
@@ -6755,7 +6670,7 @@ export interface CreateFollowIndexRequest extends RequestBase {
     max_write_request_size?: string
     read_poll_timeout?: Time
     remote_cluster?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface CreateFollowIndexResponse extends ResponseBase {
@@ -6853,7 +6768,7 @@ export interface ForgetFollowerIndexRequest extends RequestBase {
     follower_index?: IndexName
     follower_index_uuid?: string
     leader_remote_cluster?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ForgetFollowerIndexResponse extends ResponseBase {
@@ -6880,7 +6795,7 @@ export interface ResumeFollowIndexRequest extends RequestBase {
     max_write_request_operation_count?: long
     max_write_request_size?: string
     read_poll_timeout?: Time
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ResumeFollowIndexResponse extends AcknowledgedResponseBase {
@@ -6975,7 +6890,7 @@ export interface PutEnrichPolicyRequest extends RequestBase {
   body: {
     geo_match?: EnrichPolicy
     match?: EnrichPolicy
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutEnrichPolicyResponse extends AcknowledgedResponseBase {
@@ -7012,7 +6927,7 @@ export interface GraphExploreRequest extends RequestBase {
     controls?: GraphExploreControls
     query?: QueryContainer
     vertices?: Array<GraphVertexDefinition>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GraphExploreResponse extends ResponseBase {
@@ -7150,7 +7065,7 @@ export interface MoveToStepRequest extends RequestBase {
   body?: {
     current_step?: StepKey
     next_step?: StepKey
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface MoveToStepResponse extends AcknowledgedResponseBase {
@@ -7166,7 +7081,7 @@ export interface PutLifecycleRequest extends RequestBase {
   policy: Name
   body?: {
     policy?: Policy
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutLifecycleResponse extends AcknowledgedResponseBase {
@@ -7525,7 +7440,7 @@ export interface PostLicenseRequest extends RequestBase {
   acknowledge?: boolean
   body?: {
     license?: License
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PostLicenseResponse extends ResponseBase {
@@ -7692,7 +7607,7 @@ export interface EstimateModelMemoryRequest extends RequestBase {
     analysis_config?: AnalysisConfig
     max_bucket_cardinality?: Record<Field, long>
     overall_cardinality?: Record<Field, long>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface EstimateModelMemoryResponse extends ResponseBase {
@@ -7707,7 +7622,7 @@ export interface FlushJobRequest extends RequestBase {
     calc_interim?: boolean
     end?: Date
     start?: Date
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface FlushJobResponse extends ResponseBase {
@@ -7719,7 +7634,7 @@ export interface ForecastJobRequest extends RequestBase {
   body?: {
     duration?: Time
     expires_in?: Time
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ForecastJobResponse extends AcknowledgedResponseBase {
@@ -7736,7 +7651,7 @@ export interface GetAnomalyRecordsRequest extends RequestBase {
     record_score?: double
     sort?: Field
     start?: Date
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GetAnomalyRecordsResponse extends ResponseBase {
@@ -7756,7 +7671,7 @@ export interface GetBucketsRequest extends RequestBase {
     page?: Page
     sort?: Field
     start?: Date
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GetBucketsResponse extends ResponseBase {
@@ -7772,7 +7687,7 @@ export interface GetCalendarEventsRequest extends RequestBase {
   body?: {
     from?: integer
     size?: integer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GetCalendarEventsResponse extends ResponseBase {
@@ -7790,7 +7705,7 @@ export interface GetCalendarsRequest extends RequestBase {
   calendar_id?: Id
   body?: {
     page?: Page
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GetCalendarsResponse extends ResponseBase {
@@ -7803,7 +7718,7 @@ export interface GetCategoriesRequest extends RequestBase {
   category_id?: CategoryId
   body?: {
     page?: Page
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GetCategoriesResponse extends ResponseBase {
@@ -7858,7 +7773,7 @@ export interface GetInfluencersRequest extends RequestBase {
     page?: Page
     sort?: Field
     start?: Date
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GetInfluencersResponse extends ResponseBase {
@@ -7895,7 +7810,7 @@ export interface GetModelSnapshotsRequest extends RequestBase {
     page?: Page
     sort?: Field
     start?: Date
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GetModelSnapshotsResponse extends ResponseBase {
@@ -7913,7 +7828,7 @@ export interface GetOverallBucketsRequest extends RequestBase {
     overall_score?: double
     start?: Date
     top_n?: integer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GetOverallBucketsResponse extends ResponseBase {
@@ -8186,7 +8101,7 @@ export interface AnomalyDetectors {
 }
 
 export interface CategorizationAnalyzer {
-  filter: Array<ITokenFilter>
+  filter: Array<TokenFilterBase>
   tokenizer: string
 }
 
@@ -8216,7 +8131,7 @@ export interface OpenJobRequest extends RequestBase {
   job_id: Id
   body?: {
     timeout?: Time
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface OpenJobResponse extends ResponseBase {
@@ -8227,7 +8142,7 @@ export interface PostCalendarEventsRequest extends RequestBase {
   calendar_id: Id
   body: {
     events?: Array<ScheduledEvent>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PostCalendarEventsResponse extends ResponseBase {
@@ -8248,7 +8163,7 @@ export interface PostJobDataRequest extends RequestBase {
   reset_start?: Date
   body: {
     data?: Array<any>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PostJobDataResponse extends ResponseBase {
@@ -8281,7 +8196,7 @@ export interface PutCalendarRequest extends RequestBase {
   calendar_id: Id
   body?: {
     description?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutCalendarResponse extends ResponseBase {
@@ -8318,7 +8233,7 @@ export interface PutDatafeedRequest extends RequestBase {
     query_delay?: Time
     script_fields?: Record<string, ScriptField>
     scroll_size?: integer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutDatafeedResponse extends ResponseBase {
@@ -8340,7 +8255,7 @@ export interface PutFilterRequest extends RequestBase {
   body: {
     description?: string
     items?: Array<string>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutFilterResponse extends ResponseBase {
@@ -8362,7 +8277,7 @@ export interface PutJobRequest extends RequestBase {
     model_plot?: ModelPlotConfig
     model_snapshot_retention_days?: long
     results_index_name?: IndexName
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutJobResponse extends ResponseBase {
@@ -8388,7 +8303,7 @@ export interface RevertModelSnapshotRequest extends RequestBase {
   snapshot_id: Id
   body?: {
     delete_intervening_results?: boolean
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface RevertModelSnapshotResponse extends ResponseBase {
@@ -8409,7 +8324,7 @@ export interface StartDatafeedRequest extends RequestBase {
     end?: Date
     start?: Date
     timeout?: Time
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface StartDatafeedResponse extends ResponseBase {
@@ -8422,7 +8337,7 @@ export interface StopDatafeedRequest extends RequestBase {
   body?: {
     force?: boolean
     timeout?: Time
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface StopDatafeedResponse extends ResponseBase {
@@ -8446,7 +8361,7 @@ export interface UpdateDatafeedRequest extends RequestBase {
     query_delay?: Time
     script_fields?: Record<string, ScriptField>
     scroll_size?: integer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface UpdateDatafeedResponse extends ResponseBase {
@@ -8469,7 +8384,7 @@ export interface UpdateFilterRequest extends RequestBase {
     add_items?: Array<string>
     description?: string
     remove_items?: Array<string>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface UpdateFilterResponse extends ResponseBase {
@@ -8490,7 +8405,7 @@ export interface UpdateJobRequest extends RequestBase {
     model_snapshot_retention_days?: long
     renormalization_window_days?: long
     results_retention_days?: long
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface UpdateJobResponse extends ResponseBase {
@@ -8502,7 +8417,7 @@ export interface UpdateModelSnapshotRequest extends RequestBase {
   body: {
     description?: string
     retain?: boolean
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface UpdateModelSnapshotResponse extends AcknowledgedResponseBase {
@@ -8512,7 +8427,7 @@ export interface UpdateModelSnapshotResponse extends AcknowledgedResponseBase {
 export interface ValidateDetectorRequest extends RequestBase {
   body: {
     detector?: Detector
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ValidateDetectorResponse extends AcknowledgedResponseBase {
@@ -8527,7 +8442,7 @@ export interface ValidateJobRequest extends RequestBase {
     model_plot?: ModelPlotConfig
     model_snapshot_retention_days?: long
     results_index_name?: IndexName
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ValidateJobResponse extends AcknowledgedResponseBase {
@@ -8561,7 +8476,7 @@ export interface CreateRollupJobRequest extends RequestBase {
     metrics?: Array<RollupFieldMetric>
     page_size?: long
     rollup_index?: IndexName
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface CreateRollupJobResponse extends AcknowledgedResponseBase {
@@ -8695,7 +8610,7 @@ export interface RollupSearchRequest extends RequestBase {
     aggs?: Record<string, AggregationContainer>
     query?: QueryContainer
     size?: integer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface RollupSearchResponse<TDocument = unknown> extends ResponseBase {
@@ -8739,7 +8654,7 @@ export interface CreateApiKeyRequest extends RequestBase {
     expiration?: Time
     name?: string
     role_descriptors?: Record<string, ApiKeyRole>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface CreateApiKeyResponse extends ResponseBase {
@@ -8778,7 +8693,7 @@ export interface InvalidateApiKeyRequest extends RequestBase {
     owner?: boolean
     realm_name?: string
     username?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface InvalidateApiKeyResponse extends ResponseBase {
@@ -8906,7 +8821,7 @@ export interface HasPrivilegesRequest extends RequestBase {
     application?: Array<ApplicationPrivilegesCheck>
     cluster?: Array<string>
     index?: Array<IndexPrivilegesCheck>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface HasPrivilegesResponse extends ResponseBase {
@@ -8936,7 +8851,7 @@ export interface PutPrivilegesRequest extends RequestBase {
   refresh?: Refresh
   body: {
     applications?: Record<string, Record<string, PrivilegesActions>>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutPrivilegesResponse extends DictionaryResponseBase<string, Record<string, PutPrivilegesStatus>> {
@@ -8983,7 +8898,7 @@ export interface PutRoleMappingRequest extends RequestBase {
     roles?: Array<string>
     rules?: RoleMappingRuleBase
     run_as?: Array<string>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutRoleMappingResponse extends ResponseBase {
@@ -9053,7 +8968,7 @@ export interface PutRoleRequest extends RequestBase {
     indices?: Array<IndicesPrivileges>
     metadata?: Record<string, any>
     run_as?: Array<string>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutRoleResponse extends ResponseBase {
@@ -9069,7 +8984,7 @@ export interface ChangePasswordRequest extends RequestBase {
   refresh?: Refresh
   body: {
     password?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ChangePasswordResponse extends ResponseBase {
@@ -9121,7 +9036,7 @@ export interface GetUserAccessTokenRequest extends RequestBase {
   body: {
     grant_type?: AccessTokenGrantType
     scope?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface GetUserAccessTokenResponse extends ResponseBase {
@@ -9151,7 +9066,7 @@ export interface PutUserRequest extends RequestBase {
     password?: string
     password_hash?: string
     roles?: Array<string>
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutUserResponse extends ResponseBase {
@@ -9258,7 +9173,7 @@ export interface PutSnapshotLifecycleRequest extends RequestBase {
     repository?: string
     retention?: SnapshotRetentionConfiguration
     schedule?: CronExpression
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutSnapshotLifecycleResponse extends AcknowledgedResponseBase {
@@ -9279,7 +9194,7 @@ export interface StopSnapshotLifecycleManagementResponse extends AcknowledgedRes
 export interface ClearSqlCursorRequest extends RequestBase {
   body: {
     cursor?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ClearSqlCursorResponse extends ResponseBase {
@@ -9295,7 +9210,7 @@ export interface QuerySqlRequest extends RequestBase {
     filter?: QueryContainer
     query?: string
     time_zone?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface QuerySqlResponse extends ResponseBase {
@@ -9319,7 +9234,7 @@ export interface TranslateSqlRequest extends RequestBase {
     filter?: QueryContainer
     query?: string
     time_zone?: string
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface TranslateSqlResponse extends ResponseBase {
@@ -9473,7 +9388,7 @@ export interface PreviewTransformRequest extends RequestBase {
     pivot?: TransformPivot
     source?: TransformSource
     sync?: TransformSyncContainer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PreviewTransformResponse<TTransform = unknown> extends ResponseBase {
@@ -9491,7 +9406,7 @@ export interface PutTransformRequest extends RequestBase {
     pivot?: TransformPivot
     source?: TransformSource
     sync?: TransformSyncContainer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutTransformResponse extends AcknowledgedResponseBase {
@@ -9526,7 +9441,7 @@ export interface UpdateTransformRequest extends RequestBase {
     frequency?: Time
     source?: TransformSource
     sync?: TransformSyncContainer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface UpdateTransformResponse extends ResponseBase {
@@ -9758,7 +9673,7 @@ export interface ExecuteWatchRequest extends RequestBase {
     simulated_actions?: SimulatedActions
     trigger_data?: ScheduleTriggerEvent
     watch?: Watch
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface ExecuteWatchResponse extends ResponseBase {
@@ -10007,7 +9922,7 @@ export interface PutWatchRequest extends RequestBase {
     throttle_period?: string
     transform?: TransformContainer
     trigger?: TriggerContainer
-  }
+  } | string | Buffer | ReadableStream
 }
 
 export interface PutWatchResponse extends ResponseBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import { Readable as ReadableStream } from 'stream'
-
 export type Aggregate = SingleBucketAggregate | AutoDateHistogramAggregate | FiltersAggregate | SignificantTermsAggregate<object> | TermsAggregate<object> | BucketAggregate | CompositeBucketAggregate | MultiBucketAggregate<object> | MatrixStatsAggregate | KeyedValueAggregate | MetricAggregate
 export interface AggregateBase {
   meta?: Record<string, any>
@@ -915,15 +913,15 @@ export interface CatHelpRequest extends CatRequestBase {
 export type CatHelpResponse = CatHelpRecord[]
 
 export interface CatIndicesRecord {
-  'docs.count': long
-  'docs.deleted': long
+  'docs.count': string
+  'docs.deleted': string
   health: string
   index: string
   pri: string
-  'pri.store.size': long
+  'pri.store.size': string
   rep: string
   status: string
-  'store.size': long
+  'store.size': string
   tm: string
   uuid: string
 }
@@ -1475,7 +1473,7 @@ export interface ClusterAllocationExplainRequest extends RequestBase {
     index?: IndexName
     primary?: boolean
     shard?: integer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ClusterAllocationExplainResponse extends ResponseBase {
@@ -1635,7 +1633,7 @@ export interface ClusterRerouteRequest extends RequestBase {
   timeout?: Time
   body?: {
     commands?: Array<ClusterRerouteCommand>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ClusterRerouteResponse extends ResponseBase {
@@ -1666,7 +1664,7 @@ export interface ClusterPutSettingsRequest extends RequestBase {
   body: {
     persistent?: Record<string, any>
     transient?: Record<string, any>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ClusterPutSettingsResponse extends ResponseBase {
@@ -2729,7 +2727,7 @@ export interface BulkRequest<TSource = unknown> extends RequestBase {
   type_query_string?: string
   wait_for_active_shards?: string
   require_alias?: boolean
-  body: Array<BulkOperationContainer | TSource> | string | Buffer | ReadableStream
+  body: Array<BulkOperationContainer | TSource>
 }
 
 export interface BulkResponse extends ResponseBase {
@@ -2840,7 +2838,7 @@ export interface DeleteByQueryRequest extends RequestBase {
     max_docs?: long
     query?: QueryContainer
     slice?: SlicedScroll
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface DeleteByQueryResponse extends ResponseBase {
@@ -2892,24 +2890,23 @@ export interface MultiGetRequest extends RequestBase {
   stored_fields?: Array<Field>
   body: {
     docs?: Array<MultiGetOperation>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface MultiGetHit<TDocument = unknown> {
-  error: MainError
   found: boolean
-  id: string
-  index: string
-  primary_term: long
-  routing: string
-  sequence_number: long
-  source: TDocument
-  type: string
-  version: long
+  _id: string
+  _index: string
+  _primary_term: long
+  _routing: string
+  _seq_no: long
+  _source: TDocument
+  _type: string
+  _version: long
 }
 
-export interface MultiGetResponse extends ResponseBase {
-  docs: Array<MultiGetHit<object>>
+export interface MultiGetResponse<TDocument = unknown> extends ResponseBase {
+  docs: Array<MultiGetHit<TDocument>>
 }
 
 export interface MultiTermVectorOperation {
@@ -2945,7 +2942,7 @@ export interface MultiTermVectorsRequest extends RequestBase {
   body?: {
     docs?: Array<MultiTermVectorOperation>
     ids?: Array<Id>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface MultiTermVectorsResponse extends ResponseBase {
@@ -2968,6 +2965,7 @@ export interface ReindexRequest extends RequestBase {
   timeout?: Time
   wait_for_active_shards?: string
   wait_for_completion?: boolean
+  require_alias?: boolean
   body: {
     conflicts?: Conflicts
     dest?: ReindexDestination
@@ -2975,7 +2973,7 @@ export interface ReindexRequest extends RequestBase {
     script?: Script
     size?: long
     source?: ReindexSource
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ReindexResponse extends ResponseBase {
@@ -3101,7 +3099,7 @@ export interface UpdateByQueryRequest extends RequestBase {
     query?: QueryContainer
     script?: Script
     slice?: SlicedScroll
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface UpdateByQueryResponse extends ResponseBase {
@@ -3116,6 +3114,11 @@ export interface UpdateByQueryResponse extends ResponseBase {
   total: long
   updated: long
   version_conflicts: long
+}
+
+export interface UpdateByQueryRethrottleRequest extends RequestBase {
+  task_id: Id
+  requests_per_second?: long
 }
 
 export interface WriteResponseBase extends ResponseBase {
@@ -3141,7 +3144,7 @@ export interface CreateRequest<TDocument = unknown> extends RequestBase {
   version?: long
   version_type?: VersionType
   wait_for_active_shards?: string
-  body: TDocument | string | Buffer | ReadableStream
+  body: TDocument
 }
 
 export interface CreateResponse extends WriteResponseBase {
@@ -3225,7 +3228,7 @@ export interface IndexRequest<TDocument = unknown> extends RequestBase {
   version_type?: VersionType
   wait_for_active_shards?: string
   require_alias?: boolean
-  body: TDocument | string | Buffer | ReadableStream
+  body: TDocument
 }
 
 export interface IndexResponse extends WriteResponseBase {
@@ -3305,7 +3308,7 @@ export interface TermVectorsRequest<TDocument = unknown> extends RequestBase {
     doc?: TDocument
     filter?: TermVectorFilter
     per_field_analyzer?: Record<Field, string>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface TermVectorsResponse extends ResponseBase {
@@ -3367,7 +3370,7 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
     scripted_upsert?: boolean
     _source?: boolean | SourceFilter
     upsert?: TDocument
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface UpdateResponse<TDocument = unknown> extends WriteResponseBase {
@@ -3390,11 +3393,11 @@ export interface Alias {
 }
 
 export interface AliasDefinition {
-  filter: QueryContainer
-  index_routing: string
-  is_write_index: boolean
-  routing: string
-  search_routing: string
+  filter?: QueryContainer
+  index_routing?: string
+  is_write_index?: boolean
+  routing?: string
+  search_routing?: string
 }
 
 export interface BulkAliasRequest extends RequestBase {
@@ -3402,7 +3405,7 @@ export interface BulkAliasRequest extends RequestBase {
   timeout?: Time
   body: {
     actions?: Array<AliasAction>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface BulkAliasResponse extends AcknowledgedResponseBase {
@@ -3457,7 +3460,7 @@ export interface PutAliasRequest extends RequestBase {
     is_write_index?: boolean
     routing?: Routing
     search_routing?: Routing
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutAliasResponse extends ResponseBase {
@@ -3482,7 +3485,7 @@ export interface AnalyzeRequest extends RequestBase {
     normalizer?: string
     text?: Array<string>
     tokenizer?: string | TokenizerBase
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface AnalyzeResponse extends ResponseBase {
@@ -3530,7 +3533,7 @@ export interface CloneIndexRequest extends RequestBase {
   body?: {
     aliases?: Record<IndexName, Alias>
     settings?: Record<string, any>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface CloneIndexResponse extends AcknowledgedResponseBase {
@@ -3548,7 +3551,7 @@ export interface CreateIndexRequest extends RequestBase {
     aliases?: Record<IndexName, Alias>
     mappings?: TypeMapping
     settings?: Record<string, any>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface CreateIndexResponse extends AcknowledgedResponseBase {
@@ -3667,7 +3670,7 @@ export interface RolloverIndexRequest extends RequestBase {
     conditions?: RolloverConditions
     mappings?: TypeMapping
     settings?: Record<string, any>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface RolloverIndexResponse extends AcknowledgedResponseBase {
@@ -3688,7 +3691,7 @@ export interface ShrinkIndexRequest extends RequestBase {
   body?: {
     aliases?: Record<IndexName, Alias>
     settings?: Record<string, any>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ShrinkIndexResponse extends AcknowledgedResponseBase {
@@ -3704,7 +3707,7 @@ export interface SplitIndexRequest extends RequestBase {
   body?: {
     aliases?: Record<IndexName, Alias>
     settings?: Record<string, any>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface SplitIndexResponse extends AcknowledgedResponseBase {
@@ -3799,7 +3802,7 @@ export interface PutIndexTemplateRequest extends RequestBase {
     order?: integer
     settings?: Record<string, any>
     version?: integer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutIndexTemplateResponse extends AcknowledgedResponseBase {
@@ -3816,7 +3819,7 @@ export interface UpdateIndexSettingsRequest extends RequestBase {
   timeout?: Time
   body: {
     index?: Record<string, any>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface UpdateIndexSettingsResponse extends AcknowledgedResponseBase {
@@ -3883,7 +3886,7 @@ export interface PutMappingRequest extends RequestBase {
     routing_field?: RoutingField
     size_field?: SizeField
     source_field?: SourceField
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutMappingResponse extends IndicesResponseBase {
@@ -4684,7 +4687,7 @@ export interface PutPipelineRequest extends RequestBase {
     description?: string
     on_failure?: Array<ProcessorContainer>
     processors?: Array<ProcessorContainer>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutPipelineResponse extends AcknowledgedResponseBase {
@@ -4722,7 +4725,7 @@ export interface SimulatePipelineRequest extends RequestBase {
   body: {
     docs?: Array<SimulatePipelineDocument>
     pipeline?: Pipeline
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface SimulatePipelineResponse extends ResponseBase {
@@ -4829,14 +4832,14 @@ export interface TypeMapping {
   dynamic?: boolean | DynamicMapping
   dynamic_date_formats?: Array<string>
   dynamic_templates?: Record<string, DynamicTemplate>
-  _field_names: FieldNamesField
+  _field_names?: FieldNamesField
   index_field?: IndexField
-  _meta: Record<string, any>
+  _meta?: Record<string, any>
   numeric_detection?: boolean
   properties: Record<PropertyName, PropertyBase>
-  _routing: RoutingField
-  _size: SizeField
-  _source: SourceField
+  _routing?: RoutingField
+  _size?: SizeField
+  _source?: SourceField
 }
 
 export interface DynamicTemplate {
@@ -4917,7 +4920,7 @@ export interface ExecutePainlessScriptRequest extends RequestBase {
     context?: string
     context_setup?: PainlessContextSetup
     script?: InlineScript
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ExecutePainlessScriptResponse<TResult = unknown> extends ResponseBase {
@@ -4946,7 +4949,7 @@ export interface PutScriptRequest extends RequestBase {
   timeout?: Time
   body: {
     script?: StoredScript
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutScriptResponse extends AcknowledgedResponseBase {
@@ -4978,7 +4981,7 @@ export interface CreateRepositoryRequest extends RequestBase {
   verify?: boolean
   body: {
     repository?: SnapshotRepository
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface CreateRepositoryResponse extends AcknowledgedResponseBase {
@@ -5032,7 +5035,7 @@ export interface RestoreRequest extends RequestBase {
     partial?: boolean
     rename_pattern?: string
     rename_replacement?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface RestoreResponse extends ResponseBase {
@@ -5099,7 +5102,7 @@ export interface SnapshotRequest extends RequestBase {
     indices?: Indices
     metadata?: Record<string, any>
     partial?: boolean
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface SnapshotResponse extends ResponseBase {
@@ -5786,7 +5789,7 @@ export interface CountRequest extends RequestBase {
   terminate_after?: long
   body?: {
     query?: QueryContainer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface CountResponse extends ResponseBase {
@@ -5812,7 +5815,7 @@ export interface ExplainRequest extends RequestBase {
   stored_fields?: Array<Field>
   body?: {
     query?: QueryContainer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ExplainResponse<TDocument = unknown> extends ResponseBase {
@@ -5875,18 +5878,31 @@ export interface MultiSearchRequest extends RequestBase {
   typed_keys?: boolean
   body: {
     operations?: Record<string, SearchRequest>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface MultiSearchResponse extends ResponseBase {
   responses: Array<SearchResponse<any>>
 }
 
+export interface MultiSearchTemplateRequest extends RequestBase {
+  index?: Indices
+  type?: TypeNames
+  ccs_minimize_roundtrips?: boolean
+  max_concurrent_searches?: long
+  search_type?: SearchType
+  total_hits_as_integer?: boolean
+  typed_keys?: boolean
+  body: {
+    operations?: Record<string, SearchTemplateRequest>
+  }
+}
+
 export interface ClearScrollRequest extends RequestBase {
   scroll_id?: Ids
   body?: {
     scroll_id?: Array<string>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ClearScrollResponse extends ResponseBase {
@@ -5895,10 +5911,11 @@ export interface ClearScrollResponse extends ResponseBase {
 export interface ScrollRequest extends RequestBase {
   scroll_id?: Id
   total_hits_as_integer?: boolean
+  scroll?: Time
   body?: {
     scroll?: Time
     scroll_id?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ScrollResponse<TDocument = unknown> extends SearchResponse<TDocument> {
@@ -5982,7 +5999,7 @@ export interface SearchRequest extends RequestBase {
     seq_no_primary_term?: boolean
     stored_fields?: Field | Array<Field>
     pit?: PointInTimeReference
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface SearchResponse<TDocument = unknown> extends ResponseBase {
@@ -6048,11 +6065,11 @@ export interface SearchTemplateRequest extends RequestBase {
   search_type?: SearchType
   total_hits_as_integer?: boolean
   typed_keys?: boolean
-  body?: {
+  body: {
     id?: string
     params?: Record<string, any>
     source?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface RenderSearchTemplateRequest extends RequestBase {
@@ -6060,7 +6077,7 @@ export interface RenderSearchTemplateRequest extends RequestBase {
     file?: string
     params?: Record<string, any>
     source?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface RenderSearchTemplateResponse extends ResponseBase {
@@ -6145,7 +6162,7 @@ export interface Hit<TDocument = unknown> {
   _shard?: string
   _node?: string
   _routing?: string
-  _source?: TDocument
+  _source: TDocument
   _seq_no?: long
   _primary_term?: long
   _version?: long
@@ -6492,7 +6509,7 @@ export interface ValidateQueryRequest extends RequestBase {
   rewrite?: boolean
   body?: {
     query?: QueryContainer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ValidateQueryResponse extends ResponseBase {
@@ -6521,7 +6538,7 @@ export interface AsyncSearchGetRequest extends RequestBase {
     keep_alive?: Time
     typed_keys?: boolean
     wait_for_completion_timeout?: Time
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface AsyncSearchGetResponse<TDocument = unknown> extends ResponseBase {
@@ -6581,7 +6598,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     typed_keys?: boolean
     version?: boolean
     wait_for_completion_timeout?: Time
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface AsyncSearchSubmitResponse<TDocument = unknown> extends ResponseBase {
@@ -6603,7 +6620,7 @@ export interface CreateAutoFollowPatternRequest extends RequestBase {
     max_write_request_operation_count?: integer
     max_write_request_size?: string
     remote_cluster?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface CreateAutoFollowPatternResponse extends AcknowledgedResponseBase {
@@ -6670,7 +6687,7 @@ export interface CreateFollowIndexRequest extends RequestBase {
     max_write_request_size?: string
     read_poll_timeout?: Time
     remote_cluster?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface CreateFollowIndexResponse extends ResponseBase {
@@ -6768,7 +6785,7 @@ export interface ForgetFollowerIndexRequest extends RequestBase {
     follower_index?: IndexName
     follower_index_uuid?: string
     leader_remote_cluster?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ForgetFollowerIndexResponse extends ResponseBase {
@@ -6795,7 +6812,7 @@ export interface ResumeFollowIndexRequest extends RequestBase {
     max_write_request_operation_count?: long
     max_write_request_size?: string
     read_poll_timeout?: Time
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ResumeFollowIndexResponse extends AcknowledgedResponseBase {
@@ -6890,7 +6907,7 @@ export interface PutEnrichPolicyRequest extends RequestBase {
   body: {
     geo_match?: EnrichPolicy
     match?: EnrichPolicy
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutEnrichPolicyResponse extends AcknowledgedResponseBase {
@@ -6927,7 +6944,7 @@ export interface GraphExploreRequest extends RequestBase {
     controls?: GraphExploreControls
     query?: QueryContainer
     vertices?: Array<GraphVertexDefinition>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GraphExploreResponse extends ResponseBase {
@@ -7065,7 +7082,7 @@ export interface MoveToStepRequest extends RequestBase {
   body?: {
     current_step?: StepKey
     next_step?: StepKey
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface MoveToStepResponse extends AcknowledgedResponseBase {
@@ -7081,7 +7098,7 @@ export interface PutLifecycleRequest extends RequestBase {
   policy: Name
   body?: {
     policy?: Policy
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutLifecycleResponse extends AcknowledgedResponseBase {
@@ -7440,7 +7457,7 @@ export interface PostLicenseRequest extends RequestBase {
   acknowledge?: boolean
   body?: {
     license?: License
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PostLicenseResponse extends ResponseBase {
@@ -7607,7 +7624,7 @@ export interface EstimateModelMemoryRequest extends RequestBase {
     analysis_config?: AnalysisConfig
     max_bucket_cardinality?: Record<Field, long>
     overall_cardinality?: Record<Field, long>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface EstimateModelMemoryResponse extends ResponseBase {
@@ -7622,7 +7639,7 @@ export interface FlushJobRequest extends RequestBase {
     calc_interim?: boolean
     end?: Date
     start?: Date
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface FlushJobResponse extends ResponseBase {
@@ -7634,7 +7651,7 @@ export interface ForecastJobRequest extends RequestBase {
   body?: {
     duration?: Time
     expires_in?: Time
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ForecastJobResponse extends AcknowledgedResponseBase {
@@ -7651,7 +7668,7 @@ export interface GetAnomalyRecordsRequest extends RequestBase {
     record_score?: double
     sort?: Field
     start?: Date
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GetAnomalyRecordsResponse extends ResponseBase {
@@ -7671,7 +7688,7 @@ export interface GetBucketsRequest extends RequestBase {
     page?: Page
     sort?: Field
     start?: Date
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GetBucketsResponse extends ResponseBase {
@@ -7687,7 +7704,7 @@ export interface GetCalendarEventsRequest extends RequestBase {
   body?: {
     from?: integer
     size?: integer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GetCalendarEventsResponse extends ResponseBase {
@@ -7705,7 +7722,7 @@ export interface GetCalendarsRequest extends RequestBase {
   calendar_id?: Id
   body?: {
     page?: Page
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GetCalendarsResponse extends ResponseBase {
@@ -7718,7 +7735,7 @@ export interface GetCategoriesRequest extends RequestBase {
   category_id?: CategoryId
   body?: {
     page?: Page
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GetCategoriesResponse extends ResponseBase {
@@ -7773,7 +7790,7 @@ export interface GetInfluencersRequest extends RequestBase {
     page?: Page
     sort?: Field
     start?: Date
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GetInfluencersResponse extends ResponseBase {
@@ -7810,7 +7827,7 @@ export interface GetModelSnapshotsRequest extends RequestBase {
     page?: Page
     sort?: Field
     start?: Date
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GetModelSnapshotsResponse extends ResponseBase {
@@ -7828,7 +7845,7 @@ export interface GetOverallBucketsRequest extends RequestBase {
     overall_score?: double
     start?: Date
     top_n?: integer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GetOverallBucketsResponse extends ResponseBase {
@@ -8131,7 +8148,7 @@ export interface OpenJobRequest extends RequestBase {
   job_id: Id
   body?: {
     timeout?: Time
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface OpenJobResponse extends ResponseBase {
@@ -8142,7 +8159,7 @@ export interface PostCalendarEventsRequest extends RequestBase {
   calendar_id: Id
   body: {
     events?: Array<ScheduledEvent>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PostCalendarEventsResponse extends ResponseBase {
@@ -8163,7 +8180,7 @@ export interface PostJobDataRequest extends RequestBase {
   reset_start?: Date
   body: {
     data?: Array<any>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PostJobDataResponse extends ResponseBase {
@@ -8196,7 +8213,7 @@ export interface PutCalendarRequest extends RequestBase {
   calendar_id: Id
   body?: {
     description?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutCalendarResponse extends ResponseBase {
@@ -8233,7 +8250,7 @@ export interface PutDatafeedRequest extends RequestBase {
     query_delay?: Time
     script_fields?: Record<string, ScriptField>
     scroll_size?: integer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutDatafeedResponse extends ResponseBase {
@@ -8255,7 +8272,7 @@ export interface PutFilterRequest extends RequestBase {
   body: {
     description?: string
     items?: Array<string>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutFilterResponse extends ResponseBase {
@@ -8277,7 +8294,7 @@ export interface PutJobRequest extends RequestBase {
     model_plot?: ModelPlotConfig
     model_snapshot_retention_days?: long
     results_index_name?: IndexName
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutJobResponse extends ResponseBase {
@@ -8303,7 +8320,7 @@ export interface RevertModelSnapshotRequest extends RequestBase {
   snapshot_id: Id
   body?: {
     delete_intervening_results?: boolean
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface RevertModelSnapshotResponse extends ResponseBase {
@@ -8324,7 +8341,7 @@ export interface StartDatafeedRequest extends RequestBase {
     end?: Date
     start?: Date
     timeout?: Time
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface StartDatafeedResponse extends ResponseBase {
@@ -8337,7 +8354,7 @@ export interface StopDatafeedRequest extends RequestBase {
   body?: {
     force?: boolean
     timeout?: Time
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface StopDatafeedResponse extends ResponseBase {
@@ -8361,7 +8378,7 @@ export interface UpdateDatafeedRequest extends RequestBase {
     query_delay?: Time
     script_fields?: Record<string, ScriptField>
     scroll_size?: integer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface UpdateDatafeedResponse extends ResponseBase {
@@ -8384,7 +8401,7 @@ export interface UpdateFilterRequest extends RequestBase {
     add_items?: Array<string>
     description?: string
     remove_items?: Array<string>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface UpdateFilterResponse extends ResponseBase {
@@ -8405,7 +8422,7 @@ export interface UpdateJobRequest extends RequestBase {
     model_snapshot_retention_days?: long
     renormalization_window_days?: long
     results_retention_days?: long
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface UpdateJobResponse extends ResponseBase {
@@ -8417,7 +8434,7 @@ export interface UpdateModelSnapshotRequest extends RequestBase {
   body: {
     description?: string
     retain?: boolean
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface UpdateModelSnapshotResponse extends AcknowledgedResponseBase {
@@ -8427,7 +8444,7 @@ export interface UpdateModelSnapshotResponse extends AcknowledgedResponseBase {
 export interface ValidateDetectorRequest extends RequestBase {
   body: {
     detector?: Detector
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ValidateDetectorResponse extends AcknowledgedResponseBase {
@@ -8442,7 +8459,7 @@ export interface ValidateJobRequest extends RequestBase {
     model_plot?: ModelPlotConfig
     model_snapshot_retention_days?: long
     results_index_name?: IndexName
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ValidateJobResponse extends AcknowledgedResponseBase {
@@ -8476,7 +8493,7 @@ export interface CreateRollupJobRequest extends RequestBase {
     metrics?: Array<RollupFieldMetric>
     page_size?: long
     rollup_index?: IndexName
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface CreateRollupJobResponse extends AcknowledgedResponseBase {
@@ -8610,7 +8627,7 @@ export interface RollupSearchRequest extends RequestBase {
     aggs?: Record<string, AggregationContainer>
     query?: QueryContainer
     size?: integer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface RollupSearchResponse<TDocument = unknown> extends ResponseBase {
@@ -8654,7 +8671,7 @@ export interface CreateApiKeyRequest extends RequestBase {
     expiration?: Time
     name?: string
     role_descriptors?: Record<string, ApiKeyRole>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface CreateApiKeyResponse extends ResponseBase {
@@ -8693,7 +8710,7 @@ export interface InvalidateApiKeyRequest extends RequestBase {
     owner?: boolean
     realm_name?: string
     username?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface InvalidateApiKeyResponse extends ResponseBase {
@@ -8821,7 +8838,7 @@ export interface HasPrivilegesRequest extends RequestBase {
     application?: Array<ApplicationPrivilegesCheck>
     cluster?: Array<string>
     index?: Array<IndexPrivilegesCheck>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface HasPrivilegesResponse extends ResponseBase {
@@ -8851,7 +8868,7 @@ export interface PutPrivilegesRequest extends RequestBase {
   refresh?: Refresh
   body: {
     applications?: Record<string, Record<string, PrivilegesActions>>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutPrivilegesResponse extends DictionaryResponseBase<string, Record<string, PutPrivilegesStatus>> {
@@ -8898,7 +8915,7 @@ export interface PutRoleMappingRequest extends RequestBase {
     roles?: Array<string>
     rules?: RoleMappingRuleBase
     run_as?: Array<string>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutRoleMappingResponse extends ResponseBase {
@@ -8968,7 +8985,7 @@ export interface PutRoleRequest extends RequestBase {
     indices?: Array<IndicesPrivileges>
     metadata?: Record<string, any>
     run_as?: Array<string>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutRoleResponse extends ResponseBase {
@@ -8984,7 +9001,7 @@ export interface ChangePasswordRequest extends RequestBase {
   refresh?: Refresh
   body: {
     password?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ChangePasswordResponse extends ResponseBase {
@@ -9036,7 +9053,7 @@ export interface GetUserAccessTokenRequest extends RequestBase {
   body: {
     grant_type?: AccessTokenGrantType
     scope?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface GetUserAccessTokenResponse extends ResponseBase {
@@ -9066,7 +9083,7 @@ export interface PutUserRequest extends RequestBase {
     password?: string
     password_hash?: string
     roles?: Array<string>
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutUserResponse extends ResponseBase {
@@ -9173,7 +9190,7 @@ export interface PutSnapshotLifecycleRequest extends RequestBase {
     repository?: string
     retention?: SnapshotRetentionConfiguration
     schedule?: CronExpression
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutSnapshotLifecycleResponse extends AcknowledgedResponseBase {
@@ -9194,7 +9211,7 @@ export interface StopSnapshotLifecycleManagementResponse extends AcknowledgedRes
 export interface ClearSqlCursorRequest extends RequestBase {
   body: {
     cursor?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ClearSqlCursorResponse extends ResponseBase {
@@ -9210,7 +9227,7 @@ export interface QuerySqlRequest extends RequestBase {
     filter?: QueryContainer
     query?: string
     time_zone?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface QuerySqlResponse extends ResponseBase {
@@ -9234,7 +9251,7 @@ export interface TranslateSqlRequest extends RequestBase {
     filter?: QueryContainer
     query?: string
     time_zone?: string
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface TranslateSqlResponse extends ResponseBase {
@@ -9388,7 +9405,7 @@ export interface PreviewTransformRequest extends RequestBase {
     pivot?: TransformPivot
     source?: TransformSource
     sync?: TransformSyncContainer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PreviewTransformResponse<TTransform = unknown> extends ResponseBase {
@@ -9406,7 +9423,7 @@ export interface PutTransformRequest extends RequestBase {
     pivot?: TransformPivot
     source?: TransformSource
     sync?: TransformSyncContainer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutTransformResponse extends AcknowledgedResponseBase {
@@ -9441,7 +9458,7 @@ export interface UpdateTransformRequest extends RequestBase {
     frequency?: Time
     source?: TransformSource
     sync?: TransformSyncContainer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface UpdateTransformResponse extends ResponseBase {
@@ -9673,7 +9690,7 @@ export interface ExecuteWatchRequest extends RequestBase {
     simulated_actions?: SimulatedActions
     trigger_data?: ScheduleTriggerEvent
     watch?: Watch
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface ExecuteWatchResponse extends ResponseBase {
@@ -9922,7 +9939,7 @@ export interface PutWatchRequest extends RequestBase {
     throttle_period?: string
     transform?: TransformContainer
     trigger?: TriggerContainer
-  } | string | Buffer | ReadableStream
+  }
 }
 
 export interface PutWatchResponse extends ResponseBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17,7 +17,9 @@
  * under the License.
  */
 
-export type Aggregate = ValueAggregate | DocCountAggregate | AutoDateHistogramAggregate | FiltersAggregate | SignificantTermsAggregate<object> | TermsAggregate<object> | BucketAggregate | CompositeBucketAggregate | MultiBucketAggregate<object> | SingleBucketAggregate | MatrixStatsAggregate | BoxPlotAggregate | ExtendedStatsAggregate | GeoBoundsAggregate | GeoCentroidAggregate | PercentilesAggregate | ScriptedMetricAggregate | StatsAggregate | StringStatsAggregate | TopHitsAggregate | TopMetricsAggregate | KeyedValueAggregate | TDigestPercentilesAggregate | HdrPercentilesAggregate
+import { Readable as ReadableStream } from 'stream'
+
+export type Aggregate = SingleBucketAggregate | AutoDateHistogramAggregate | FiltersAggregate | SignificantTermsAggregate<object> | TermsAggregate<object> | BucketAggregate | CompositeBucketAggregate | MultiBucketAggregate<object> | MatrixStatsAggregate | KeyedValueAggregate | MetricAggregate
 export interface AggregateBase {
   meta?: Record<string, any>
 }
@@ -112,7 +114,7 @@ export interface BucketAggregate extends AggregateBase {
   items: Bucket
 }
 
-export interface BucketBase {
+export interface BucketBase extends IDictionary<AggregateName, Aggregate> {
 }
 
 export interface CompositeBucket extends BucketBase {
@@ -123,10 +125,6 @@ export interface CompositeBucketAggregate extends MultiBucketAggregate<Record<st
 }
 
 export interface DateHistogramBucket extends BucketBase {
-}
-
-export interface DocCountAggregate extends AggregateBase {
-  doc_count: double
 }
 
 export interface ExtendedStatsAggregate extends StatsAggregate {
@@ -192,6 +190,7 @@ export interface MatrixStatsAggregate extends AggregateBase {
   name: string
 }
 
+export type MetricAggregate = ValueAggregate | BoxPlotAggregate | GeoBoundsAggregate | GeoCentroidAggregate | PercentilesAggregate | ScriptedMetricAggregate | StatsAggregate | StringStatsAggregate | TopHitsAggregate | TopMetricsAggregate | ExtendedStatsAggregate | TDigestPercentilesAggregate | HdrPercentilesAggregate
 export type Missing = string | integer | boolean
 export interface MultiBucketAggregate<TBucket = unknown> extends AggregateBase {
   buckets: Array<TBucket>
@@ -223,7 +222,8 @@ export interface SignificantTermsAggregate<TKey = unknown> extends MultiBucketAg
 export interface SignificantTermsBucket<TKey = unknown> extends BucketBase {
 }
 
-export interface SingleBucketAggregate extends AggregateBase {
+export interface SingleBucketAggregate extends AggregateBase, IDictionary<AggregateName, Aggregate> {
+  doc_count: double
 }
 
 export interface StandardDeviationBounds {
@@ -2424,6 +2424,9 @@ export type ExpandWildcards = ExpandWildcardOptions | Array<ExpandWildcardOption
 export type GroupBy = 'nodes' | 'parents' | 'none'
 
 export type Health = 'green' | 'yellow' | 'red'
+
+export interface IDictionary<TKey = unknown, TValue = unknown> {
+}
 
 export type Level = 'cluster' | 'indices' | 'shards'
 
@@ -4796,6 +4799,8 @@ export interface SimulatePipelineResponse extends ResponseBase {
   docs: Array<PipelineSimulation>
 }
 
+export type AggregateName = string
+
 export type CategoryId = string
 
 export interface Date {
@@ -6070,7 +6075,7 @@ export interface SearchResponse<TDocument = unknown> extends ResponseBase {
   timed_out: boolean
   _shards: ShardStatistics
   hits: HitsMetadata<TDocument>
-  aggregations?: Record<string, Aggregate>
+  aggregations?: Record<AggregateName, Aggregate>
   _clusters?: ClusterStatistics
   documents?: Array<TDocument>
   fields?: Record<string, LazyDocument>

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1477,29 +1477,37 @@ export interface ClusterAllocationExplainRequest extends RequestBase {
 }
 
 export interface ClusterAllocationExplainResponse extends ResponseBase {
-  allocate_explanation: string
-  allocation_delay: string
-  allocation_delay_in_millis: long
-  can_allocate: Decision
-  can_move_to_other_node: Decision
-  can_rebalance_cluster: Decision
-  can_rebalance_cluster_decisions: Array<AllocationDecision>
-  can_rebalance_to_other_node: Decision
-  can_remain_decisions: Array<AllocationDecision>
-  can_remain_on_current_node: Decision
-  configured_delay: string
-  configured_delay_in_mills: long
-  current_node: CurrentNode
+  allocate_explanation?: string
+  allocation_delay?: string
+  allocation_delay_in_millis?: long
+  can_allocate?: Decision
+  can_move_to_other_node?: Decision
+  can_rebalance_cluster?: Decision
+  can_rebalance_cluster_decisions?: Array<AllocationDecision>
+  can_rebalance_to_other_node?: Decision
+  can_remain_decisions?: Array<AllocationDecision>
+  can_remain_on_current_node?: Decision
+  cluster_info?: ClusterInfo
+  configured_delay?: string
+  configured_delay_in_mills?: long
+  current_node?: CurrentNode
   current_state: string
   index: string
-  move_explanation: string
-  node_allocation_decisions: Array<NodeAllocationExplanation>
+  move_explanation?: string
+  node_allocation_decisions?: Array<NodeAllocationExplanation>
   primary: boolean
-  rebalance_explanation: string
-  remaining_delay: string
-  remaining_delay_in_millis: long
+  rebalance_explanation?: string
+  remaining_delay?: string
+  remaining_delay_in_millis?: long
   shard: integer
-  unassigned_info: UnassignedInformation
+  unassigned_info?: UnassignedInformation
+}
+
+export interface ClusterInfo {
+  nodes: Record<string, NodeDiskUsage>
+  shard_sizes: Record<string, long>
+  shard_paths: Record<string, string>
+  reserved_sizes: Array<ReservedSize>
 }
 
 export interface CurrentNode {
@@ -1512,21 +1520,45 @@ export interface CurrentNode {
 
 export type Decision = 'yes' | 'no' | 'worse_balance' | 'throttled' | 'awaiting_info' | 'allocation_delayed' | 'no_valid_shard_copy' | 'no_attempt'
 
+export interface DiskUsage {
+  path: string
+  total_bytes: long
+  used_bytes: long
+  free_bytes: long
+  free_disk_percent: double
+  used_disk_percent: double
+}
+
 export interface NodeAllocationExplanation {
   deciders: Array<AllocationDecision>
   node_attributes: Record<string, string>
   node_decision: Decision
   node_id: string
   node_name: string
-  store: AllocationStore
+  store?: AllocationStore
   transport_address: string
   weight_ranking: integer
+}
+
+export interface NodeDiskUsage {
+  node_name: string
+  least_available: DiskUsage
+  most_available: DiskUsage
+}
+
+export interface ReservedSize {
+  node_id: string
+  path: string
+  total: long
+  shards: Array<string>
 }
 
 export interface UnassignedInformation {
   at: Date
   last_allocation_status: string
   reason: UnassignedInformationReason
+  details?: string
+  failed_allocation_attempts?: integer
 }
 
 export type UnassignedInformationReason = 'INDEX_CREATED' | 'CLUSTER_RECOVERED' | 'INDEX_REOPENED' | 'DANGLING_INDEX_IMPORTED' | 'NEW_INDEX_RESTORED' | 'EXISTING_INDEX_RESTORED' | 'REPLICA_ADDED' | 'ALLOCATION_FAILED' | 'NODE_LEFT' | 'REROUTE_CANCELLED' | 'REINITIALIZED' | 'REALLOCATED_REPLICA' | 'PRIMARY_FAILED' | 'FORCED_EMPTY_PRIMARY' | 'MANUAL_ALLOCATION'
@@ -2529,6 +2561,7 @@ export type ShapeRelation = 'intersects' | 'disjoint' | 'within'
 
 export interface CompletionStats {
   size_in_bytes: long
+  fields?: Record<Field, CompletionStats>
 }
 
 export interface DocStats {
@@ -2537,26 +2570,27 @@ export interface DocStats {
 }
 
 export interface FielddataStats {
-  evictions: long
+  evictions?: long
   memory_size_in_bytes: long
+  fields?: Record<Field, FielddataStats>
 }
 
 export interface FlushStats {
   periodic: long
   total: long
-  total_time: string
+  total_time?: string
   total_time_in_millis: long
 }
 
 export interface GetStats {
   current: long
-  exists_time: string
+  exists_time?: string
   exists_time_in_millis: long
   exists_total: long
-  missing_time: string
+  missing_time?: string
   missing_time_in_millis: long
   missing_total: long
-  time: string
+  time?: string
   time_in_millis: long
   total: long
 }
@@ -2564,35 +2598,36 @@ export interface GetStats {
 export interface IndexingStats {
   index_current: long
   delete_current: long
-  delete_time: string
+  delete_time?: string
   delete_time_in_millis: long
   delete_total: long
   is_throttled: boolean
   noop_update_total: long
-  throttle_time: string
+  throttle_time?: string
   throttle_time_in_millis: long
-  index_time: string
+  index_time?: string
   index_time_in_millis: long
   index_total: long
-  types: Record<string, IndexingStats>
+  index_failed: long
+  types?: Record<string, IndexingStats>
 }
 
 export interface MergesStats {
   current: long
   current_docs: long
-  current_size: string
+  current_size?: string
   current_size_in_bytes: long
   total: long
-  total_auto_throttle: string
+  total_auto_throttle?: string
   total_auto_throttle_in_bytes: long
   total_docs: long
-  total_size: string
+  total_size?: string
   total_size_in_bytes: long
-  total_stopped_time: string
-  total__stopped_time_in_millis: long
-  total_throttled_time: string
+  total_stopped_time?: string
+  total_stopped_time_in_millis: long
+  total_throttled_time?: string
   total_throttled_time_in_millis: long
-  total_time: string
+  total_time?: string
   total_time_in_millis: long
 }
 
@@ -2620,22 +2655,23 @@ export interface QueryCacheStats {
 export interface RecoveryStats {
   current_as_source: long
   current_as_target: long
-  throttle_time: string
+  throttle_time?: string
   throttle_time_in_millis: long
 }
 
 export interface RefreshStats {
   external_total: long
   external_total_time_in_millis: long
+  listeners: long
   total: long
-  total_time: string
+  total_time?: string
   total_time_in_millis: long
 }
 
 export interface RequestCacheStats {
   evictions: long
   hit_count: long
-  memory_size: string
+  memory_size?: string
   memory_size_in_bytes: long
   miss_count: long
 }
@@ -2644,7 +2680,7 @@ export interface SearchStats {
   fetch_current: long
   fetch_time_in_millis: long
   fetch_total: long
-  open_contexts: long
+  open_contexts?: long
   query_current: long
   query_time_in_millis: long
   query_total: long
@@ -2654,6 +2690,7 @@ export interface SearchStats {
   suggest_current: long
   suggest_time_in_millis: long
   suggest_total: long
+  groups?: Record<string, SearchStats>
 }
 
 export interface SegmentsStats {
@@ -2661,7 +2698,7 @@ export interface SegmentsStats {
   doc_values_memory_in_bytes: long
   file_sizes: Record<string, ShardFileSizeInfo>
   fixed_bit_set_memory_in_bytes: long
-  index_writer_max_memory_in_bytes: long
+  index_writer_max_memory_in_bytes?: long
   index_writer_memory_in_bytes: long
   max_unsafe_auto_id_timestamp: long
   memory_in_bytes: long
@@ -2674,24 +2711,25 @@ export interface SegmentsStats {
 }
 
 export interface StoreStats {
-  size: string
+  size?: string
   size_in_bytes: double
+  reserved_in_bytes: double
 }
 
 export interface TranslogStats {
   earliest_last_modified_age: long
   operations: long
-  size: string
+  size?: string
   size_in_bytes: long
   uncommitted_operations: integer
-  uncommitted_size: string
+  uncommitted_size?: string
   uncommitted_size_in_bytes: long
 }
 
 export interface WarmerStats {
   current: long
   total: long
-  total_time: string
+  total_time?: string
   total_time_in_millis: long
 }
 
@@ -3375,8 +3413,8 @@ export interface UpdateResponse<TDocument = unknown> extends WriteResponseBase {
 }
 
 export interface IndexState {
-  aliases: Record<IndexName, Alias>
-  mappings: TypeMapping
+  aliases?: Record<IndexName, Alias>
+  mappings?: TypeMapping
   settings: Record<string, any>
 }
 
@@ -3464,10 +3502,16 @@ export interface PutAliasResponse extends ResponseBase {
 }
 
 export interface AnalyzeDetail {
-  charfilters: Array<CharFilterDetail>
+  analyzer?: AnalyzerDetail
+  charfilters?: Array<CharFilterDetail>
   custom_analyzer: boolean
-  tokenfilters: Array<TokenDetail>
-  tokenizer: TokenDetail
+  tokenfilters?: Array<TokenDetail>
+  tokenizer?: TokenDetail
+}
+
+export interface AnalyzerDetail {
+  name: string
+  tokens: Array<ExplainAnalyzeToken>
 }
 
 export interface AnalyzeRequest extends RequestBase {
@@ -3480,20 +3524,20 @@ export interface AnalyzeRequest extends RequestBase {
     field?: Field
     filter?: Array<string | TokenFilterBase>
     normalizer?: string
-    text?: Array<string>
+    text?: string | Array<string>
     tokenizer?: string | TokenizerBase
   }
 }
 
 export interface AnalyzeResponse extends ResponseBase {
-  detail: AnalyzeDetail
-  tokens: Array<AnalyzeToken>
+  detail?: AnalyzeDetail
+  tokens?: Array<AnalyzeToken>
 }
 
 export interface AnalyzeToken {
   end_offset: long
   position: long
-  position_length: long
+  position_length?: long
   start_offset: long
   token: string
   type: string
@@ -3507,7 +3551,7 @@ export interface CharFilterDetail {
 export interface ExplainAnalyzeToken {
   bytes: string
   end_offset: long
-  keyword: boolean
+  keyword?: boolean
   position: long
   positionLength: long
   start_offset: long
@@ -3526,7 +3570,7 @@ export interface CloneIndexRequest extends RequestBase {
   target: Name
   master_timeout?: Time
   timeout?: Time
-  wait_for_active_shards?: string
+  wait_for_active_shards?: string | number
   body?: {
     aliases?: Record<IndexName, Alias>
     settings?: Record<string, any>
@@ -4056,47 +4100,48 @@ export interface ShardStoreWrapper {
 }
 
 export interface IndexStats {
-  completion: CompletionStats
-  docs: DocStats
-  fielddata: FielddataStats
-  flush: FlushStats
-  get: GetStats
-  indexing: IndexingStats
-  merges: MergesStats
-  query_cache: QueryCacheStats
-  recovery: RecoveryStats
-  refresh: RefreshStats
-  request_cache: RequestCacheStats
-  search: SearchStats
-  segments: SegmentsStats
-  store: StoreStats
-  translog: TranslogStats
-  warmer: WarmerStats
+  completion?: CompletionStats
+  docs?: DocStats
+  fielddata?: FielddataStats
+  flush?: FlushStats
+  get?: GetStats
+  indexing?: IndexingStats
+  merges?: MergesStats
+  query_cache?: QueryCacheStats
+  recovery?: RecoveryStats
+  refresh?: RefreshStats
+  request_cache?: RequestCacheStats
+  search?: SearchStats
+  segments?: SegmentsStats
+  store?: StoreStats
+  translog?: TranslogStats
+  warmer?: WarmerStats
 }
 
 export interface IndicesStats {
   primaries: IndexStats
-  shards: Record<string, Array<ShardStats>>
+  shards?: Record<string, Array<ShardStats>>
   total: IndexStats
-  uuid: string
+  uuid?: string
 }
 
 export interface IndicesStatsRequest extends RequestBase {
   metric?: Metrics
   index?: Indices
-  completion_fields?: Array<Field>
+  completion_fields?: Fields
   expand_wildcards?: ExpandWildcards
-  fielddata_fields?: Array<Field>
-  fields?: Array<Field>
+  fielddata_fields?: Fields
+  fields?: Fields
   forbid_closed_indices?: boolean
-  groups?: Array<string>
+  groups?: string | Array<string>
   include_segment_file_sizes?: boolean
   include_unloaded_segments?: boolean
   level?: Level
+  types?: TypeNames
 }
 
 export interface IndicesStatsResponse extends ResponseBase {
-  indices: Record<string, IndicesStats>
+  indices?: Record<string, IndicesStats>
   _shards: ShardStatistics
   _all: IndicesStats
 }
@@ -4129,6 +4174,7 @@ export interface ShardFileSizeInfo {
 
 export interface ShardFlush {
   total: long
+  periodic: long
   total_time_in_millis: long
 }
 
@@ -4153,6 +4199,13 @@ export interface ShardIndexing {
   is_throttled: boolean
   noop_update_total: long
   throttle_time_in_millis: long
+}
+
+export interface ShardLease {
+  id: string
+  retaining_seq_no: long
+  timestamp: long
+  source: string
 }
 
 export interface ShardMerges {
@@ -4188,6 +4241,8 @@ export interface ShardRefresh {
   listeners: long
   total: long
   total_time_in_millis: long
+  external_total: long
+  external_total_time_in_millis: long
 }
 
 export interface ShardRequestCache {
@@ -4197,10 +4252,16 @@ export interface ShardRequestCache {
   miss_count: long
 }
 
+export interface ShardRetentionLeases {
+  primary_term: long
+  version: long
+  leases: Array<ShardLease>
+}
+
 export interface ShardRouting {
   node: string
   primary: boolean
-  relocating_node: string
+  relocating_node?: string
   state: ShardRoutingState
 }
 
@@ -4258,6 +4319,7 @@ export interface ShardStats {
   recovery: ShardStatsRecovery
   refresh: ShardRefresh
   request_cache: ShardRequestCache
+  retention_leases: ShardRetentionLeases
   routing: ShardRouting
   search: ShardSearch
   segments: ShardSegments
@@ -4274,10 +4336,12 @@ export interface ShardStatsRecovery {
 }
 
 export interface ShardStatsStore {
+  reserved_in_bytes: long
   size_in_bytes: long
 }
 
 export interface ShardTransactionLog {
+  earliest_last_modified_age: long
   operations: long
   size_in_bytes: long
   uncommitted_operations: long

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2390,9 +2390,6 @@ export type GroupBy = 'nodes' | 'parents' | 'none'
 
 export type Health = 'green' | 'yellow' | 'red'
 
-export interface IDictionary<TKey = unknown, TValue = unknown> {
-}
-
 export type Level = 'cluster' | 'indices' | 'shards'
 
 export type OpType = 'index' | 'create'
@@ -4730,6 +4727,9 @@ export interface SimulatePipelineRequest extends RequestBase {
 
 export interface SimulatePipelineResponse extends ResponseBase {
   docs: Array<PipelineSimulation>
+}
+
+export interface AdditionalProperties<TKey = unknown, TValue = unknown> {
 }
 
 export type AggregateName = string

--- a/specification/specs/aggregations/Aggregate.ts
+++ b/specification/specs/aggregations/Aggregate.ts
@@ -9,7 +9,7 @@ type Bucket =
   | SignificantTermsBucket<any>
   | KeyedBucket<any>
 
-class BucketBase {}
+class BucketBase implements IDictionary<AggregateName, Aggregate> {}
 class CompositeBucket extends BucketBase {}
 class DateHistogramBucket extends BucketBase {}
 class FiltersBucketItem extends BucketBase {
@@ -21,8 +21,8 @@ class RareTermsBucket<TKey> extends BucketBase {}
 class SignificantTermsBucket<TKey> extends BucketBase {}
 class KeyedBucket<TKey> extends BucketBase {}
 
-type Aggregate  = ValueAggregate
-  | DocCountAggregate
+type Aggregate  =
+  | SingleBucketAggregate
   | AutoDateHistogramAggregate
   | FiltersAggregate
   | SignificantTermsAggregate<any>
@@ -30,10 +30,13 @@ type Aggregate  = ValueAggregate
   | BucketAggregate
   | CompositeBucketAggregate
   | MultiBucketAggregate<any>
-  | SingleBucketAggregate
   | MatrixStatsAggregate
+  | KeyedValueAggregate
+  | MetricAggregate
+
+type MetricAggregate =
+  | ValueAggregate
   | BoxPlotAggregate
-  | ExtendedStatsAggregate
   | GeoBoundsAggregate
   | GeoCentroidAggregate
   | PercentilesAggregate
@@ -42,7 +45,7 @@ type Aggregate  = ValueAggregate
   | StringStatsAggregate
   | TopHitsAggregate
   | TopMetricsAggregate
-  | KeyedValueAggregate
+  | ExtendedStatsAggregate
   | TDigestPercentilesAggregate
   | HdrPercentilesAggregate
 
@@ -59,7 +62,7 @@ class ValueAggregate extends AggregateBase {
   value_as_string?: string;
 }
 
-class DocCountAggregate extends AggregateBase {
+class SingleBucketAggregate extends AggregateBase implements IDictionary<AggregateName, Aggregate> {
   doc_count: double;
 }
 class KeyedValueAggregate extends ValueAggregate {
@@ -85,6 +88,7 @@ class TermsAggregate<TKey> extends MultiBucketAggregate<TKey> {
   sum_other_doc_count: long;
 }
 
+// TODO this is an intermediate type in NEST
 class BucketAggregate extends AggregateBase {
   after_key:Dictionary<string, UserDefinedValue>;
   bg_count:long;
@@ -98,9 +102,6 @@ class BucketAggregate extends AggregateBase {
 class CompositeBucketAggregate extends MultiBucketAggregate<Dictionary<string, UserDefinedValue>> {
   after_key:Dictionary<string, UserDefinedValue>;
 }
-
-//TODO Hard
-class SingleBucketAggregate extends AggregateBase {}
 
 class MatrixStatsAggregate extends AggregateBase {
   correlation: Dictionary<string, double>;

--- a/specification/specs/aggregations/Aggregate.ts
+++ b/specification/specs/aggregations/Aggregate.ts
@@ -9,7 +9,7 @@ type Bucket =
   | SignificantTermsBucket<any>
   | KeyedBucket<any>
 
-class BucketBase implements IDictionary<AggregateName, Aggregate> {}
+class BucketBase implements AdditionalProperties<AggregateName, Aggregate> {}
 class CompositeBucket extends BucketBase {}
 class DateHistogramBucket extends BucketBase {}
 class FiltersBucketItem extends BucketBase {
@@ -62,7 +62,7 @@ class ValueAggregate extends AggregateBase {
   value_as_string?: string;
 }
 
-class SingleBucketAggregate extends AggregateBase implements IDictionary<AggregateName, Aggregate> {
+class SingleBucketAggregate extends AggregateBase implements AdditionalProperties<AggregateName, Aggregate> {
   doc_count: double;
 }
 class KeyedValueAggregate extends ValueAggregate {

--- a/specification/specs/analysis/char_filters/CharFilterBase.ts
+++ b/specification/specs/analysis/char_filters/CharFilterBase.ts
@@ -1,4 +1,4 @@
-class CharFilterBase implements ICharFilter {
+class CharFilterBase {
   type: string;
   version: string;
 }

--- a/specification/specs/analysis/char_filters/ICharFilter.ts
+++ b/specification/specs/analysis/char_filters/ICharFilter.ts
@@ -1,4 +1,0 @@
-interface ICharFilter {
-  type: string;
-  version: string;
-}

--- a/specification/specs/analysis/token_filters/ITokenFilter.ts
+++ b/specification/specs/analysis/token_filters/ITokenFilter.ts
@@ -1,5 +1,0 @@
-interface ITokenFilter {
-  type: string;
-  version?: string;
-  stopwords?: Array<string>;
-}

--- a/specification/specs/analysis/token_filters/TokenFilterBase.ts
+++ b/specification/specs/analysis/token_filters/TokenFilterBase.ts
@@ -1,5 +1,4 @@
 class TokenFilterBase {
   type: string;
   version: string;
-  stopwords?: Array<string>;
 }

--- a/specification/specs/analysis/token_filters/TokenFilterBase.ts
+++ b/specification/specs/analysis/token_filters/TokenFilterBase.ts
@@ -1,4 +1,5 @@
-class TokenFilterBase implements ITokenFilter {
+class TokenFilterBase {
   type: string;
   version: string;
+  stopwords?: Array<string>;
 }

--- a/specification/specs/analysis/tokenizers/ITokenizer.ts
+++ b/specification/specs/analysis/tokenizers/ITokenizer.ts
@@ -1,4 +1,0 @@
-interface ITokenizer {
-  type: string;
-  version: string;
-}

--- a/specification/specs/analysis/tokenizers/TokenizerBase.ts
+++ b/specification/specs/analysis/tokenizers/TokenizerBase.ts
@@ -1,4 +1,4 @@
-class TokenizerBase implements ITokenizer {
+class TokenizerBase {
   type: string;
   version: string;
 }

--- a/specification/specs/behaviors.ts
+++ b/specification/specs/behaviors.ts
@@ -1,0 +1,17 @@
+/*
+ * This file hosts `behaviors`. We use this interfaces that are marked with a `@behavior` JS Doc annotation
+ * to signal complicated mappings to the compiler -> canonical json -> client generators.
+ *
+ * These are problem sets that need a custom client solution.
+ */
+
+
+/**
+ * In some places in the specification an object consists of the union of a set of known properties
+ * and a set of runtime injected properties. Meaning that object should theoretically extend Dictionary but expose
+ * a set of known keys and possibly. The object might already be part of an object graph and have a parent class.
+ * This puts it into a bind that needs a client specific solution.
+ * We therefore document the requirement to behave like a dictionary for unknown properties with this interface.
+ * @behavior Defines a trait that any unknown property for the class should be typed to TValue
+ */
+interface AdditionalProperties<TKey, TValue> {}

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -89,6 +89,13 @@ type GeoHashPrecision = number
 /** Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.  */
 type Fields = Field | Field[]
 
+
+/**
+ * The aggregation name as returned from the server. Depending whether typed_keys is specified this could come back
+ * in the form of `name#type` instead of simply `name`
+ */
+type AggregateName = string
+
 /** A reference to a date field with formatting instructions on how to return the date */
 class DateField {
   field: Field;

--- a/specification/specs/common/Dictionary.ts
+++ b/specification/specs/common/Dictionary.ts
@@ -1,4 +1,6 @@
-
+/**
+ * @trait Defines a trait that any unknown property for the class should be typed to TValue
+ */
 interface IDictionary<TKey, TValue> {}
 
 class Dictionary<TKey, TValue> {}

--- a/specification/specs/common/Dictionary.ts
+++ b/specification/specs/common/Dictionary.ts
@@ -1,8 +1,6 @@
-class Dictionary<TKey, TValue> {
-  key: TKey;
-  value: TValue;
-}
 
-class SingleKeyDictionary<TValue> {
-  value: TValue
-}
+interface IDictionary<TKey, TValue> {}
+
+class Dictionary<TKey, TValue> {}
+
+class SingleKeyDictionary<TValue> {}

--- a/specification/specs/common/Dictionary.ts
+++ b/specification/specs/common/Dictionary.ts
@@ -1,7 +1,3 @@
-/**
- * @trait Defines a trait that any unknown property for the class should be typed to TValue
- */
-interface IDictionary<TKey, TValue> {}
 
 class Dictionary<TKey, TValue> {}
 

--- a/specification/specs/indices/analyze/AnalyzeRequest.ts
+++ b/specification/specs/indices/analyze/AnalyzeRequest.ts
@@ -8,12 +8,12 @@ class AnalyzeRequest extends RequestBase {
   body?: {
     analyzer?: string;
     attributes?: string[];
-    char_filter?: Union<string, ICharFilter>[];
+    char_filter?: Union<string, CharFilterBase>[];
     explain?: boolean;
     field?: Field;
-    filter?: Union<string, ITokenFilter>[];
+    filter?: Union<string, TokenFilterBase>[];
     normalizer?: string;
     text?: string | Array<string>;
-    tokenizer?: Union<string, ITokenizer>;
+    tokenizer?: Union<string, TokenizerBase>;
   }
 }

--- a/specification/specs/indices/mapping_management/put_mapping/PutMappingRequest.ts
+++ b/specification/specs/indices/mapping_management/put_mapping/PutMappingRequest.ts
@@ -22,7 +22,7 @@ class PutMappingRequest extends RequestBase {
     index_field?: IndexField;
     meta?: Dictionary<string, UserDefinedValue>;
     numeric_detection?: boolean;
-    properties?: Dictionary<PropertyName, IProperty>;
+    properties?: Dictionary<PropertyName, PropertyBase>;
     routing_field?: RoutingField;
     size_field?: SizeField;
     source_field?: SourceField;

--- a/specification/specs/mapping/TypeMapping.ts
+++ b/specification/specs/mapping/TypeMapping.ts
@@ -9,7 +9,7 @@ class TypeMapping {
   index_field?: IndexField;
   _meta?: Dictionary<string, UserDefinedValue>;
   numeric_detection?: boolean;
-  properties: Dictionary<PropertyName, IProperty>;
+  properties: Dictionary<PropertyName, PropertyBase>;
   _routing?: RoutingField;
   _size?: SizeField;
   _source?: SourceField;

--- a/specification/specs/mapping/dynamic_template/DynamicTemplate.ts
+++ b/specification/specs/mapping/dynamic_template/DynamicTemplate.ts
@@ -1,5 +1,5 @@
 class DynamicTemplate {
-  mapping: IProperty;
+  mapping: PropertyBase;
   match: string;
   match_mapping_type: string;
   match_pattern: MatchType;

--- a/specification/specs/mapping/types/CorePropertyBase.ts
+++ b/specification/specs/mapping/types/CorePropertyBase.ts
@@ -1,6 +1,6 @@
 class CorePropertyBase extends PropertyBase {
   copy_to: Field[];
-  fields: Dictionary<PropertyName, IProperty>;
+  fields: Dictionary<PropertyName, PropertyBase>;
   similarity: string;
   store: boolean;
 }

--- a/specification/specs/mapping/types/IProperty.ts
+++ b/specification/specs/mapping/types/IProperty.ts
@@ -1,7 +1,0 @@
-interface IProperty {
-  local_metadata?: Dictionary<string, UserDefinedValue>;
-  meta?: Dictionary<string, string>;
-  name?: PropertyName;
-  type: string;
-  properties?: Dictionary<PropertyName, IProperty>;
-}

--- a/specification/specs/mapping/types/PropertyBase.ts
+++ b/specification/specs/mapping/types/PropertyBase.ts
@@ -1,4 +1,4 @@
-class PropertyBase implements IProperty {
+class PropertyBase {
   local_metadata: Dictionary<string, UserDefinedValue>;
   meta: Dictionary<string, string>;
   name: PropertyName;

--- a/specification/specs/mapping/types/complex/object/ObjectProperty.ts
+++ b/specification/specs/mapping/types/complex/object/ObjectProperty.ts
@@ -2,5 +2,5 @@ class ObjectProperty extends CorePropertyBase {
   /** @prop_serializer DynamicMappingFormatter */
   dynamic: Union<boolean, DynamicMapping>;
   enabled: boolean;
-  properties: Dictionary<PropertyName, IProperty>;
+  properties: Dictionary<PropertyName, PropertyBase>;
 }

--- a/specification/specs/search/search/SearchResponse.ts
+++ b/specification/specs/search/search/SearchResponse.ts
@@ -4,7 +4,7 @@ class SearchResponse<TDocument> extends ResponseBase {
   _shards: ShardStatistics;
   hits: HitsMetadata<TDocument>;
 
-  aggregations?: Dictionary<string, Aggregate>;
+  aggregations?: Dictionary<AggregateName, Aggregate>;
   _clusters?: ClusterStatistics;
   documents?: TDocument[];
   fields?: Dictionary<string, LazyDocument>;

--- a/specification/specs/x_pack/machine_learning/machine_learning_info/CategorizationAnalyzer.ts
+++ b/specification/specs/x_pack/machine_learning/machine_learning_info/CategorizationAnalyzer.ts
@@ -1,4 +1,4 @@
 class CategorizationAnalyzer {
-  filter: ITokenFilter[];
+  filter: TokenFilterBase[];
   tokenizer: string;
 }

--- a/specification/src/api-specification.ts
+++ b/specification/src/api-specification.ts
@@ -44,6 +44,7 @@ export class Specification {
       if (!(t instanceof Domain.Interface)) return
       t.inherits = []
       t.implements = []
+      t.traits = []
       for (const key of Object.keys(t.inheritsFromUnresolved)) {
         const refType = lookup(key)
         const ref = new Domain.InheritsReference(refType)
@@ -55,7 +56,8 @@ export class Specification {
         const unresolved = t.implementsFromUnresolved[key]
         const ref = new Domain.ImplementsReference(refType, unresolved.depth)
         ref.closedGenerics = unresolved.instanceOf;
-        t.implements.push(ref)
+        if (ref.depth === 0) t.implements.push(ref)
+        if (ref.type.generatorHints.trait) t.traits.push(ref.type.name)
       }
     })
     this.types = types

--- a/specification/src/api-specification.ts
+++ b/specification/src/api-specification.ts
@@ -34,6 +34,7 @@ export class Specification {
       }
     }
 
+    const supportedTraits = ["IDictionary"]
     const specVisitor = new TypeReader(this.program)
     const types = [].concat(specVisitor.interfaces).concat(specVisitor.enums)
     // resolve inherits by creating the proper pointers to instances, pretty hairy but it works
@@ -57,7 +58,12 @@ export class Specification {
         const ref = new Domain.ImplementsReference(refType, unresolved.depth)
         ref.closedGenerics = unresolved.instanceOf;
         if (ref.depth === 0) t.implements.push(ref)
-        if (ref.type.generatorHints.trait) t.traits.push(ref.type.name)
+        if (ref.type.generatorHints.trait) {
+          if (!supportedTraits.includes(ref.type.name)) {
+            throw new Error(`${ref.type.name} is not a known trait, please include it here`)
+          }
+          else t.traits.push(ref.type.name)
+        }
       }
     })
     this.types = types

--- a/specification/src/api-specification.ts
+++ b/specification/src/api-specification.ts
@@ -43,11 +43,19 @@ export class Specification {
     types.forEach(t => {
       if (!(t instanceof Domain.Interface)) return
       t.inherits = []
+      t.implements = []
       for (const key of Object.keys(t.inheritsFromUnresolved)) {
         const refType = lookup(key)
-        const ref = new Domain.ImplementsReference(refType)
+        const ref = new Domain.InheritsReference(refType)
         ref.closedGenerics = t.inheritsFromUnresolved[key]
         t.inherits.push(ref)
+      }
+      for (const key of Object.keys(t.implementsFromUnresolved)) {
+        const refType = lookup(key)
+        const unresolved = t.implementsFromUnresolved[key]
+        const ref = new Domain.ImplementsReference(refType, unresolved.depth)
+        ref.closedGenerics = unresolved.instanceOf;
+        t.implements.push(ref)
       }
     })
     this.types = types

--- a/specification/src/domain.ts
+++ b/specification/src/domain.ts
@@ -42,6 +42,7 @@ namespace Domain {
 
       this.alternateName = this.annotations.alternate_name
       this.customSerializationRoutine = this.annotations.prop_serializer
+      this.trait = this.annotations.trait
     }
 
     annotations: Record<string, string>;
@@ -52,10 +53,13 @@ namespace Domain {
     /** presents a suggestion for an alternate name in case of conflicts */
     alternateName: string;
 
+    /** marks an interface as a trait, holds a description to its purpose */
+    trait: string;
+
     /**
-    * The name of the custom serialization routine, in some cases the spec knows there is no 1-1 mapping.
-    * This property can be used to generate stubs for manual serialization work
-    */
+     * The name of the custom serialization routine, in some cases the spec knows there is no 1-1 mapping.
+     * This property can be used to generate stubs for manual serialization work
+     */
     customSerializationRoutine: string;
   }
 
@@ -72,6 +76,7 @@ namespace Domain {
     implementsFromUnresolved: Record<string, { depth: number, instanceOf: InstanceOf[]}> = {};
     inherits: Domain.InheritsReference[] = [];
     implements: Domain.ImplementsReference[] = [];
+    traits: string[];
     openGenerics: string[];
     implementsUnion = (): boolean => Object.keys(this.inheritsFromUnresolved).includes('Union');
   }

--- a/specification/src/domain.ts
+++ b/specification/src/domain.ts
@@ -21,6 +21,7 @@ namespace Domain {
     key: InstanceOf;
     value: InstanceOf;
   }
+
   export class SingleKeyDictionary {
     type = new Type('singlekeydictionary');
     value: InstanceOf;
@@ -68,7 +69,9 @@ namespace Domain {
   export class Interface extends TypeDeclaration {
     properties: InterfaceProperty[] = [];
     inheritsFromUnresolved: Record<string, InstanceOf[]> = {};
-    inherits: Domain.ImplementsReference[] = [];
+    implementsFromUnresolved: Record<string, { depth: number, instanceOf: InstanceOf[]}> = {};
+    inherits: Domain.InheritsReference[] = [];
+    implements: Domain.ImplementsReference[] = [];
     openGenerics: string[];
     implementsUnion = (): boolean => Object.keys(this.inheritsFromUnresolved).includes('Union');
   }
@@ -88,8 +91,14 @@ namespace Domain {
     path: InterfaceProperty[] = [];
   }
 
-  export class ImplementsReference {
+  export class InheritsReference {
     constructor (public type: Domain.Interface) {}
+    closedGenerics: Domain.InstanceOf[];
+  }
+  export class ImplementsReference extends InheritsReference {
+    constructor (public type: Domain.Interface, public depth:number = 0) {
+      super(type)
+    }
     closedGenerics: Domain.InstanceOf[];
   }
 

--- a/specification/src/domain.ts
+++ b/specification/src/domain.ts
@@ -42,7 +42,7 @@ namespace Domain {
 
       this.alternateName = this.annotations.alternate_name
       this.customSerializationRoutine = this.annotations.prop_serializer
-      this.trait = this.annotations.trait
+      this.behavior = this.annotations.behavior
     }
 
     annotations: Record<string, string>;
@@ -54,7 +54,7 @@ namespace Domain {
     alternateName: string;
 
     /** marks an interface as a trait, holds a description to its purpose */
-    trait: string;
+    behavior: string;
 
     /**
      * The name of the custom serialization routine, in some cases the spec knows there is no 1-1 mapping.
@@ -76,7 +76,8 @@ namespace Domain {
     implementsFromUnresolved: Record<string, { depth: number, instanceOf: InstanceOf[]}> = {};
     inherits: Domain.InheritsReference[] = [];
     implements: Domain.ImplementsReference[] = [];
-    traits: string[];
+    behaviors: Domain.ImplementsReference[] = [];
+    attachedBehaviors: string[];
     openGenerics: string[];
     implementsUnion = (): boolean => Object.keys(this.inheritsFromUnresolved).includes('Union');
   }

--- a/specification/src/main.ts
+++ b/specification/src/main.ts
@@ -21,7 +21,7 @@ for (const e of specification.endpoints) {
   //  console.log(type);
 }
 for (const t of specification.types) {
-  if (['StopWords'].includes(t.name)) { console.log(t) }
+  if (['CompositeBucket'].includes(t.name)) { console.dir(t, {depth: 20} ) }
 }
 
 console.log('Done!')

--- a/specification/src/metamodel.ts
+++ b/specification/src/metamodel.ts
@@ -126,10 +126,10 @@ export class Inherits {
   type: TypeName;
   generics?: ValueOf[];
 }
+
 export class Implements {
   type: TypeName;
   generics?: ValueOf[];
-  depth:number
 }
 
 /**
@@ -140,6 +140,7 @@ export class Interface extends BaseType {
   generics?: string[];
   inherits?: Inherits[];
   implements?: Implements[];
+  traits?: string[];
   properties: Property[];
 }
 

--- a/specification/src/metamodel.ts
+++ b/specification/src/metamodel.ts
@@ -126,6 +126,11 @@ export class Inherits {
   type: TypeName;
   generics?: ValueOf[];
 }
+export class Implements {
+  type: TypeName;
+  generics?: ValueOf[];
+  depth:number
+}
 
 /**
  * An interface type
@@ -134,6 +139,7 @@ export class Interface extends BaseType {
   kind: "interface";
   generics?: string[];
   inherits?: Inherits[];
+  implements?: Implements[];
   properties: Property[];
 }
 

--- a/specification/src/metamodel.ts
+++ b/specification/src/metamodel.ts
@@ -140,7 +140,8 @@ export class Interface extends BaseType {
   generics?: string[];
   inherits?: Inherits[];
   implements?: Implements[];
-  traits?: string[];
+  behaviors?: Implements[];
+  attachedBehaviors?: string[];
   properties: Property[];
 }
 

--- a/specification/src/metamodel_reader.ts
+++ b/specification/src/metamodel_reader.ts
@@ -5,6 +5,7 @@ import {
   Endpoint,
   EnumMember,
   Inherits,
+  Implements,
   Model,
   PropertiesBody,
   Property,
@@ -188,7 +189,7 @@ export function loadModel(spec: Specification): Model {
         description: makeDescription(specType),
         annotations: makeAnnotations(specType),
         generics: nonEmptyArr(specType.openGenerics),
-        inherits: nonEmptyArr(specType.inherits.map(i => makeImplements(i, specType.openGenerics))),
+        inherits: nonEmptyArr(specType.inherits.map(i => makeInherits(i, specType.openGenerics))),
         path: specType.path.map(prop => makeProperty(prop, specType.openGenerics)),
         query: specType.queryParameters.map(prop => makeProperty(prop, specType.openGenerics)),
         body: body
@@ -238,7 +239,8 @@ export function loadModel(spec: Specification): Model {
         kind: "interface",
         name: fullName,
         generics: nonEmptyArr(specType.openGenerics),
-        inherits: nonEmptyArr(specType.inherits.map(impl => makeImplements(impl, specType.openGenerics))),
+        inherits: nonEmptyArr(specType.inherits.map(impl => makeInherits(impl, specType.openGenerics))),
+        implements: nonEmptyArr(specType.implements.map(impl => makeImplements(impl, specType.openGenerics))),
         properties: specType.properties.map(prop => makeProperty(prop, specType.openGenerics))
       });
     }
@@ -248,7 +250,18 @@ export function loadModel(spec: Specification): Model {
     }
   }
 
-  function makeImplements(impl: Domain.ImplementsReference, openGenerics: string[]): Inherits {
+  function makeImplements(impl: Domain.ImplementsReference, openGenerics: string[]): Implements {
+
+    const type = makeTypeName(impl.type.name, openGenerics);
+
+    return {
+      depth: impl.depth,
+      type: type,
+      generics: nonEmptyArr(impl.closedGenerics.map(i => makeInstanceOf(i, openGenerics)))
+    };
+  }
+
+  function makeInherits(impl: Domain.InheritsReference, openGenerics: string[]): Inherits {
 
     // Autofix requests and responses that have self-reference generic parameters
     if (impl.closedGenerics.length > 0 && impl.type.openGenerics.length === 0) {

--- a/specification/src/metamodel_reader.ts
+++ b/specification/src/metamodel_reader.ts
@@ -241,6 +241,7 @@ export function loadModel(spec: Specification): Model {
         generics: nonEmptyArr(specType.openGenerics),
         inherits: nonEmptyArr(specType.inherits.map(impl => makeInherits(impl, specType.openGenerics))),
         implements: nonEmptyArr(specType.implements.map(impl => makeImplements(impl, specType.openGenerics))),
+        traits: nonEmptyArr(specType.traits),
         properties: specType.properties.map(prop => makeProperty(prop, specType.openGenerics))
       });
     }
@@ -255,7 +256,6 @@ export function loadModel(spec: Specification): Model {
     const type = makeTypeName(impl.type.name, openGenerics);
 
     return {
-      depth: impl.depth,
       type: type,
       generics: nonEmptyArr(impl.closedGenerics.map(i => makeInstanceOf(i, openGenerics)))
     };

--- a/specification/src/metamodel_reader.ts
+++ b/specification/src/metamodel_reader.ts
@@ -241,7 +241,8 @@ export function loadModel(spec: Specification): Model {
         generics: nonEmptyArr(specType.openGenerics),
         inherits: nonEmptyArr(specType.inherits.map(impl => makeInherits(impl, specType.openGenerics))),
         implements: nonEmptyArr(specType.implements.map(impl => makeImplements(impl, specType.openGenerics))),
-        traits: nonEmptyArr(specType.traits),
+        behaviors: nonEmptyArr(specType.behaviors.map(impl => makeImplements(impl, specType.openGenerics))),
+        attachedBehaviors: nonEmptyArr(specType.attachedBehaviors),
         properties: specType.properties.map(prop => makeProperty(prop, specType.openGenerics))
       });
     }

--- a/specification/src/specification/type-reader.ts
+++ b/specification/src/specification/type-reader.ts
@@ -104,22 +104,6 @@ class InterfaceVisitor extends Visitor {
       const x: any = s.valueDeclaration
       const heritageClauses: ts.HeritageClause[] = (x ? x.heritageClauses : []) || []
 
-      // the specification only uses interfaces as a signal to type reader
-      // its up to generators to choose to implement base classes as interfaces or not
-      const unknownImplementsClauses = heritageClauses
-        .filter(c => c.token === ts.SyntaxKind.ImplementsKeyword)
-        .flatMap(c => ((c as any).types || []) as ts.Node[])
-        .map(t=> {
-          const expression = ((t as any).expression as ts.Identifier)
-          return expression.text
-        })
-        .filter(name => {
-          if (name.startsWith("IDictionary")) return false;
-          return true;
-        })
-      if (unknownImplementsClauses.length > 0)
-        throw new Error(`${s.name} uses unknown implements on ${unknownImplementsClauses.join(", ")}`)
-
       domainInterface.inheritsFromUnresolved = heritageClauses
         .filter((c:ts.HeritageClause) => c.token === ts.SyntaxKind.ExtendsKeyword)
         .flatMap(c => ((c as any).types || []) as ts.Node[])

--- a/specification/src/specification/type-reader.ts
+++ b/specification/src/specification/type-reader.ts
@@ -244,7 +244,7 @@ class InterfaceVisitor extends Visitor {
 
   private visitTypeReference (t: ts.TypeReferenceNode): Domain.InstanceOf {
     const typeName = t.typeName?.getText() ?? (t as any).expression?.text
-    if (typeName.startsWith('Dictionary') || typeName.startsWith('IDictionary')) return this.createDictionary(t, typeName)
+    if (typeName.startsWith('Dictionary') || typeName.startsWith('AdditionalProperties')) return this.createDictionary(t, typeName)
     if (typeName.startsWith('Union')) return this.createUnion(t, typeName)
     if (typeName.startsWith('SingleKeyDictionary')) return this.createSingleKeyDictionary(t, typeName)
     if (typeName.startsWith('UserDefinedValue')) return this.createUserDefinedValue(t, typeName)


### PR DESCRIPTION
This PR splits extends and implements to two seperately exposed
components. Previously they were all exposed under `.inherits`.

Interfaces are barely used in the input specification. Where they were
used there was always also a common base class implementation.

I removed all the used interfaces and reintroduced `IDictionary<TKey,
TValue>`

This allows types to declare they implement this dictionary and we can
the presence of this to either generate an appropiate type or know that
we might need to handle serialization explicitly.

```json
{
    "doc_count: 0
    "mykey" { .. }
    "myother_key" : { ... }
}
```

Can therefor now be typed as:

```ts
class ThingWithDocCount implements IDictionary<string, Aggregate> {}
```

In the typescript output we can inspect `interface.implements` to see if
it extends `IDictionary` and know we need to generate:

```ts
type ThingWithDocCount = {
   doc_count: long
} & Record<string, Aggregate>
```

Implements is exposed on all the types to ease generation e.g

```
A implements Y
B extends A
C extends B
```

In the canonical domain when inspecting `C`

`types['C']["implements"]` will hold a reference to `Y`
`types['C']["extends"]` will hold a reference to `B`

Implements exposes `depth` to know if the implements is a direct
constraint or one coming through from a base class.

In `C#` this may be used to know if properties from `Y` need to be
explicitly implemented or if we can assume a baseclass has done so
already.
