### PR TITLE
Fixed docs and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,28 +136,28 @@ git clone https://github.com/elastic/elastic-client-generator.git
 git clone https://github.com/elastic/clients-flight-recorder.git
 
 cd elastic-client-generator
-./run-validations
+./run-validations.sh
 ```
 
 The last command above will boot an Elasticsearch instance and start the fligh recorder
 recording process, once that is finished, it will not be executed
-again unless you run again the command like this: `PULL_LATEST=true ./run-validations`.
+again unless you run again the command like this: `PULL_LATEST=true ./run-validations.sh`.
 
 You can validate a specific API with the `--api` option, same goes for `--request` and `--response`.
 For example, the following command validates the index request api:
 
 ```js
-./run-validations --api index --request
+./run-validations.sh --api index --request
 ```
 The following command validates the index response api:
 
 ```js
-./run-validations --api index --response
+./run-validations.sh --api index --response
 ```
 The following command validates the index request and response api:
 
 ```js
-./run-validations --api index --request --response
+./run-validations.sh --api index --request --response
 ```
 
 Once you see the errors, you can fix the original definition in `/specification/specs`
@@ -366,7 +366,7 @@ Very likely the recordings on your machine are stale, you can regenerate them
 by executing the following command (it will take a while).
 
 ```sh
-PULL_LATEST=true ./run-validations
+PULL_LATEST=true ./run-validations.sh
 ```
 
 ### Which editor should I use?

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ class IndexRequest<TDocument> extends RequestBase { ... }
 
 And finally open a pull request with your changes.
 
+Namespaced APIs can be validated in the same way, for example:
+
+```js
+./run-validations.sh --api cat.health --request
+```
+
 ### Where do I see the test?
 
 Everytime you run the `run-validations` script, a series of test will be generated and dumped on disk.

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "specification/lib/src/api-specification.d.ts",
   "scripts": {
     "lint:fix": "standardx --fix **/*.ts **/**/*.ts",
-    "compile:brain": "tsc --project specification/specs/tsconfig.json --noEmit",
-    "compile:specs": "tsc --project specification/tsconfig.json",
+    "compile:brain": "npm run compile:brain --prefix specification",
+    "compile:specs": "npm run compile:specs --prefix specification",
     "compile:canonical-json": "npm run generate-schema --prefix specification",
     "compile:ts-validation": "npm run start --prefix typescript-generator",
     "copy:specs": "cpy 'specs' ./lib --cwd=specification --no-overwrite --parents",

--- a/specification/package.json
+++ b/specification/package.json
@@ -9,7 +9,8 @@
     "format": "ts-node src/format.ts",
     "generate-schema": "ts-node src/metamodel_generate.ts",
     "debug-windows": "npm run compile && node %NODE_DEBUG_OPTION% src/main.js",
-    "compile": "tsc"
+    "compile:specs": "tsc",
+    "compile:brain": "tsc --project specs/tsconfig.json --noEmit"
   },
   "author": "Elastic",
   "license": "MIT",


### PR DESCRIPTION
This fix removes the requirement of a first `npm install` in the top-level folder and some docs nits.