### PR TITLE
Make targets for contrib & check-license

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ generate-spec:	  ## Generate the output spec
 	@npm run compile:canonical-json
 	@npm run compile:ts-validation
 
+check-license:	## Add the license headers to the files
+	@echo ">> checking license headers .."
+	.github/check-license-headers.sh
+
+contrib: | check-license format-code generate-spec	## Pre contribution target
+
 help:  ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 #------------- <https://suva.sh/posts/well-documented-makefiles> --------------


### PR DESCRIPTION
* `check-license` target that locally verifies the presence of license headers
* `contrib` target that runs all pre contribution tasks: `check-license`, `format-code` and `generate-spec`