### PR TITLE
Indices Get Settings

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -31349,7 +31349,7 @@
               }
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "mappings",
@@ -31360,7 +31360,7 @@
               "name": "TypeMapping"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "settings",
@@ -33060,6 +33060,9 @@
         "namespace": "indices.index_management.freeze_index",
         "name": "FreezeIndexRequest"
       },
+      "annotations": {
+        "type_stability": "stable"
+      },
       "inherits": [
         {
           "type": {
@@ -33146,11 +33149,23 @@
         {
           "name": "wait_for_active_shards",
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "namespace": "internal",
-              "name": "string"
-            }
+            "kind": "union_of",
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "namespace": "internal",
+                  "name": "string"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "namespace": "internal",
+                  "name": "number"
+                }
+              }
+            ]
           },
           "required": false,
           "description": "Sets the number of active shards to wait for before the operation returns."

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3375,8 +3375,8 @@ export interface UpdateResponse<TDocument = unknown> extends WriteResponseBase {
 }
 
 export interface IndexState {
-  aliases: Record<IndexName, Alias>
-  mappings: TypeMapping
+  aliases?: Record<IndexName, Alias>
+  mappings?: TypeMapping
   settings: Record<string, any>
 }
 
@@ -3575,7 +3575,7 @@ export interface FreezeIndexRequest extends RequestBase {
   ignore_unavailable?: boolean
   master_timeout?: Time
   timeout?: Time
-  wait_for_active_shards?: string
+  wait_for_active_shards?: string | number
 }
 
 export interface FreezeIndexResponse extends AcknowledgedResponseBase {

--- a/specification/specs/index_modules/index_settings/IndexState.ts
+++ b/specification/specs/index_modules/index_settings/IndexState.ts
@@ -1,5 +1,5 @@
 class IndexState {
-  aliases: Dictionary<IndexName, Alias>;
-  mappings: TypeMapping;
+  aliases?: Dictionary<IndexName, Alias>;
+  mappings?: TypeMapping;
   settings: Dictionary<string, UserDefinedValue>;
 }


### PR DESCRIPTION
Fix `IndexState` with nullable properties so that Indices.Get_Settings response tests pass.
