### PR TITLE
Add linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,30 @@
+name: Linter
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
+    - name: Install
+      run: |
+        npm install --prefix specification
+        npm install --prefix typescript-generator
+
+    - name: Lint specification
+      run: |
+        npm run lint --prefix specification
+
+    - name: Lint typescript-generator
+      run: |
+        npm run lint --prefix typescript-generator
+

--- a/specification/package-lock.json
+++ b/specification/package-lock.json
@@ -43,6 +43,32 @@
         }
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
+      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -73,6 +99,12 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/lodash": {
@@ -171,6 +203,42 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -195,10 +263,52 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-includes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
+      "integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "get-intrinsic": "^1.0.1",
+        "is-string": "^1.0.5"
+      }
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "array.prototype.flat": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
+      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
     "balanced-match": {
@@ -241,6 +351,73 @@
       "resolved": "https://registry.npmjs.org/byots/-/byots-4.1.0-dev.20201102.16.32.tgz",
       "integrity": "sha512-W8IrnBgfWpP3tFxlTeYMjokY8mnOXKWQOR52OiXIXwVI4BpqN74rWi41sESIDuMRoktYqnChFhY7NzTo+aczFw=="
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -267,11 +444,28 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
     },
     "debug": {
       "version": "4.3.1",
@@ -280,6 +474,21 @@
       "dev": true,
       "requires": {
         "ms": "2.1.2"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
       }
     },
     "diff": {
@@ -297,10 +506,335 @@
         "path-type": "^4.0.0"
       }
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.18.0-next.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.9.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.3",
+        "string.prototype.trimstart": "^1.0.3"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.18.0.tgz",
+      "integrity": "sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.3.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^6.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.4",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-standard": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.2.tgz",
+      "integrity": "sha512-fx3f1rJDsl9bY7qzyX8SAtP8GBSk6MfXFaTfaGgk12aAYW4gJSyRm7dM790L6cbXv63fvjY4XeSzXnb4WM+SKw==",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-10.0.0.tgz",
+      "integrity": "sha512-hLeA2f5e06W1xyr/93/QJulN/rLbUVUmqTlexv9PRKHFwEC9ffJcH2LvJhMoEqYQBEYafedgGZXH2W8NUpt5lA==",
+      "dev": true
+    },
+    "eslint-config-standard-with-typescript": {
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-19.0.1.tgz",
+      "integrity": "sha512-hAKj81+f4a+9lnvpHwZ4XSL672CbwSe5UJ7fTdL/RsQdqs4IjHudMETZuNQwwU7NlYpBTF9se7FRf5Pp7CVdag==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "^4.0.0",
+        "eslint-config-standard": "^14.1.1"
+      },
+      "dependencies": {
+        "eslint-config-standard": {
+          "version": "14.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
+          "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",
+      "integrity": "sha512-p30tuX3VS+NWv9nQot9xIGAHBXR0+xJVaZriEsHoJrASGCJZDJ8JLNM0YqKqI0AKm6Uxaa1VUHoNEibxRCMQHA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flatmap": "^1.2.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "object.entries": "^1.1.2",
+        "object.fromentries": "^2.0.2",
+        "object.values": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.18.1",
+        "string.prototype.matchall": "^4.0.2"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
+    "eslint-plugin-standard": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
+      "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
       "dev": true
     },
     "eslint-scope": {
@@ -336,11 +870,47 @@
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
+    "espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
     },
     "esrecurse": {
       "version": "4.3.0",
@@ -365,6 +935,18 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "fast-glob": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
@@ -379,6 +961,18 @@
         "picomatch": "^2.2.1"
       }
     },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
     "fastq": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
@@ -386,6 +980,15 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
+      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
       }
     },
     "fill-range": {
@@ -396,6 +999,31 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -412,6 +1040,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
+      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true
     },
     "glob": {
@@ -436,6 +1081,15 @@
         "is-glob": "^4.0.1"
       }
     },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
     "globby": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
@@ -449,6 +1103,12 @@
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
     },
     "has": {
       "version": "1.0.3",
@@ -465,10 +1125,38 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
+    },
     "ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflight": {
@@ -485,6 +1173,29 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "dev": true
+    },
     "is-core-module": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
@@ -494,10 +1205,22 @@
         "has": "^1.0.3"
       }
     },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-glob": {
@@ -509,10 +1232,52 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "js-tokens": {
@@ -531,10 +1296,88 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
+      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.2",
+        "object.assign": "^4.1.2"
+      }
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -596,6 +1439,98 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.3.tgz",
+      "integrity": "sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.values": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
+      "integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has": "^1.0.3"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -604,10 +1539,78 @@
         "wrappy": "1"
       }
     },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -627,16 +1630,204 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
     "prettier": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "resolve": {
@@ -649,11 +1840,26 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "run-parallel": {
       "version": "1.1.10",
@@ -670,11 +1876,74 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -692,10 +1961,121 @@
         "source-map": "^0.6.0"
       }
     },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "standard-engine": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-14.0.1.tgz",
+      "integrity": "sha512-7FEzDwmHDOGva7r9ifOzD3BGdTbA7ujJ50afLVdW/tK14zQEptJjbFuUfn50irqdHDcTbNh0DTIoMPynMCXb0Q==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.5",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz",
+      "integrity": "sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has-symbols": "^1.0.1",
+        "internal-slot": "^1.0.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "supports-color": {
@@ -706,6 +2086,44 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "table": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
+      "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^7.0.2",
+        "lodash": "^4.17.20",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
+          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -728,6 +2146,40 @@
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.17",
         "yn": "3.1.1"
+      }
+    },
+    "ts-standard": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/ts-standard/-/ts-standard-10.0.0.tgz",
+      "integrity": "sha512-Svy9HscRHqFV5Q3BwnkE6tv+njyZQSSFyuofhmPdut8jbaIARzaIdtCdPdnyQSvgv5kjO8i4Z0VdOJ4d+ZF6WQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/eslint-plugin": "^4.8.2",
+        "eslint": "^7.14.0",
+        "eslint-config-standard": "^16.0.2",
+        "eslint-config-standard-jsx": "^10.0.0",
+        "eslint-config-standard-with-typescript": "^19.0.1",
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^4.2.1",
+        "eslint-plugin-react": "^7.21.5",
+        "eslint-plugin-standard": "4.1.0",
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.5",
+        "pkg-conf": "^3.1.0",
+        "standard-engine": "^14.0.1"
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "tslib": {
@@ -794,16 +2246,77 @@
         "tslib": "^1.8.1"
       }
     },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
     "typescript": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",

--- a/specification/package.json
+++ b/specification/package.json
@@ -4,6 +4,8 @@
   "description": "A library that exposes the elasticsearch client specification as a validatable and iteratable source",
   "main": "src/api-specification.js",
   "scripts": {
+    "lint": "ts-standard",
+    "lint:fix": "ts-standard --fix",
     "format:check": "prettier --check specs/",
     "format:fix": "prettier --write specs/",
     "start": "ts-node src/main.ts",
@@ -21,6 +23,7 @@
     "@typescript-eslint/parser": "^4.14.0",
     "prettier": "2.2.1",
     "ts-node": "^9.1.1",
+    "ts-standard": "^10.0.0",
     "tslint": "^6.1.2",
     "typescript": "^4.1.3"
   },
@@ -31,5 +34,12 @@
   },
   "engines": {
     "node": ">=14"
+  },
+  "ts-standard": {
+    "ignore": [
+      "lib/",
+      "build/",
+      "specs/"
+    ]
   }
 }

--- a/specification/src/api-specification.ts
+++ b/specification/src/api-specification.ts
@@ -5,19 +5,19 @@ import { RestSpecMapping } from './specification/rest-spec-mapping'
 import _ from 'lodash'
 import * as glob from 'glob'
 import * as ts from 'byots'
-import Domain = require('./domain');
+import Domain = require('./domain')
 
-export type TypeDictionary = { [p: string]: Domain.TypeDeclaration };
+export interface TypeDictionary { [p: string]: Domain.TypeDeclaration }
 export class Specification {
-  private specsFolder = path.join(__dirname, '..', 'specs');
-  private configPath = path.join(this.specsFolder, 'tsconfig.json');
-  private readonly program: ts.Program;
+  private readonly specsFolder = path.join(__dirname, '..', 'specs')
+  private readonly configPath = path.join(this.specsFolder, 'tsconfig.json')
+  private readonly program: ts.Program
 
-  types: Domain.TypeDeclaration[] = [];
-  typeLookup: TypeDictionary = {};
-  domain_errors: string[] = [];
-  endpoints: Domain.Endpoint[] = [];
-  endpoint_errors: string[] = [];
+  types: Domain.TypeDeclaration[] = []
+  typeLookup: TypeDictionary = {}
+  domain_errors: string[] = []
+  endpoints: Domain.Endpoint[] = []
+  endpoint_errors: string[] = []
 
   private constructor (validate: boolean) {
     const config = ts.readConfigFile(this.configPath, file => ts.sys.readFile(file))
@@ -34,13 +34,13 @@ export class Specification {
       }
     }
 
-    const knownBehaviors = ["AdditionalProperties", 'ArrayResponse', 'EmptyResponseBase']
+    const knownBehaviors = ['AdditionalProperties', 'ArrayResponse', 'EmptyResponseBase']
     const specVisitor = new TypeReader(this.program)
-    const types = [].concat(specVisitor.interfaces).concat(specVisitor.enums)
+    const types = specVisitor.interfaces.concat(specVisitor.enums)
     // resolve inherits by creating the proper pointers to instances, pretty hairy but it works
     const dictTypes = types.reduce((o, p) => ({ ...o, [p.name]: p }), {}) as TypeDictionary
     const stringType = new Domain.Interface('string', 'internal')
-    const lookup = (key: string) => key === 'string' ? stringType : (dictTypes[key] as Domain.Interface)
+    const lookup = (key: string): Domain.Interface => key === 'string' ? stringType : (dictTypes[key] as Domain.Interface)
     types.forEach(t => {
       if (!(t instanceof Domain.Interface)) return
       t.inherits = []
@@ -57,18 +57,18 @@ export class Specification {
         const refType = lookup(key)
         const unresolved = t.implementsFromUnresolved[key]
         const ref = new Domain.ImplementsReference(refType, unresolved.depth)
-        ref.closedGenerics = unresolved.instanceOf;
-        const isBehavior = !!ref.type.generatorHints.behavior;
+        ref.closedGenerics = unresolved.instanceOf
+        const isBehavior = Boolean(ref.type.generatorHints.behavior)
         if (ref.depth === 0 && !isBehavior) t.implements.push(ref)
         else if (ref.depth === 0 && isBehavior) t.behaviors.push(ref)
         if (isBehavior) {
           if (!knownBehaviors.includes(ref.type.name)) {
             throw new Error(`${ref.type.name} is not a known behavior, please include it here`)
-          }
-          else t.attachedBehaviors.push(ref.type.name)
+          } else t.attachedBehaviors.push(ref.type.name)
         }
       }
     })
+
     this.types = types
     this.typeLookup = dictTypes
 
@@ -76,19 +76,18 @@ export class Specification {
     this.endpoints = endpointReader.endpoints
   }
 
-  static load = () => new Specification(false);
-  static loadWithValidation = () => new Specification(true);
+  static load = (): Specification => new Specification(false)
+  static loadWithValidation = (): Specification => new Specification(true)
 }
 
 export class EndpointReader {
-  endpoints: Domain.Endpoint[];
+  endpoints: Domain.Endpoint[]
 
   constructor (types: Domain.TypeDeclaration[], restSpecMapping: { [p: string]: RestSpecMapping }) {
     this.endpoints = _(glob.sync(path.join(__dirname, '..', 'specs', '_json_spec', '*.json')))
-      .filter(f => !f.match(/tsconfig/))
-      .filter(f => !f.match(/tslint/))
+      .filter(f => f.match(/tsconfig/) == null)
+      .filter(f => f.match(/tslint/) == null)
       .map(f => new Domain.Endpoint(f, restSpecMapping))
-      // @ts-ignore
       .value()
   }
 }

--- a/specification/src/domain.ts
+++ b/specification/src/domain.ts
@@ -1,88 +1,88 @@
+/* eslint-disable @typescript-eslint/no-extraneous-class, @typescript-eslint/no-namespace */
+
 import { RestSpecMapping } from './specification/rest-spec-mapping'
 import _ from 'lodash'
-import ts from 'byots/bin/typescript'
 
 namespace Domain {
-
   export class Type {
     name: string
-    required: boolean;
-    closedGenerics: InstanceOf[] = [];
+    required: boolean
+    closedGenerics: InstanceOf[] = []
     constructor (name: string) {
       this.name = name
     }
   }
   export class ArrayOf {
-    type = new Type('array');
-    of: InstanceOf;
+    type = new Type('array')
+    of: InstanceOf
   }
   export class Dictionary {
-    type = new Type('dictionary');
-    key: InstanceOf;
-    value: InstanceOf;
+    type = new Type('dictionary')
+    key: InstanceOf
+    value: InstanceOf
   }
 
   export class SingleKeyDictionary {
-    type = new Type('singlekeydictionary');
-    value: InstanceOf;
+    type = new Type('singlekeydictionary')
+    value: InstanceOf
   }
   export class UnionOf {
-    type = new Type('union');
-    items: InstanceOf[] = [];
+    type = new Type('union')
+    items: InstanceOf[] = []
   }
   export class UserDefinedValue {
-    type = new Type('userdefinedvalue');
+    type = new Type('userdefinedvalue')
   }
-  export type InstanceOf = Type|ArrayOf|Dictionary|UnionOf|SingleKeyDictionary|UserDefinedValue;
+  export type InstanceOf = Type|ArrayOf|Dictionary|UnionOf|SingleKeyDictionary|UserDefinedValue
 
   export class GeneratorDocumentation {
     constructor (description: string, keyValues: Record<string, string>) {
       this.description = description
-      this.annotations = keyValues || {}
+      this.annotations = keyValues ?? {}
 
       this.alternateName = this.annotations.alternate_name
       this.customSerializationRoutine = this.annotations.prop_serializer
       this.behavior = this.annotations.behavior
     }
 
-    annotations: Record<string, string>;
+    annotations: Record<string, string>
 
     /** a textual description of the type or property */
-    description: string;
+    description: string
 
     /** presents a suggestion for an alternate name in case of conflicts */
-    alternateName: string;
+    alternateName: string
 
     /** marks an interface as a trait, holds a description to its purpose */
-    behavior: string;
+    behavior: string
 
     /**
      * The name of the custom serialization routine, in some cases the spec knows there is no 1-1 mapping.
      * This property can be used to generate stubs for manual serialization work
      */
-    customSerializationRoutine: string;
+    customSerializationRoutine: string
   }
 
   export class TypeDeclaration {
     constructor (public name: string, public namespace: string) {}
 
     /** generator hinting, never null */
-    generatorHints: GeneratorDocumentation;
+    generatorHints: GeneratorDocumentation
   }
 
   export class Interface extends TypeDeclaration {
-    properties: InterfaceProperty[] = [];
-    inheritsFromUnresolved: Record<string, InstanceOf[]> = {};
-    implementsFromUnresolved: Record<string, { depth: number, instanceOf: InstanceOf[]}> = {};
-    inherits: Domain.InheritsReference[] = [];
-    implements: Domain.ImplementsReference[] = [];
-    behaviors: Domain.ImplementsReference[] = [];
-    attachedBehaviors: string[];
-    openGenerics: string[];
-    implementsUnion = (): boolean => Object.keys(this.inheritsFromUnresolved).includes('Union');
+    properties: InterfaceProperty[] = []
+    inheritsFromUnresolved: Record<string, InstanceOf[]> = {}
+    implementsFromUnresolved: Record<string, { depth: number, instanceOf: InstanceOf[]}> = {}
+    inherits: Domain.InheritsReference[] = []
+    implements: Domain.ImplementsReference[] = []
+    behaviors: Domain.ImplementsReference[] = []
+    attachedBehaviors: string[]
+    openGenerics: string[]
+    implementsUnion = (): boolean => Object.keys(this.inheritsFromUnresolved).includes('Union')
   }
   export class UnionAlias extends TypeDeclaration {
-    wraps: Domain.UnionOf;
+    wraps: Domain.UnionOf
   }
   export class StringAlias extends TypeDeclaration {
 
@@ -92,20 +92,21 @@ namespace Domain {
   }
 
   export class RequestInterface extends Interface {
-    body: InstanceOf | InterfaceProperty[];
-    queryParameters: InterfaceProperty[];
-    path: InterfaceProperty[] = [];
+    body: InstanceOf | InterfaceProperty[]
+    queryParameters: InterfaceProperty[]
+    path: InterfaceProperty[] = []
   }
 
   export class InheritsReference {
     constructor (public type: Domain.Interface) {}
-    closedGenerics: Domain.InstanceOf[];
+    closedGenerics: Domain.InstanceOf[]
   }
   export class ImplementsReference extends InheritsReference {
-    constructor (public type: Domain.Interface, public depth:number = 0) {
+    constructor (public type: Domain.Interface, public depth: number = 0) {
       super(type)
     }
-    closedGenerics: Domain.InstanceOf[];
+
+    closedGenerics: Domain.InstanceOf[]
   }
 
   export class InterfaceProperty {
@@ -114,7 +115,7 @@ namespace Domain {
     required: boolean
     kind: string
     /** generator hinting, never null */
-    generatorHints: GeneratorDocumentation;
+    generatorHints: GeneratorDocumentation
     constructor (
       name: string,
       type: InstanceOf,
@@ -146,20 +147,20 @@ namespace Domain {
     constructor (public name: string, public stringRepresentation: string) {}
 
     /** generator hinting, never null */
-    generatorHints: Domain.GeneratorDocumentation;
+    generatorHints: Domain.GeneratorDocumentation
   }
 
   export class BodyDocumentation {
-    description: string;
-    required: boolean;
+    description: string
+    required: boolean
     constructor (data: any) {
       this.description = data.description
-      this.required = !!data.required
+      this.required = Boolean(data.required)
     }
   }
   export class Documentation {
-    description: string;
-    url: string;
+    description: string
+    url: string
     constructor (data: any) {
       this.description = data.description
       this.url = data.url
@@ -168,8 +169,8 @@ namespace Domain {
   export enum Stability { stable, beta, experimental }
 
   export class Deprecation {
-    version: string;
-    description: string;
+    version: string
+    description: string
     constructor (data: any) {
       this.version = data.version
       this.description = data.description
@@ -177,26 +178,26 @@ namespace Domain {
   }
 
   export class Endpoint {
-    name: string;
-    typeMapping: RestSpecMapping;
+    name: string
+    typeMapping: RestSpecMapping
 
-    documentation: Documentation;
-    stability: Stability;
-    body: BodyDocumentation;
-    url: Url;
-    queryStringParameters: QueryStringParameter[] = [];
-    routeParts: RoutePart[] = [];
-    deprecated: Deprecation;
+    documentation: Documentation
+    stability: Stability
+    body: BodyDocumentation
+    url: Url
+    queryStringParameters: QueryStringParameter[] = []
+    routeParts: RoutePart[] = []
+    deprecated: Deprecation
 
     constructor (file: string, restSpecMapping: { [p: string]: RestSpecMapping }) {
-      const json = require(file)
-      // @ts-ignore
+      const json = require(file) // eslint-disable-line
+      // @ts-expect-error
       this.name = _(json).keys().first()
       this.typeMapping = restSpecMapping[this.name]
       const data = json[this.name]
 
       this.documentation = new Documentation(data.documentation)
-      // @ts-ignore
+      // @ts-expect-error
       this.queryStringParameters = _(data.params).map((v, k) => new QueryStringParameter(k, v)).value()
 
       const routeParts = _(data.url.paths).reduce((acc, val) => {
@@ -206,9 +207,9 @@ namespace Domain {
         return acc
       }, {})
       // defines if there are required path parameters
-      let allParts = []
+      let allParts: string[][] = []
       for (const path of data.url.paths) {
-        if (path.parts) {
+        if (path.parts != null) {
           allParts.push(Object.keys(path.parts))
         } else {
           allParts = []
@@ -216,7 +217,7 @@ namespace Domain {
         }
       }
       if (allParts.length > 0) {
-        // @ts-ignore
+        // @ts-expect-error
         intersect(...allParts).forEach(part => {
           routeParts[part].required = true
         })
@@ -225,8 +226,12 @@ namespace Domain {
         this.routeParts.push(new RoutePart(part, routeParts[part]))
       }
 
-      if (data.body) { this.body = new BodyDocumentation(data.body) }
-      if (data.deprecated) { this.deprecated = new Deprecation(data.deprecated) }
+      if (data.body != null) {
+        this.body = new BodyDocumentation(data.body)
+      }
+      if (data.deprecated != null) {
+        this.deprecated = new Deprecation(data.deprecated)
+      }
 
       switch (data.stability) {
         case 'stable': this.stability = Stability.stable; break
@@ -244,24 +249,25 @@ namespace Domain {
     }
   }
   export class UrlPath {
-    path: string;
-    methods: string[];
-    parts: RoutePart[];
-    deprecated: Deprecation;
+    path: string
+    methods: string[]
+    parts: RoutePart[]
+    deprecated: Deprecation
     constructor (data: any) {
       this.path = data.path
       this.methods = data.methods
-      // @ts-ignore
+      // @ts-expect-error
       this.parts = _(data.parts).map((v, k) => new RoutePart(k, v)).value()
-      if (data.deprecated) { this.deprecated = new Deprecation(data.deprecated) }
+      if (data.deprecated != null) {
+        this.deprecated = new Deprecation(data.deprecated)
+      }
     }
   }
 
   export class Url {
-    paths: UrlPath[];
+    paths: UrlPath[]
 
     constructor (data: any) {
-      // @ts-ignore
       this.paths = _(data.paths).map(p => new UrlPath(p)).value()
     }
   }
@@ -271,7 +277,7 @@ namespace Domain {
       if (name === 'routing') return 'Routing'
       const fieldsParams = ['fields', '_source_include', '_source_exclude']
       const isFields = fieldsParams.some(n => n === name) || name.endsWith('_fields')
-      const isField = name.indexOf('field') >= 0
+      const isField = name.includes('field')
       if (isFields || isField) {
         switch (specType) {
           case 'list': return 'Fields'
@@ -280,7 +286,7 @@ namespace Domain {
       }
 
       const doubleFields = ['boost', 'percen', 'score']
-      const isDoubleField = doubleFields.some(n => name.toLowerCase().indexOf(n) >= 0)
+      const isDoubleField = doubleFields.some(n => name.toLowerCase().includes(n))
       switch (specType) {
         case 'boolean': return 'boolean'
         case 'list': return 'string' // todo array of strings should be a string with a comment
@@ -358,34 +364,34 @@ namespace Domain {
   }
 
   export class QueryStringParameter {
-    name: string;
-    type: string;
-    description: string;
-    required: boolean;
-    default: boolean;
+    name: string
+    type: string
+    description: string
+    required: boolean
+    default: boolean
 
     constructor (name: string, data: any) {
       this.name = name
       this.type = RestSpecTypeConverter.toQueryStringType(name, data.type)
-      this.description = data.description || name
-      this.required = !!data.required
-      this.default = data.default || null
+      this.description = data.description ?? name
+      this.required = Boolean(data.required)
+      this.default = data.default ?? null
     }
   }
 
   export class RoutePart {
-    name: string;
-    type: string;
-    description: string;
-    required: boolean;
+    name: string
+    type: string
+    description: string
+    required: boolean
 
     constructor (name: string, data: any) {
       this.name = name
       this.type = RestSpecTypeConverter.toRouteParamType(name, data.type)
-      this.description = data.description || name
-      this.required = !!data.required
+      this.description = data.description ?? name
+      this.required = Boolean(data.required)
     }
   }
 
 }
-export = Domain;
+export = Domain

--- a/specification/src/format.ts
+++ b/specification/src/format.ts
@@ -8,14 +8,14 @@ const response = specification.typeLookup[api.typeMapping.response]
 // const searchResponse = specification.typeLookup[searchAPI.typeMapping.responseQuery];
 // const searchResponse = specification.typeLookup[searchAPI.typeMapping.responsePath];
 // console.log(searchAPI)
-// @ts-ignore
+// @ts-expect-error
 console.log(response)
 // console.log(specification.typeLookup)
 /* console.log()
 console.log(searchRequest)
 console.log()
 console.log(searchResponse) */
-// @ts-ignore
+// @ts-expect-error
 /* for (const prop of searchRequest.properties) {
   console.log(prop)
 } */

--- a/specification/src/main.ts
+++ b/specification/src/main.ts
@@ -15,13 +15,5 @@ The specification contains
   - ${specification.endpoints.length} API Endpoints
   - ${specification.types.length} Types.
 `)
-for (const e of specification.endpoints) {
-  const type = specification.typeLookup[e.typeMapping.request]
-  // if (["IndexRequest", "SearchRequest"].includes(type.name))
-  //  console.log(type);
-}
-for (const t of specification.types) {
-  if (['CompositeBucket'].includes(t.name)) { console.dir(t, {depth: 20} ) }
-}
 
 console.log('Done!')

--- a/specification/src/metamodel.ts
+++ b/specification/src/metamodel.ts
@@ -15,8 +15,8 @@
  *    - object: used to represent "any". We may forbid it at some point. UserDefinedValue should be used for user data.
  */
 export class TypeName {
-  namespace: string;
-  name: string;
+  namespace: string
+  name: string
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -32,41 +32,41 @@ export class TypeName {
 /**
  * Type of a value. Used both for property types and nested type definitions.
  */
-export type ValueOf = InstanceOf | ArrayOf | UnionOf | DictionaryOf | NamedValueOf | UserDefinedValue;
+export type ValueOf = InstanceOf | ArrayOf | UnionOf | DictionaryOf | NamedValueOf | UserDefinedValue
 
 /**
  * A single value
  */
 export class InstanceOf {
-  kind: "instance_of";
-  type: TypeName;
+  kind: 'instance_of'
+  type: TypeName
   /** generic parameters: either concrete types or open parameters from the enclosing type */
-  generics?: ValueOf[];
+  generics?: ValueOf[]
 }
 
 /**
  * An array
  */
 export class ArrayOf {
-  kind: "array_of";
-  value: ValueOf;
+  kind: 'array_of'
+  value: ValueOf
 }
 
 /**
  * One of several possible types which don't necessarily have a common superclass
  */
 export class UnionOf {
-  kind: "union_of";
-  items: ValueOf[];
+  kind: 'union_of'
+  items: ValueOf[]
 }
 
 /**
  * A dictionary (or map)
  */
 export class DictionaryOf {
-  kind: "dictionary_of";
-  key: ValueOf;
-  value: ValueOf;
+  kind: 'dictionary_of'
+  key: ValueOf
+  value: ValueOf
 }
 
 /**
@@ -74,8 +74,8 @@ export class DictionaryOf {
  * associate some value to a field name, e.g. the "sort" field in search.
  */
 export class NamedValueOf {
-  kind: "named_value_of";
-  value: ValueOf;
+  kind: 'named_value_of'
+  value: ValueOf
 }
 
 /**
@@ -89,7 +89,7 @@ export class NamedValueOf {
  * will also require to buffer raw JSON data which may have performance implications.
  */
 export class UserDefinedValue {
-  kind: "user_defined_value";
+  kind: 'user_defined_value'
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -98,51 +98,51 @@ export class UserDefinedValue {
  * An interface or request interface property.
  */
 export class Property {
-  name: string;
-  type: ValueOf;
-  required: boolean;
-  description?: string;
-  annotations?: Record<string, string>;
+  name: string
+  type: ValueOf
+  required: boolean
+  description?: string
+  annotations?: Record<string, string>
 }
 
 // ------------------------------------------------------------------------------------------------
 // Type definitions
 
-export type TypeDefinition = Interface | Request | Union | Enum | TypeAlias;
+export type TypeDefinition = Interface | Request | Union | Enum | TypeAlias
 
 /**
  * Common attributes for all type definitions
  */
 abstract class BaseType {
-  name: TypeName;
-  description?: string;
-  annotations?: Record<string, string>;
+  name: TypeName
+  description?: string
+  annotations?: Record<string, string>
 }
 
 /**
  * Inherits clause (aka extends or implements) for an interface or request
  */
 export class Inherits {
-  type: TypeName;
-  generics?: ValueOf[];
+  type: TypeName
+  generics?: ValueOf[]
 }
 
 export class Implements {
-  type: TypeName;
-  generics?: ValueOf[];
+  type: TypeName
+  generics?: ValueOf[]
 }
 
 /**
  * An interface type
  */
 export class Interface extends BaseType {
-  kind: "interface";
-  generics?: string[];
-  inherits?: Inherits[];
-  implements?: Implements[];
-  behaviors?: Implements[];
-  attachedBehaviors?: string[];
-  properties: Property[];
+  kind: 'interface'
+  generics?: string[]
+  inherits?: Inherits[]
+  implements?: Implements[]
+  behaviors?: Implements[]
+  attachedBehaviors?: string[]
+  properties: Property[]
 }
 
 /**
@@ -150,13 +150,13 @@ export class Interface extends BaseType {
  */
 export class Request extends BaseType {
   // Note: does not extend Interface as properties are split across path, query and body
-  kind: "request";
-  generics?: string[];
-  inherits?: Inherits[];
+  kind: 'request'
+  generics?: string[]
+  inherits?: Inherits[]
   /** URL path properties */
-  path: Property[];
+  path: Property[]
   /** Query string properties */
-  query: Property[];
+  query: Property[]
   // FIXME: we need an annotation that lists query params replaced by a body property so that we can skip them.
   // Examples on _search: sort -> sort, _source -> (_source, _source_include, _source_exclude)
   // Or can we say that implicitly a body property replaces all path params starting with its name?
@@ -168,17 +168,17 @@ export class Request extends BaseType {
    * Body type. In most cases this is just a list of properties, except for a few specific cases like bulk requests
    * (an array of bulk operations) or create requests (a user provided document type).
    */
-  body?: ValueBody | PropertiesBody;
+  body?: ValueBody | PropertiesBody
 }
 
 export class ValueBody {
-  kind: "value";
-  value: ValueOf;
+  kind: 'value'
+  value: ValueOf
 }
 
 export class PropertiesBody {
-  kind: "properties";
-  properties: Property[];
+  kind: 'properties'
+  properties: Property[]
 }
 
 /**
@@ -188,8 +188,8 @@ export class PropertiesBody {
  * a unionOf in a single list of type references.
  */
 export class Union extends BaseType {
-  kind: "union";
-  items: ValueOf[];
+  kind: 'union'
+  items: ValueOf[]
 }
 
 /**
@@ -201,78 +201,78 @@ export class Union extends BaseType {
  */
 export class EnumMember {
   /** The identifier to use for this enum */
-  name: string;
-  description?: string;
+  name: string
+  description?: string
   /** The value to send of the wire. Use `name` if absent */
-  stringValue?: string;
-  annotations?: Record<string, string>;
+  stringValue?: string
+  annotations?: Record<string, string>
 }
 
 /**
  * An enumeration
  */
 export class Enum extends BaseType {
-  kind: "enum";
-  members: EnumMember[];
+  kind: 'enum'
+  members: EnumMember[]
 }
 
 /**
  * An alias for an existing type.
  */
 export class TypeAlias extends BaseType {
-  kind: "type_alias";
+  kind: 'type_alias'
   type: ValueOf
 }
 
 // ------------------------------------------------------------------------------------------------
 
 export enum Stability {
-  stable = "stable",
-  beta = "beta",
-  experimental = "experimental"
+  stable = 'stable',
+  beta = 'beta',
+  experimental = 'experimental'
   // NOTE: do we filter out "private"?
 }
 
 export class Deprecation {
-  version: string;
-  description: string;
+  version: string
+  description: string
 }
 
 export class Endpoint {
-  name: string;
-  description: string;
-  docUrl: string;
-  stability: Stability;
+  name: string
+  description: string
+  docUrl: string
+  stability: Stability
   /**
    * The version when this endpoint reached its current stability level.
    * Missing data means "forever", i.e. before any of the target client versions produced from this spec.
    */
-  since?: string;
+  since?: string
   deprecation: Deprecation
 
   /**
    * If the request value is `null` it means that there is not yet a
    * request type definition for this endpoint.
    */
-  request: TypeName | null;
-  requestBodyRequired: boolean; // Not sure this is useful
+  request: TypeName | null
+  requestBodyRequired: boolean // Not sure this is useful
 
   /**
    * If the response value is `null` it means that there is not yet a
    * response type definition for this endpoint.
    */
-  response: TypeName | null;
+  response: TypeName | null
 
-  urls: UrlTemplate[];
+  urls: UrlTemplate[]
 }
 
 export class UrlTemplate {
-  path: string;
-  methods: string[];
-  deprecation?: Deprecation;
+  path: string
+  methods: string[]
+  deprecation?: Deprecation
 }
 
 export class Model {
-  types: TypeDefinition[];
-  endpoints: Endpoint[];
+  types: TypeDefinition[]
+  endpoints: Endpoint[]
 }

--- a/specification/src/metamodel_generate.ts
+++ b/specification/src/metamodel_generate.ts
@@ -1,11 +1,11 @@
-import {Specification} from "./api-specification";
-import {loadModel} from "./metamodel_reader";
-import fs from "fs";
+import { Specification } from './api-specification'
+import { loadModel } from './metamodel_reader'
+import fs from 'fs'
 
-const spec = Specification.load();
+const spec = Specification.load()
 
-const model = loadModel(spec);
+const model = loadModel(spec)
 
-fs.writeFileSync("../output/schema/schema.json", JSON.stringify(model, null, 2));
+fs.writeFileSync('../output/schema/schema.json', JSON.stringify(model, null, 2))
 
-console.log("Schema generated in ../output/schema/schema.json")
+console.log('Schema generated in ../output/schema/schema.json')

--- a/specification/src/metamodel_reader.ts
+++ b/specification/src/metamodel_reader.ts
@@ -1,6 +1,6 @@
-import Domain from "./domain";
+import Domain from './domain'
 
-import {Specification} from "./api-specification";
+import { Specification } from './api-specification'
 import {
   Endpoint,
   EnumMember,
@@ -16,101 +16,100 @@ import {
   UrlTemplate,
   ValueBody,
   ValueOf
-} from "./metamodel";
+} from './metamodel'
 
-export function loadModel(spec: Specification): Model {
+export function loadModel (spec: Specification): Model {
   const model: Model = {
     types: [],
     endpoints: []
-  };
+  }
 
-  const allTypeDefinitions = new Map<string, TypeDefinition>();
-  const allTypeNames = new Map<string, TypeName>();
-  const autoFixedGenerics = new Set<string>();
+  const allTypeDefinitions = new Map<string, TypeDefinition>()
+  const allTypeNames = new Map<string, TypeName>()
+  const autoFixedGenerics = new Set<string>()
 
-  allTypeNames.set("boolean", { namespace: "internal", name:"boolean" });
-  allTypeNames.set("string", { namespace: "internal", name:"string" });
-  allTypeNames.set("number", { namespace: "internal", name:"number" });
-  allTypeNames.set("null", { namespace: "internal", name:"null" });
-  allTypeNames.set("Array", { namespace: "internal", name:"Array" });
+  allTypeNames.set('boolean', { namespace: 'internal', name: 'boolean' })
+  allTypeNames.set('string', { namespace: 'internal', name: 'string' })
+  allTypeNames.set('number', { namespace: 'internal', name: 'number' })
+  allTypeNames.set('null', { namespace: 'internal', name: 'null' })
+  allTypeNames.set('Array', { namespace: 'internal', name: 'Array' })
 
-  //makeTypeDefinition is viral and updates allTypeDefinitions
+  // makeTypeDefinition is viral and updates allTypeDefinitions
   // here we forcefully include certain types that are orphaned and not linked directly
   // through any of the endpoints
-  makeTypeDefinition("ErrorResponse");
+  makeTypeDefinition('ErrorResponse')
 
   // 'any' is translated to 'object'
-  const objectType: TypeName = { namespace: "internal", name:"object" };
-  allTypeNames.set("object", objectType);
+  const objectType: TypeName = { namespace: 'internal', name: 'object' }
+  allTypeNames.set('object', objectType)
 
   // Make endpoints, this will pull all needed types transitively
-  model.endpoints = spec.endpoints.map(ep => makeEndpoint(ep)).filter(ep => ep);
-  model.types = Array.from(allTypeDefinitions.values());
+  model.endpoints = spec.endpoints.map(ep => makeEndpoint(ep)).filter(ep => ep)
+  model.types = Array.from(allTypeDefinitions.values())
 
   // Sort endpoints and types by name for stable output order
-  model.endpoints.sort((a, b) => a.name.localeCompare(b.name));
+  model.endpoints.sort((a, b) => a.name.localeCompare(b.name))
   model.types.sort((a, b) => {
-    const x = a.name.namespace.localeCompare(b.name.namespace);
-    return x !== 0 ? x : a.name.name.localeCompare(b.name.name);
-  });
+    const x = a.name.namespace.localeCompare(b.name.namespace)
+    return x !== 0 ? x : a.name.name.localeCompare(b.name.name)
+  })
 
-  console.log("Model: " + model.types.length + " types (" + spec.types.length + " in spec)");
-  console.log("Model: " + model.endpoints.length + " endpoints (" + spec.endpoints.length + " in spec)");
+  console.log(`Model: ${model.types.length} types (${spec.types.length} in spec)`)
+  console.log(`Model: ${model.endpoints.length} endpoints (${spec.endpoints.length} in spec)`)
 
-  function makeEndpoint(api: Domain.Endpoint): Endpoint {
-    let request = null
-    let response = null
+  function makeEndpoint (api: Domain.Endpoint): Endpoint {
+    let request: TypeName | TypeDefinition | null = null
+    let response: TypeName | TypeDefinition | null = null
 
-    if (api.typeMapping && spec.typeLookup[api.typeMapping.request]) {
+    if (api.typeMapping != null && spec.typeLookup[api.typeMapping.request] != null) {
       // Move endpoint docs to the request definition
-      request = makeTypeDefinition(api.typeMapping.request) as Request;
-      if (!request.description || request.description.length === 0) {
-        request.description = nonEmpty(api.body && api.body.description);
+      request = makeTypeDefinition(api.typeMapping.request) as Request
+      if (request.description == null || request.description.length === 0) {
+        request.description = nonEmpty(api.body?.description)
       }
 
       request.path.forEach(prop => {
-        if (prop.description && prop.description.length > 0) return; // already has some docs
-        outer: for (const path of api.url.paths) {
+        if (prop.description != null && prop.description.length > 0) return // already has some docs
+        for (const path of api.url.paths) {
           for (const part of path.parts) {
             if (part.name === prop.name) {
-              prop.description = nonEmpty(part.description);
-              break outer;
+              prop.description = nonEmpty(part.description)
+              return
             }
           }
         }
-      });
+      })
 
       request.query.forEach(prop => {
-        if (prop.description && prop.description.length > 0) return; // already has some docs
+        if (prop.description != null && prop.description.length > 0) return // already has some docs
         for (const param of api.queryStringParameters) {
           if (param.name === prop.name) {
-            prop.description = nonEmpty(param.description);
-            break;
+            prop.description = nonEmpty(param.description)
+            break
           }
         }
-      });
+      })
 
       request = request.name
     } else {
       console.log(`Request type for endpoint ${api.name} not found`)
     }
 
-    if (api.typeMapping && spec.typeLookup[api.typeMapping.response]) {
+    if (api.typeMapping != null && spec.typeLookup[api.typeMapping.response] != null) {
       response = makeTypeDefinition(api.typeMapping.response).name
     } else {
       console.log(`Response type for endpoint ${api.name} not found`)
     }
 
-
     return {
       name: api.name,
-      description: nonEmpty(api.documentation.description),
+      description: nonEmpty(api.documentation.description) ?? '',
       docUrl: api.documentation.url,
       stability: makeStability(api.stability),
       deprecation: api.deprecated,
 
       request,
-      requestBodyRequired: !!api.body && api.body.required,
+      requestBodyRequired: !!api.body?.required,
 
       response,
 
@@ -118,30 +117,30 @@ export function loadModel(spec: Specification): Model {
     }
   }
 
-  function makeStability(s: Domain.Stability): Stability {
+  function makeStability (s: Domain.Stability): Stability {
     switch (s) {
-      case Domain.Stability.stable: return Stability.stable;
-      case Domain.Stability.beta: return Stability.beta;
-      case Domain.Stability.experimental: return Stability.experimental;
+      case Domain.Stability.stable: return Stability.stable
+      case Domain.Stability.beta: return Stability.beta
+      case Domain.Stability.experimental: return Stability.experimental
     }
   }
 
-  function makeTypeDefinition(name: string): TypeDefinition {
-    const cached = allTypeDefinitions.get(name);
-    if (cached) return cached;
+  function makeTypeDefinition (name: string): TypeDefinition {
+    const cached = allTypeDefinitions.get(name)
+    if (cached != null) return cached
 
-    function store(t: TypeDefinition): TypeDefinition {
-      allTypeDefinitions.set(name, t);
-      return t;
+    function store (t: TypeDefinition): TypeDefinition {
+      allTypeDefinitions.set(name, t)
+      return t
     }
 
-    const fullName = makeTypeName(name, []);
-    const specType = spec.typeLookup[name]; // existence checked in makeTypeName
+    const fullName = makeTypeName(name, [])
+    const specType = spec.typeLookup[name] // existence checked in makeTypeName
 
     if (specType instanceof Domain.Enum) {
       // "Enum.flags" doesn't seem to be used and is ignored
       return store({
-        kind: "enum",
+        kind: 'enum',
         name: fullName,
         description: makeDescription(specType),
         annotations: makeAnnotations(specType),
@@ -149,42 +148,40 @@ export function loadModel(spec: Specification): Model {
           // Remove "alternate_name" from annotations, it's provided in "stringRepresentation"
           // Only incarnation up to now is common_options/date_math/DateMathTimeUnit - ideally we should update
           // the spec to use TypeScript string enumerations.
-          const annotations = m.generatorHints && m.generatorHints.annotations || {};
-          delete annotations.alternate_name;
+          const annotations = m.generatorHints?.annotations ?? {}
+          delete annotations.alternate_name
 
           const r: EnumMember = {
             name: m.name,
-            description: nonEmpty(m.generatorHints && m.generatorHints.description),
+            description: nonEmpty(m.generatorHints?.description),
             annotations: nonEmptyObj(annotations)
-          };
-
-          if (m.stringRepresentation !== m.name) {
-            r.stringValue = m.stringRepresentation;
           }
 
-          return r;
-        })
-      });
-    }
+          if (m.stringRepresentation !== m.name) {
+            r.stringValue = m.stringRepresentation
+          }
 
-    else if (specType instanceof Domain.RequestInterface) {
-      let body: ValueBody | PropertiesBody;
-      if (!specType.body) {
-        body = undefined;
-      } else if (specType.body instanceof Array) {
+          return r
+        })
+      })
+    } else if (specType instanceof Domain.RequestInterface) {
+      let body: ValueBody | PropertiesBody | undefined
+      if (specType.body == null) {
+        body = undefined
+      } else if (Array.isArray(specType.body)) {
         body = {
-          kind: "properties",
+          kind: 'properties',
           properties: specType.body.map(prop => makeProperty(prop, specType.openGenerics))
         }
       } else {
         body = {
-          kind: "value",
-          value: specType.body && makeInstanceOf(specType.body, specType.openGenerics)
-        };
+          kind: 'value',
+          value: makeInstanceOf(specType.body, specType.openGenerics)
+        }
       }
 
       return store({
-        kind: "request",
+        kind: 'request',
         name: fullName,
         description: makeDescription(specType),
         annotations: makeAnnotations(specType),
@@ -193,50 +190,42 @@ export function loadModel(spec: Specification): Model {
         path: specType.path.map(prop => makeProperty(prop, specType.openGenerics)),
         query: specType.queryParameters.map(prop => makeProperty(prop, specType.openGenerics)),
         body: body
-      });
-    }
-
-    else if (specType instanceof Domain.UnionAlias) {
+      })
+    } else if (specType instanceof Domain.UnionAlias) {
       return store({
-        kind: "union",
+        kind: 'union',
         name: fullName,
         description: makeDescription(specType),
         annotations: makeAnnotations(specType),
         items: specType.wraps.items.map(item => makeInstanceOf(item, []))
-      });
-    }
-
-    else if (specType instanceof Domain.StringAlias) {
+      })
+    } else if (specType instanceof Domain.StringAlias) {
       // It's just an alias to the internal string type
       return store({
-        kind: "type_alias",
+        kind: 'type_alias',
         name: fullName,
         description: makeDescription(specType),
         annotations: makeAnnotations(specType),
         type: {
-          kind: "instance_of",
-          type: { namespace: "internal", name: "string" }
+          kind: 'instance_of',
+          type: { namespace: 'internal', name: 'string' }
         }
-      });
-    }
-
-    else if (specType instanceof Domain.NumberAlias) {
+      })
+    } else if (specType instanceof Domain.NumberAlias) {
       // It's just an alias to the internal number type
       return store({
-        kind: "type_alias",
+        kind: 'type_alias',
         name: fullName,
         description: makeDescription(specType),
         annotations: makeAnnotations(specType),
         type: {
-          kind: "instance_of",
-          type: { namespace: "internal", name: "number" }
+          kind: 'instance_of',
+          type: { namespace: 'internal', name: 'number' }
         }
-      });
-    }
-
-    else if (specType instanceof Domain.Interface) {
+      })
+    } else if (specType instanceof Domain.Interface) {
       return store({
-        kind: "interface",
+        kind: 'interface',
         name: fullName,
         generics: nonEmptyArr(specType.openGenerics),
         inherits: nonEmptyArr(specType.inherits.map(impl => makeInherits(impl, specType.openGenerics))),
@@ -244,170 +233,151 @@ export function loadModel(spec: Specification): Model {
         behaviors: nonEmptyArr(specType.behaviors.map(impl => makeImplements(impl, specType.openGenerics))),
         attachedBehaviors: nonEmptyArr(specType.attachedBehaviors),
         properties: specType.properties.map(prop => makeProperty(prop, specType.openGenerics))
-      });
-    }
-
-    else {
-      throw Error("Unknown type " + typeof (specType))
+      })
+    } else {
+      throw Error('Unknown type ' + typeof (specType))
     }
   }
 
-  function makeImplements(impl: Domain.ImplementsReference, openGenerics: string[]): Implements {
-
-    const type = makeTypeName(impl.type.name, openGenerics);
+  function makeImplements (impl: Domain.ImplementsReference, openGenerics: string[]): Implements {
+    const type = makeTypeName(impl.type.name, openGenerics)
 
     return {
       type: type,
       generics: nonEmptyArr(impl.closedGenerics.map(i => makeInstanceOf(i, openGenerics)))
-    };
+    }
   }
 
-  function makeInherits(impl: Domain.InheritsReference, openGenerics: string[]): Inherits {
-
+  function makeInherits (impl: Domain.InheritsReference, openGenerics: string[]): Inherits {
     // Autofix requests and responses that have self-reference generic parameters
     if (impl.closedGenerics.length > 0 && impl.type.openGenerics.length === 0) {
       if (!autoFixedGenerics.has(impl.type.name)) {
-        console.log("Auto fixing implements generic parameters for " + impl.type.name);
-        autoFixedGenerics.add(impl.type.name);
+        console.log('Auto fixing implements generic parameters for ' + impl.type.name)
+        autoFixedGenerics.add(impl.type.name)
       }
-      impl.closedGenerics = [];
+      impl.closedGenerics = []
     }
 
-    const type = makeTypeName(impl.type.name, openGenerics);
+    const type = makeTypeName(impl.type.name, openGenerics)
 
     return {
       type: type,
       generics: nonEmptyArr(impl.closedGenerics.map(i => makeInstanceOf(i, openGenerics)))
-    };
+    }
   }
 
-  function makeInstanceOf(inst: Domain.InstanceOf, openGenerics: string[]): ValueOf {
-
+  function makeInstanceOf (inst: Domain.InstanceOf, openGenerics: string[]): ValueOf {
     if (inst instanceof Domain.Type) {
       return {
-        kind: "instance_of",
+        kind: 'instance_of',
         type: makeTypeName(inst.name, openGenerics),
         generics: nonEmptyArr(inst.closedGenerics.map(g => makeInstanceOf(g, openGenerics)))
-      };
-    }
-
-    else if (inst instanceof Domain.ArrayOf) {
+      }
+    } else if (inst instanceof Domain.ArrayOf) {
       return {
-        kind: "array_of",
+        kind: 'array_of',
         value: makeInstanceOf(inst.of, openGenerics)
-      };
-    }
-
-    else if (inst instanceof Domain.UnionOf) {
+      }
+    } else if (inst instanceof Domain.UnionOf) {
       return {
-        kind: "union_of",
+        kind: 'union_of',
         items: inst.items.map(i => makeInstanceOf(i, openGenerics))
-      };
-    }
-
-    else if (inst instanceof Domain.Dictionary) {
+      }
+    } else if (inst instanceof Domain.Dictionary) {
       return {
-        kind: "dictionary_of",
+        kind: 'dictionary_of',
         key: makeInstanceOf(inst.key, openGenerics),
         value: makeInstanceOf(inst.value, openGenerics)
-      };
-    }
-
-    else if (inst instanceof Domain.SingleKeyDictionary) {
+      }
+    } else if (inst instanceof Domain.SingleKeyDictionary) {
       return {
-        kind: "named_value_of",
+        kind: 'named_value_of',
         value: makeInstanceOf(inst.value, openGenerics)
-      };
-    }
-
-    else if (inst instanceof Domain.UserDefinedValue) {
+      }
+    } else if (inst instanceof Domain.UserDefinedValue) {
       return {
-        kind: "user_defined_value"
-      };
-    }
-
-    else {
-      throw Error("Unnkown instance kind: " + typeof inst);
+        kind: 'user_defined_value'
+      }
+    } else {
+      throw Error('Unnkown instance kind: ' + typeof inst)
     }
   }
 
-  function makeProperty(prop: Domain.InterfaceProperty, openGenerics: string[]): Property {
+  function makeProperty (prop: Domain.InterfaceProperty, openGenerics: string[]): Property {
     return {
       name: prop.name,
       type: makeInstanceOf(prop.type, openGenerics),
       required: prop.required,
-      description: nonEmpty(prop.generatorHints && prop.generatorHints.description),
-      annotations: nonEmptyObj(prop.generatorHints && prop.generatorHints.annotations)
-    };
+      description: nonEmpty(prop.generatorHints?.description),
+      annotations: nonEmptyObj(prop.generatorHints?.annotations)
+    }
   }
 
-  function makeTypeName(name: string, openGenerics: string[]): TypeName {
-    const cached = allTypeNames.get(name);
-    if (cached) return cached;
+  function makeTypeName (name: string, openGenerics: string[]): TypeName {
+    const cached = allTypeNames.get(name)
+    if (cached != null) return cached
 
     if (openGenerics.includes(name)) {
       // Open generics have precedence
-      return { namespace: "generic", name: name };
+      return { namespace: 'generic', name: name }
     }
 
-    const t = spec.typeLookup[name];
-    if (!t) {
-      // console.log("Type " + name + " was not found");
-      // return { name: name, namespace: "unknown"};
-      throw Error("Type " + name + " was not found");
+    const t = spec.typeLookup[name]
+    if (t == null) {
+      throw Error(`Type ${name} was not found`)
     }
 
-    const r = { namespace: t.namespace, name: t.name };
-    allTypeNames.set(name, r);
+    const r = { namespace: t.namespace, name: t.name }
+    allTypeNames.set(name, r)
 
     // Make sure the type has been defined
-    makeTypeDefinition(name);
+    makeTypeDefinition(name)
 
-    return r;
+    return r
   }
 
-  function makeUrlTemplates(url: Domain.Url): UrlTemplate[] {
+  function makeUrlTemplates (url: Domain.Url): UrlTemplate[] {
     return url.paths.map(path => {
       const t: UrlTemplate = {
         path: path.path,
         methods: path.methods,
         deprecation: path.deprecated
       }
-      return t;
+      return t
     })
   }
 
-  function makeDescription(specType: Domain.TypeDeclaration) {
-    return nonEmpty(specType.generatorHints && specType.generatorHints.description);
+  function makeDescription (specType: Domain.TypeDeclaration): string | undefined {
+    return nonEmpty(specType.generatorHints?.description)
   }
 
-  function makeAnnotations(specType: Domain.TypeDeclaration) {
-    return nonEmptyObj(specType.generatorHints && specType.generatorHints.annotations);
+  function makeAnnotations (specType: Domain.TypeDeclaration): Record<string, any> | undefined {
+    return nonEmptyObj(specType.generatorHints?.annotations)
   }
 
-  function nonEmpty(str: string): string {
-    if (!str || str.length === 0) {
-      return undefined;
-    } else {
-      return str;
-    }
-  }
-
-  function nonEmptyArr<T>(arr: T[]): T[] {
-    if (!arr || arr.length === 0) {
-      return undefined;
-    } else {
-      return arr;
-    }
-  }
-
-  function nonEmptyObj<T>(obj: T): T {
-    if (!obj || Object.keys(obj).length === 0) {
+  function nonEmpty (str: string | undefined): string | undefined {
+    if (str == null || str.length === 0) {
       return undefined
     } else {
-      return obj;
+      return str
     }
   }
 
-  return model;
+  function nonEmptyArr<T> (arr: T[] | undefined): T[] | undefined {
+    if (arr == null || arr.length === 0) {
+      return undefined
+    } else {
+      return arr
+    }
+  }
+
+  function nonEmptyObj (obj: Record<string, any> | undefined): Record<string, any> | undefined {
+    if (obj == null || Object.keys(obj).length === 0) {
+      return undefined
+    } else {
+      return obj
+    }
+  }
+
+  return model
 }

--- a/specification/src/specification/rest-spec-mapping.ts
+++ b/specification/src/specification/rest-spec-mapping.ts
@@ -1,5 +1,5 @@
-export type TypeName = string;
-export type RestSpecName = string;
+export type TypeName = string
+export type RestSpecName = string
 export class RestSpecMapping {
   constructor (public spec: RestSpecName, public request: TypeName, public response: TypeName) {}
 }

--- a/specification/src/specification/validator.ts
+++ b/specification/src/specification/validator.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-extraneous-class */
+
 import * as ts from 'byots'
 
 export class SpecValidator {
@@ -9,11 +11,11 @@ export class SpecValidator {
     for (const d of allDiagnostics) {
       const message = ts.flattenDiagnosticMessageText(d.messageText, '\n')
       if (d.file == null) {
-        errors.push('<global> ' + message)
+        errors.push(`<global> ${message}`)
         continue
       }
-      const { line, character } = d.file.getLineAndCharacterOfPosition(d.start)
-      const error = d.file.fileName + ' ' + line + 1 + ',' + character + 1 + ':' + message
+      const { line, character } = d.file.getLineAndCharacterOfPosition(d.start as number)
+      const error = `${d.file.fileName} ${line + 1},${character + 1}:${message}`
       errors.push(error)
     }
     return errors

--- a/specification/tsconfig.json
+++ b/specification/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "lib/src",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "strictNullChecks": true,
     "declaration": true,
     "noImplicitAny": false,
     "removeComments": true,

--- a/typescript-generator/package.json
+++ b/typescript-generator/package.json
@@ -6,12 +6,17 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "standard",
+    "lint:fix": "standard --fix",
+    "test": "npm run lint"
   },
   "engines": {
     "node": ">=14"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "standard": "^16.0.3"
+  }
 }


### PR DESCRIPTION
This pr adds a linter, [standard](https://github.com/standard/standard) to the typescript generator and [ts-standard](https://github.com/standard/ts-standard) to the compiler, in an effort to improving the code quality and resilience.

Standard is a well known linter in the js community and other than fixing the code style, it also contains a series of gotchas to avoid falling in "brittle code" situations.
The linter will be executed as CI step as well.

This pr is the first step towards refactoring of the compiler.