### PR TITLE
Add types to the 'mget' API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -30159,7 +30159,7 @@
               "name": "IndexName"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "routing",
@@ -30167,7 +30167,7 @@
             "kind": "instance_of",
             "type": {
               "namespace": "internal",
-              "name": "string"
+              "name": "Routing"
             }
           },
           "required": false
@@ -30187,8 +30187,15 @@
               {
                 "kind": "instance_of",
                 "type": {
-                  "namespace": "search.search.source_filtering",
-                  "name": "SourceFilter"
+                  "namespace": "internal",
+                  "name": "Fields"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "namespace": "document.multiple.multi_get.request",
+                  "name": "MultiGetSourceFilter"
                 }
               }
             ]
@@ -30198,13 +30205,21 @@
         {
           "name": "stored_fields",
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "Field"
-              }
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "Fields"
+            }
+          },
+          "required": false
+        },
+        {
+          "name": "_type",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "TypeName"
             }
           },
           "required": false
@@ -30240,6 +30255,9 @@
         "name": "MultiGetRequest"
       },
       "description": "Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.",
+      "annotations": {
+        "type_stability": "stable"
+      },
       "inherits": [
         {
           "type": {
@@ -30335,43 +30353,60 @@
           "required": false
         },
         {
-          "name": "source_excludes",
+          "name": "_source",
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "Field"
+            "kind": "union_of",
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "namespace": "internal",
+                  "name": "boolean"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "namespace": "internal",
+                  "name": "Fields"
+                }
               }
-            }
+            ]
           },
-          "required": false
+          "required": false,
+          "description": "True or false to return the _source field or not, or a list of fields to return"
         },
         {
-          "name": "source_includes",
+          "name": "_source_excludes",
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "Field"
-              }
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "Fields"
             }
           },
-          "required": false
+          "required": false,
+          "description": "A list of fields to exclude from the returned _source field"
+        },
+        {
+          "name": "_source_includes",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "Fields"
+            }
+          },
+          "required": false,
+          "description": "A list of fields to extract and return from the _source field"
         },
         {
           "name": "stored_fields",
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "namespace": "internal",
-                "name": "Field"
-              }
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "Fields"
             }
           },
           "required": false,
@@ -30394,9 +30429,54 @@
               }
             },
             "required": false
+          },
+          {
+            "name": "ids",
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "namespace": "internal",
+                  "name": "Id"
+                }
+              }
+            },
+            "required": false
           }
         ]
       }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "namespace": "document.multiple.multi_get.request",
+        "name": "MultiGetSourceFilter"
+      },
+      "properties": [
+        {
+          "name": "exclude",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "Fields"
+            }
+          },
+          "required": false
+        },
+        {
+          "name": "include",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "Fields"
+            }
+          },
+          "required": false
+        }
+      ]
     },
     {
       "kind": "interface",
@@ -30409,6 +30489,38 @@
       ],
       "properties": [
         {
+          "name": "error",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "namespace": "internal",
+              "name": "MainError"
+            }
+          },
+          "required": false
+        },
+        {
+          "name": "fields",
+          "type": {
+            "kind": "dictionary_of",
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "string"
+              }
+            },
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "namespace": "internal",
+                "name": "LazyDocument"
+              }
+            }
+          },
+          "required": false
+        },
+        {
           "name": "found",
           "type": {
             "kind": "instance_of",
@@ -30417,7 +30529,7 @@
               "name": "boolean"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_id",
@@ -30450,7 +30562,7 @@
               "name": "long"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_routing",
@@ -30458,10 +30570,10 @@
             "kind": "instance_of",
             "type": {
               "namespace": "internal",
-              "name": "string"
+              "name": "Routing"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_seq_no",
@@ -30472,7 +30584,7 @@
               "name": "long"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_source",
@@ -30483,7 +30595,7 @@
               "name": "TDocument"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_type",
@@ -30491,10 +30603,10 @@
             "kind": "instance_of",
             "type": {
               "namespace": "internal",
-              "name": "string"
+              "name": "TypeName"
             }
           },
-          "required": true
+          "required": false
         },
         {
           "name": "_version",
@@ -30505,7 +30617,7 @@
               "name": "long"
             }
           },
-          "required": true
+          "required": false
         }
       ]
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3219,10 +3219,11 @@ export interface DeleteByQueryRethrottleResponse extends ListTasksResponse {
 export interface MultiGetOperation {
   can_be_flattened?: boolean
   _id: Id
-  _index: IndexName
-  routing?: string
-  _source?: boolean | SourceFilter
-  stored_fields?: Array<Field>
+  _index?: IndexName
+  routing?: Routing
+  _source?: boolean | Fields | MultiGetSourceFilter
+  stored_fields?: Fields
+  _type?: TypeName
   version?: long
   version_type?: VersionType
 }
@@ -3235,24 +3236,33 @@ export interface MultiGetRequest extends RequestBase {
   refresh?: boolean
   routing?: Routing
   source_enabled?: boolean
-  source_excludes?: Array<Field>
-  source_includes?: Array<Field>
-  stored_fields?: Array<Field>
+  _source?: boolean | Fields
+  _source_excludes?: Fields
+  _source_includes?: Fields
+  stored_fields?: Fields
   body: {
     docs?: Array<MultiGetOperation>
+    ids?: Array<Id>
   }
 }
 
+export interface MultiGetSourceFilter {
+  exclude?: Fields
+  include?: Fields
+}
+
 export interface MultiGetHit<TDocument = unknown> {
-  found: boolean
+  error?: MainError
+  fields?: Record<string, LazyDocument>
+  found?: boolean
   _id: string
   _index: string
-  _primary_term: long
-  _routing: string
-  _seq_no: long
-  _source: TDocument
-  _type: string
-  _version: long
+  _primary_term?: long
+  _routing?: Routing
+  _seq_no?: long
+  _source?: TDocument
+  _type?: TypeName
+  _version?: long
 }
 
 export interface MultiGetResponse<TDocument = unknown> {

--- a/specification/specs/document/multiple/multi_get/request/MultiGetRequest.ts
+++ b/specification/specs/document/multiple/multi_get/request/MultiGetRequest.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @type_stability stable
+ */
 @rest_spec_name('mget')
 @class_serializer('MultiGetRequestFormatter')
 class MultiGetRequest extends RequestBase {
@@ -30,22 +33,33 @@ class MultiGetRequest extends RequestBase {
     refresh?: boolean
     routing?: Routing
     source_enabled?: boolean
-    source_excludes?: Field[]
-    source_includes?: Field[]
-    stored_fields?: Field[]
+    _source?: boolean | Fields
+    _source_excludes?: Fields
+    _source_includes?: Fields
+    stored_fields?: Fields
   }
   body?: {
     docs?: MultiGetOperation[]
+    ids?: Id[]
   }
+}
+
+// This differs from SourceFilter by
+// using 'exclude' instead of 'excludes'
+// and 'include' instead of 'includes'.
+class MultiGetSourceFilter {
+  exclude?: Fields
+  include?: Fields
 }
 
 class MultiGetOperation {
   can_be_flattened?: boolean
   _id: Id
-  _index: IndexName
-  routing?: string
-  _source?: boolean | SourceFilter
-  stored_fields?: Field[]
+  _index?: IndexName
+  routing?: Routing
+  _source?: boolean | Fields | MultiGetSourceFilter
+  stored_fields?: Fields
+  _type?: TypeName
   version?: long
   version_type?: VersionType
 }

--- a/specification/specs/document/multiple/multi_get/response/MultiGetResponse.ts
+++ b/specification/specs/document/multiple/multi_get/response/MultiGetResponse.ts
@@ -17,19 +17,24 @@
  * under the License.
  */
 
+/**
+ * @type_stability stable
+ */
 @class_serializer('MultiGetResponseFormatter')
 class MultiGetResponse<TDocument> extends ResponseBase {
   docs: MultiGetHit<TDocument>[]
 }
 
 class MultiGetHit<TDocument> {
-  found: boolean
+  error?: MainError
+  fields?: Dictionary<string, LazyDocument>
+  found?: boolean
   _id: string
   _index: string
-  _primary_term: long
-  _routing: string
-  _seq_no: long
-  _source: TDocument
-  _type: string
-  _version: long
+  _primary_term?: long
+  _routing?: Routing
+  _seq_no?: long
+  _source?: TDocument
+  _type?: TypeName
+  _version?: long
 }


### PR DESCRIPTION
Wasn't sure about `MultiGetSourceFilter` but `mget` seems to use slightly different attributes for it's source filtering unfortunately?