### PR TITLE
 Check Response class existence

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -6082,10 +6082,7 @@
         "namespace": "search.multi_search_template"
       },
       "requestBodyRequired": true,
-      "response": {
-        "name": "MultiSearchTemplateResponse",
-        "namespace": "search.multi_search_template"
-      },
+      "response": null,
       "stability": "stable",
       "urls": [
         {
@@ -6938,10 +6935,7 @@
         "namespace": "search.search_template"
       },
       "requestBodyRequired": true,
-      "response": {
-        "name": "SearchTemplateResponse",
-        "namespace": "search.search_template"
-      },
+      "response": null,
       "stability": "stable",
       "urls": [
         {
@@ -8720,10 +8714,7 @@
         "namespace": "document.multiple.update_by_query_rethrottle"
       },
       "requestBodyRequired": false,
-      "response": {
-        "name": "UpdateByQueryRethrottleResponse",
-        "namespace": "document.multiple.update_by_query_rethrottle"
-      },
+      "response": null,
       "stability": "stable",
       "urls": [
         {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "elasticsearch-client-specification",
   "version": "0.0.1",
   "description": "A library that exposes the elasticsearch client specification as a validatable and iteratable source",
-  "main": "specification/lib/src/api-specification.js",
-  "types": "specification/lib/src/api-specification.d.ts",
+  "main": "specification/compiler/index.ts",
   "scripts": {
     "compile:specs": "npm run compile:specs --prefix specification",
     "compile:canonical-json": "npm run generate-schema --prefix specification",

--- a/specification/compiler/model/build-model.ts
+++ b/specification/compiler/model/build-model.ts
@@ -186,11 +186,13 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
   if (Node.isClassDeclaration(declaration) && isApi(declaration)) {
     // TODO: add support for implements and behaviors
 
+    // It's not guaranteed that every *Request definition
+    // has an associated *Response definition as well.
     let hasResponseDeclaration = false
     for (const declaration of allClasses) {
       if (declaration.getName() === `${name.slice(0, -7)}Response`) {
         hasResponseDeclaration = true
-        continue
+        break
       }
     }
     // Store the mappings for the current endpoint


### PR DESCRIPTION
Currently, we are optimistically assuming that given a. request class, we also have the response, that is not always the case, this pr adds a check to verify this assumption.