### PR TITLE
Added since decorator

### DIFF
--- a/docs/add-new-api.md
+++ b/docs/add-new-api.md
@@ -49,12 +49,14 @@ A request definition should contains three top level keys:
 - `query_parameters`: the query parameters (eg: `timeout`, `pipeline`...)
 - `body`: the body parameters (eg: `query` or user defined entities)
 
-Finally there should be a decorator to inform the compiler that this is a endpoint request definition.
+Finally there should be a decorator (`rest_spec_name`) to inform the compiler that this is a endpoint request definition.
 The value of the decorator should be the endpoint name as it's defined in the json spec (eg: `search`, `indices.create`...).
+You should also add another decorator (`since`) to track the version of Elasticsearch where this API has been introduced.
 Following you can find a template valid for any request definition.
 
 ```ts
-@rest_spec_name("endpoint.name")
+@rest_spec_name('endpoint.name')
+@since('1.2.3')
 class EndpointRequest extends RequestBase {
   path_parts?: {
 
@@ -70,7 +72,8 @@ class EndpointRequest extends RequestBase {
 
 In some cases, the request could take one or more generics, in such case the definition will be:
 ```ts
-@rest_spec_name("endpoint.name")
+@rest_spec_name('endpoint.name')
+@since('1.2.3')
 class EndpointRequest<Generic> extends RequestBase {
   path_parts?: {
 

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -21,6 +21,7 @@
         "name": "AsyncSearchDeleteResponse",
         "namespace": "x_pack.async_search.delete"
       },
+      "since": "7.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -44,6 +45,7 @@
         "name": "AsyncSearchGetResponse",
         "namespace": "x_pack.async_search.get"
       },
+      "since": "7.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -67,6 +69,7 @@
         "name": "AsyncSearchSubmitResponse",
         "namespace": "x_pack.async_search.submit"
       },
+      "since": "7.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -164,6 +167,7 @@
         "name": "BulkResponse",
         "namespace": "document.multiple.bulk"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -202,6 +206,7 @@
         "name": "CatAliasesResponse",
         "namespace": "cat.cat_aliases"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -231,6 +236,7 @@
         "name": "CatAllocationResponse",
         "namespace": "cat.cat_allocation"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -260,6 +266,7 @@
         "name": "CatCountResponse",
         "namespace": "cat.cat_count"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -289,6 +296,7 @@
         "name": "CatFielddataResponse",
         "namespace": "cat.cat_fielddata"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -318,6 +326,7 @@
         "name": "CatHealthResponse",
         "namespace": "cat.cat_health"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -341,6 +350,7 @@
         "name": "CatHelpResponse",
         "namespace": "cat.cat_help"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -364,6 +374,7 @@
         "name": "CatIndicesResponse",
         "namespace": "cat.cat_indices"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -393,6 +404,7 @@
         "name": "CatMasterResponse",
         "namespace": "cat.cat_master"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -416,6 +428,7 @@
         "name": "CatDataFrameAnalyticsResponse",
         "namespace": "cat.cat_data_frame_analytics"
       },
+      "since": "7.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -445,6 +458,7 @@
         "name": "CatDatafeedsResponse",
         "namespace": "cat.cat_datafeeds"
       },
+      "since": "7.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -474,6 +488,7 @@
         "name": "CatJobsResponse",
         "namespace": "cat.cat_jobs"
       },
+      "since": "7.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -503,6 +518,7 @@
         "name": "CatTrainedModelsResponse",
         "namespace": "cat.cat_trained_models"
       },
+      "since": "7.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -532,6 +548,7 @@
         "name": "CatNodeAttributesResponse",
         "namespace": "cat.cat_node_attributes"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -555,6 +572,7 @@
         "name": "CatNodesResponse",
         "namespace": "cat.cat_nodes"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -578,6 +596,7 @@
         "name": "CatPendingTasksResponse",
         "namespace": "cat.cat_pending_tasks"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -601,6 +620,7 @@
         "name": "CatPluginsResponse",
         "namespace": "cat.cat_plugins"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -624,6 +644,7 @@
         "name": "CatRecoveryResponse",
         "namespace": "cat.cat_recovery"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -653,6 +674,7 @@
         "name": "CatRepositoriesResponse",
         "namespace": "cat.cat_repositories"
       },
+      "since": "2.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -676,6 +698,7 @@
         "name": "CatSegmentsResponse",
         "namespace": "cat.cat_segments"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -705,6 +728,7 @@
         "name": "CatShardsResponse",
         "namespace": "cat.cat_shards"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -734,6 +758,7 @@
         "name": "CatSnapshotsResponse",
         "namespace": "cat.cat_snapshots"
       },
+      "since": "2.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -763,6 +788,7 @@
         "name": "CatTasksResponse",
         "namespace": "cat.cat_tasks"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -786,6 +812,7 @@
         "name": "CatTemplatesResponse",
         "namespace": "cat.cat_templates"
       },
+      "since": "5.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -815,6 +842,7 @@
         "name": "CatThreadPoolResponse",
         "namespace": "cat.cat_thread_pool"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -844,6 +872,7 @@
         "name": "CatTransformsResponse",
         "namespace": "cat.cat_transforms"
       },
+      "since": "7.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -873,6 +902,7 @@
         "name": "DeleteAutoFollowPatternResponse",
         "namespace": "x_pack.cross_cluster_replication.auto_follow.delete_auto_follow_pattern"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -896,6 +926,7 @@
         "name": "CreateFollowIndexResponse",
         "namespace": "x_pack.cross_cluster_replication.follow.create_follow_index"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -919,6 +950,7 @@
         "name": "FollowInfoResponse",
         "namespace": "x_pack.cross_cluster_replication.follow.follow_info"
       },
+      "since": "6.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -942,6 +974,7 @@
         "name": "FollowIndexStatsResponse",
         "namespace": "x_pack.cross_cluster_replication.follow.follow_index_stats"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -965,6 +998,7 @@
         "name": "ForgetFollowerIndexResponse",
         "namespace": "x_pack.cross_cluster_replication.follow.forget_follower_index"
       },
+      "since": "6.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -988,6 +1022,7 @@
         "name": "GetAutoFollowPatternResponse",
         "namespace": "x_pack.cross_cluster_replication.auto_follow.get_auto_follow_pattern"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -1017,6 +1052,7 @@
         "name": "PauseAutoFollowPatternResponse",
         "namespace": "x_pack.cross_cluster_replication.auto_follow.pause_auto_follow_pattern"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -1040,6 +1076,7 @@
         "name": "PauseFollowIndexResponse",
         "namespace": "x_pack.cross_cluster_replication.follow.pause_follow_index"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -1063,6 +1100,7 @@
         "name": "CreateAutoFollowPatternResponse",
         "namespace": "x_pack.cross_cluster_replication.auto_follow.create_auto_follow_pattern"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -1086,6 +1124,7 @@
         "name": "ResumeAutoFollowPatternResponse",
         "namespace": "x_pack.cross_cluster_replication.auto_follow.resume_auto_follow_pattern"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -1109,6 +1148,7 @@
         "name": "ResumeFollowIndexResponse",
         "namespace": "x_pack.cross_cluster_replication.follow.resume_follow_index"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -1132,6 +1172,7 @@
         "name": "CcrStatsResponse",
         "namespace": "x_pack.cross_cluster_replication.stats"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -1155,6 +1196,7 @@
         "name": "UnfollowIndexResponse",
         "namespace": "x_pack.cross_cluster_replication.follow.unfollow_index"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -1178,6 +1220,7 @@
         "name": "ClearScrollResponse",
         "namespace": "search.scroll.clear_scroll"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1228,6 +1271,7 @@
         "name": "ClusterAllocationExplainResponse",
         "namespace": "cluster.cluster_allocation_explain"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1326,6 +1370,7 @@
         "name": "ClusterGetSettingsResponse",
         "namespace": "cluster.cluster_settings.cluster_get_settings"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1349,6 +1394,7 @@
         "name": "ClusterHealthResponse",
         "namespace": "cluster.cluster_health"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1378,6 +1424,7 @@
         "name": "ClusterPendingTasksResponse",
         "namespace": "cluster.cluster_pending_tasks"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1436,6 +1483,7 @@
         "name": "ClusterPutSettingsResponse",
         "namespace": "cluster.cluster_settings.cluster_put_settings"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1459,6 +1507,7 @@
         "name": "RemoteInfoResponse",
         "namespace": "cluster.remote_info"
       },
+      "since": "6.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -1482,6 +1531,7 @@
         "name": "ClusterRerouteResponse",
         "namespace": "cluster.cluster_reroute"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1505,6 +1555,7 @@
         "name": "ClusterStateResponse",
         "namespace": "cluster.cluster_state"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1540,6 +1591,7 @@
         "name": "ClusterStatsResponse",
         "namespace": "cluster.cluster_stats"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1569,6 +1621,7 @@
         "name": "CountResponse",
         "namespace": "search.count"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1611,6 +1664,7 @@
         "name": "CreateResponse",
         "namespace": "document.single.create"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1875,6 +1929,7 @@
         "name": "DeleteResponse",
         "namespace": "document.single.delete"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1908,6 +1963,7 @@
         "name": "DeleteByQueryResponse",
         "namespace": "document.multiple.delete_by_query"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1941,6 +1997,7 @@
         "name": "DeleteByQueryRethrottleResponse",
         "namespace": "document.multiple.delete_by_query_rethrottle"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -1964,6 +2021,7 @@
         "name": "DeleteScriptResponse",
         "namespace": "modules.scripting.delete_script"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -1987,6 +2045,7 @@
         "name": "DeleteEnrichPolicyResponse",
         "namespace": "x_pack.enrich.delete_policy"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -2010,6 +2069,7 @@
         "name": "ExecuteEnrichPolicyResponse",
         "namespace": "x_pack.enrich.execute_policy"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -2033,6 +2093,7 @@
         "name": "GetEnrichPolicyResponse",
         "namespace": "x_pack.enrich.get_policy"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -2062,6 +2123,7 @@
         "name": "PutEnrichPolicyResponse",
         "namespace": "x_pack.enrich.put_policy"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -2085,6 +2147,7 @@
         "name": "EnrichStatsResponse",
         "namespace": "x_pack.enrich.stats"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -2160,6 +2223,7 @@
         "name": "DocumentExistsResponse",
         "namespace": "document.single.exists"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2193,6 +2257,7 @@
         "name": "SourceExistsResponse",
         "namespace": "document.single.source_exists"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -2226,6 +2291,7 @@
         "name": "ExplainResponse",
         "namespace": "search.explain"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2261,6 +2327,7 @@
         "name": "FieldCapabilitiesResponse",
         "namespace": "search.field_capabilities"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -2292,6 +2359,7 @@
         "name": "GetResponse",
         "namespace": "document.single.get"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2325,6 +2393,7 @@
         "name": "GetScriptResponse",
         "namespace": "modules.scripting.get_script"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2382,6 +2451,7 @@
         "name": "SourceResponse",
         "namespace": "document.single.source"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2415,6 +2485,7 @@
         "name": "GraphExploreResponse",
         "namespace": "x_pack.graph.explore"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2450,6 +2521,7 @@
         "name": "DeleteLifecycleResponse",
         "namespace": "x_pack.ilm.delete_lifecycle"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2473,6 +2545,7 @@
         "name": "ExplainLifecycleResponse",
         "namespace": "x_pack.ilm.explain_lifecycle"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2496,6 +2569,7 @@
         "name": "GetLifecycleResponse",
         "namespace": "x_pack.ilm.get_lifecycle"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2525,6 +2599,7 @@
         "name": "GetIlmStatusResponse",
         "namespace": "x_pack.ilm.get_status"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2548,6 +2623,7 @@
         "name": "MoveToStepResponse",
         "namespace": "x_pack.ilm.move_to_step"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2571,6 +2647,7 @@
         "name": "PutLifecycleResponse",
         "namespace": "x_pack.ilm.put_lifecycle"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2594,6 +2671,7 @@
         "name": "RemovePolicyResponse",
         "namespace": "x_pack.ilm.remove_policy"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2617,6 +2695,7 @@
         "name": "RetryIlmResponse",
         "namespace": "x_pack.ilm.retry"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2640,6 +2719,7 @@
         "name": "StartIlmResponse",
         "namespace": "x_pack.ilm.start"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2663,6 +2743,7 @@
         "name": "StopIlmResponse",
         "namespace": "x_pack.ilm.stop"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -2686,6 +2767,7 @@
         "name": "IndexResponse",
         "namespace": "document.single.index"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2754,6 +2836,7 @@
         "name": "AnalyzeResponse",
         "namespace": "indices.analyze"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2785,6 +2868,7 @@
         "name": "ClearCacheResponse",
         "namespace": "indices.status_management.clear_cache"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2814,6 +2898,7 @@
         "name": "CloneIndexResponse",
         "namespace": "indices.index_management.clone_index"
       },
+      "since": "7.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -2838,6 +2923,7 @@
         "name": "CloseIndexResponse",
         "namespace": "indices.index_management.open_close_index.close_index"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2861,6 +2947,7 @@
         "name": "CreateIndexResponse",
         "namespace": "indices.index_management.create_index"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2924,6 +3011,7 @@
         "name": "DeleteIndexResponse",
         "namespace": "indices.index_management.delete_index"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -2947,6 +3035,7 @@
         "name": "DeleteAliasResponse",
         "namespace": "indices.alias_management.delete_alias"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3010,6 +3099,7 @@
         "name": "DeleteIndexTemplateResponse",
         "namespace": "indices.index_settings.index_templates.delete_index_template"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3033,6 +3123,7 @@
         "name": "IndexExistsResponse",
         "namespace": "indices.index_management.indices_exists"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3056,6 +3147,7 @@
         "name": "AliasExistsResponse",
         "namespace": "indices.alias_management.alias_exists"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3102,6 +3194,7 @@
         "name": "IndexTemplateExistsResponse",
         "namespace": "indices.index_settings.index_templates.index_template_exists"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3125,6 +3218,7 @@
         "name": "TypeExistsResponse",
         "namespace": "indices.index_management.types_exists"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3148,6 +3242,7 @@
         "name": "FlushResponse",
         "namespace": "indices.status_management.flush"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3179,6 +3274,7 @@
         "name": "SyncedFlushResponse",
         "namespace": "indices.status_management.synced_flush"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3218,6 +3314,7 @@
         "name": "ForceMergeResponse",
         "namespace": "indices.status_management.force_merge"
       },
+      "since": "2.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -3247,6 +3344,7 @@
         "name": "FreezeIndexResponse",
         "namespace": "indices.index_management.freeze_index"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -3270,6 +3368,7 @@
         "name": "GetIndexResponse",
         "namespace": "indices.index_management.get_index"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3293,6 +3392,7 @@
         "name": "GetAliasResponse",
         "namespace": "indices.alias_management.get_alias"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3357,6 +3457,7 @@
         "name": "GetFieldMappingResponse",
         "namespace": "indices.mapping_management.get_field_mapping"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3429,6 +3530,7 @@
         "name": "GetMappingResponse",
         "namespace": "indices.mapping_management.get_mapping"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3478,6 +3580,7 @@
         "name": "GetIndexSettingsResponse",
         "namespace": "indices.index_settings.get_index_settings"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3519,6 +3622,7 @@
         "name": "GetIndexTemplateResponse",
         "namespace": "indices.index_settings.index_templates.get_index_template"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3571,6 +3675,7 @@
         "name": "OpenIndexResponse",
         "namespace": "indices.index_management.open_close_index.open_index"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3594,6 +3699,7 @@
         "name": "PutAliasResponse",
         "namespace": "indices.alias_management.put_alias"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3643,6 +3749,7 @@
         "name": "PutMappingResponse",
         "namespace": "indices.mapping_management.put_mapping"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3744,6 +3851,7 @@
         "name": "UpdateIndexSettingsResponse",
         "namespace": "indices.index_settings.update_index_settings"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3773,6 +3881,7 @@
         "name": "PutIndexTemplateResponse",
         "namespace": "indices.index_settings.index_templates.put_index_template"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3797,6 +3906,7 @@
         "name": "RecoveryStatusResponse",
         "namespace": "indices.monitoring.indices_recovery"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3826,6 +3936,7 @@
         "name": "RefreshResponse",
         "namespace": "indices.status_management.refresh"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3857,6 +3968,7 @@
         "name": "ReloadSearchAnalyzersResponse",
         "namespace": "indices.reload_search_analyzers"
       },
+      "since": "7.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -3898,6 +4010,7 @@
         "name": "RolloverIndexResponse",
         "namespace": "indices.index_management.rollover_index"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3927,6 +4040,7 @@
         "name": "SegmentsResponse",
         "namespace": "indices.monitoring.indices_segments"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3956,6 +4070,7 @@
         "name": "IndicesShardStoresResponse",
         "namespace": "indices.monitoring.indices_shard_stores"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -3985,6 +4100,7 @@
         "name": "ShrinkIndexResponse",
         "namespace": "indices.index_management.shrink_index"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4049,6 +4165,7 @@
         "name": "SplitIndexResponse",
         "namespace": "indices.index_management.split_index"
       },
+      "since": "6.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -4073,6 +4190,7 @@
         "name": "IndicesStatsResponse",
         "namespace": "indices.monitoring.indices_stats"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4114,6 +4232,7 @@
         "name": "UnfreezeIndexResponse",
         "namespace": "indices.index_management.unfreeze_index"
       },
+      "since": "6.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -4137,6 +4256,7 @@
         "name": "BulkAliasResponse",
         "namespace": "indices.alias_management.alias"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4183,6 +4303,7 @@
         "name": "ValidateQueryResponse",
         "namespace": "search.validate"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4225,6 +4346,7 @@
         "name": "RootNodeInfoResponse",
         "namespace": "cluster.root_node_info"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4248,6 +4370,7 @@
         "name": "DeletePipelineResponse",
         "namespace": "ingest.delete_pipeline"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4271,6 +4394,7 @@
         "name": "GetPipelineResponse",
         "namespace": "ingest.get_pipeline"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4300,6 +4424,7 @@
         "name": "GrokProcessorPatternsResponse",
         "namespace": "ingest.processor"
       },
+      "since": "6.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -4323,6 +4448,7 @@
         "name": "PutPipelineResponse",
         "namespace": "ingest.put_pipeline"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4346,6 +4472,7 @@
         "name": "SimulatePipelineResponse",
         "namespace": "ingest.simulate_pipeline"
       },
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4377,6 +4504,7 @@
         "name": "DeleteLicenseResponse",
         "namespace": "x_pack.license.delete_license"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4400,6 +4528,7 @@
         "name": "GetLicenseResponse",
         "namespace": "x_pack.license.get_license"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4423,6 +4552,7 @@
         "name": "GetBasicLicenseStatusResponse",
         "namespace": "x_pack.license.get_basic_license_status"
       },
+      "since": "6.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -4446,6 +4576,7 @@
         "name": "GetTrialLicenseStatusResponse",
         "namespace": "x_pack.license.get_trial_license_status"
       },
+      "since": "6.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -4469,6 +4600,7 @@
         "name": "PostLicenseResponse",
         "namespace": "x_pack.license.post_license"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4493,6 +4625,7 @@
         "name": "StartBasicLicenseResponse",
         "namespace": "x_pack.license.start_basic_license"
       },
+      "since": "6.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -4516,6 +4649,7 @@
         "name": "StartTrialLicenseResponse",
         "namespace": "x_pack.license.start_trial_license"
       },
+      "since": "6.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -4539,6 +4673,7 @@
         "name": "MultiGetResponse",
         "namespace": "document.multiple.multi_get.request"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -4581,6 +4716,7 @@
         "name": "DeprecationInfoResponse",
         "namespace": "x_pack.migration.deprecation_info"
       },
+      "since": "6.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -4610,6 +4746,7 @@
         "name": "CloseJobResponse",
         "namespace": "x_pack.machine_learning.close_job"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -4633,6 +4770,7 @@
         "name": "DeleteCalendarResponse",
         "namespace": "x_pack.machine_learning.delete_calendar"
       },
+      "since": "6.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -4656,6 +4794,7 @@
         "name": "DeleteCalendarEventResponse",
         "namespace": "x_pack.machine_learning.delete_calendar_event"
       },
+      "since": "6.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -4679,6 +4818,7 @@
         "name": "DeleteCalendarJobResponse",
         "namespace": "x_pack.machine_learning.delete_calendar_job"
       },
+      "since": "6.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -4719,6 +4859,7 @@
         "name": "DeleteDatafeedResponse",
         "namespace": "x_pack.machine_learning.delete_datafeed"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -4742,6 +4883,7 @@
         "name": "DeleteExpiredDataResponse",
         "namespace": "x_pack.machine_learning.delete_expired_data"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -4771,6 +4913,7 @@
         "name": "DeleteFilterResponse",
         "namespace": "x_pack.machine_learning.delete_filter"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -4794,6 +4937,7 @@
         "name": "DeleteForecastResponse",
         "namespace": "x_pack.machine_learning.delete_forecast"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -4823,6 +4967,7 @@
         "name": "DeleteJobResponse",
         "namespace": "x_pack.machine_learning.delete_job"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -4846,6 +4991,7 @@
         "name": "DeleteModelSnapshotResponse",
         "namespace": "x_pack.machine_learning.delete_model_snapshot"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -4886,6 +5032,7 @@
         "name": "EstimateModelMemoryResponse",
         "namespace": "x_pack.machine_learning.estimate_model_memory"
       },
+      "since": "7.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -4968,6 +5115,7 @@
         "name": "FlushJobResponse",
         "namespace": "x_pack.machine_learning.flush_job"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -4991,6 +5139,7 @@
         "name": "ForecastJobResponse",
         "namespace": "x_pack.machine_learning.forecast_job"
       },
+      "since": "6.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -5014,6 +5163,7 @@
         "name": "GetBucketsResponse",
         "namespace": "x_pack.machine_learning.get_buckets"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5045,6 +5195,7 @@
         "name": "GetCalendarEventsResponse",
         "namespace": "x_pack.machine_learning.get_calendar_events"
       },
+      "since": "6.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -5068,6 +5219,7 @@
         "name": "GetCalendarsResponse",
         "namespace": "x_pack.machine_learning.get_calendars"
       },
+      "since": "6.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -5099,6 +5251,7 @@
         "name": "GetCategoriesResponse",
         "namespace": "x_pack.machine_learning.get_categories"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5176,6 +5329,7 @@
         "name": "GetDatafeedStatsResponse",
         "namespace": "x_pack.machine_learning.get_datafeed_stats"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5205,6 +5359,7 @@
         "name": "GetDatafeedsResponse",
         "namespace": "x_pack.machine_learning.get_datafeeds"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5234,6 +5389,7 @@
         "name": "GetFiltersResponse",
         "namespace": "x_pack.machine_learning.get_filters"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5263,6 +5419,7 @@
         "name": "GetInfluencersResponse",
         "namespace": "x_pack.machine_learning.get_influencers"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5287,6 +5444,7 @@
         "name": "GetJobStatsResponse",
         "namespace": "x_pack.machine_learning.get_job_stats"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5316,6 +5474,7 @@
         "name": "GetJobsResponse",
         "namespace": "x_pack.machine_learning.get_jobs"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5345,6 +5504,7 @@
         "name": "GetModelSnapshotsResponse",
         "namespace": "x_pack.machine_learning.get_model_snapshots"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5376,6 +5536,7 @@
         "name": "GetOverallBucketsResponse",
         "namespace": "x_pack.machine_learning.get_overall_buckets"
       },
+      "since": "6.1.0",
       "stability": "stable",
       "urls": [
         {
@@ -5400,6 +5561,7 @@
         "name": "GetAnomalyRecordsResponse",
         "namespace": "x_pack.machine_learning.get_anomaly_records"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5470,6 +5632,7 @@
         "name": "MachineLearningInfoResponse",
         "namespace": "x_pack.machine_learning.machine_learning_info"
       },
+      "since": "6.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -5493,6 +5656,7 @@
         "name": "OpenJobResponse",
         "namespace": "x_pack.machine_learning.open_job"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5516,6 +5680,7 @@
         "name": "PostCalendarEventsResponse",
         "namespace": "x_pack.machine_learning.post_calendar_events"
       },
+      "since": "6.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -5539,6 +5704,7 @@
         "name": "PostJobDataResponse",
         "namespace": "x_pack.machine_learning.post_job_data"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5562,6 +5728,7 @@
         "name": "PreviewDatafeedResponse",
         "namespace": "x_pack.machine_learning.preview_datafeed"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5585,6 +5752,7 @@
         "name": "PutCalendarResponse",
         "namespace": "x_pack.machine_learning.put_calendar"
       },
+      "since": "6.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -5608,6 +5776,7 @@
         "name": "PutCalendarJobResponse",
         "namespace": "x_pack.machine_learning.put_calendar_job"
       },
+      "since": "6.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -5648,6 +5817,7 @@
         "name": "PutDatafeedResponse",
         "namespace": "x_pack.machine_learning.put_datafeed"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5671,6 +5841,7 @@
         "name": "PutFilterResponse",
         "namespace": "x_pack.machine_learning.put_filter"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5694,6 +5865,7 @@
         "name": "PutJobResponse",
         "namespace": "x_pack.machine_learning.put_job"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5734,6 +5906,7 @@
         "name": "RevertModelSnapshotResponse",
         "namespace": "x_pack.machine_learning.revert_model_snapshot"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5757,6 +5930,7 @@
         "name": "SetUpgradeModeResponse",
         "namespace": "x_pack.machine_learning.set_upgrade_mode"
       },
+      "since": "6.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -5797,6 +5971,7 @@
         "name": "StartDatafeedResponse",
         "namespace": "x_pack.machine_learning.start_datafeed"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5837,6 +6012,7 @@
         "name": "StopDatafeedResponse",
         "namespace": "x_pack.machine_learning.stop_datafeed"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5877,6 +6053,7 @@
         "name": "UpdateDatafeedResponse",
         "namespace": "x_pack.machine_learning.update_data_feed"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5900,6 +6077,7 @@
         "name": "UpdateFilterResponse",
         "namespace": "x_pack.machine_learning.update_filter"
       },
+      "since": "6.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5923,6 +6101,7 @@
         "name": "UpdateJobResponse",
         "namespace": "x_pack.machine_learning.update_job"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5946,6 +6125,7 @@
         "name": "UpdateModelSnapshotResponse",
         "namespace": "x_pack.machine_learning.update_model_snapshot"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5969,6 +6149,7 @@
         "name": "ValidateJobResponse",
         "namespace": "x_pack.machine_learning.validate_job"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -5992,6 +6173,7 @@
         "name": "ValidateDetectorResponse",
         "namespace": "x_pack.machine_learning.validate_detector"
       },
+      "since": "5.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -6044,6 +6226,7 @@
         "name": "MultiSearchResponse",
         "namespace": "search.multi_search"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6083,6 +6266,7 @@
       },
       "requestBodyRequired": true,
       "response": null,
+      "since": "5.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6125,6 +6309,7 @@
         "name": "MultiTermVectorsResponse",
         "namespace": "document.multiple.multi_term_vectors"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6167,6 +6352,7 @@
         "name": "NodesHotThreadsResponse",
         "namespace": "cluster.nodes_hot_threads"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6256,6 +6442,7 @@
         "name": "NodesInfoResponse",
         "namespace": "cluster.nodes_info"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6297,6 +6484,7 @@
         "name": "ReloadSecureSettingsResponse",
         "namespace": "cluster.reload_secure_settings"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -6326,6 +6514,7 @@
         "name": "NodesStatsResponse",
         "namespace": "cluster.nodes_stats"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6379,6 +6568,7 @@
         "name": "NodesUsageResponse",
         "namespace": "cluster.nodes_usage"
       },
+      "since": "6.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6443,6 +6633,7 @@
         "name": "PingResponse",
         "namespace": "cluster.ping"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6466,6 +6657,7 @@
         "name": "PutScriptResponse",
         "namespace": "modules.scripting.put_script"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6522,6 +6714,7 @@
         "name": "ReindexResponse",
         "namespace": "document.multiple.reindex"
       },
+      "since": "2.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -6545,6 +6738,7 @@
         "name": "ReindexRethrottleResponse",
         "namespace": "document.multiple.reindex_rethrottle"
       },
+      "since": "2.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -6568,6 +6762,7 @@
         "name": "RenderSearchTemplateResponse",
         "namespace": "search.search_template.render_search_template"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6599,6 +6794,7 @@
         "name": "DeleteRollupJobResponse",
         "namespace": "x_pack.roll_up.delete_rollup_job"
       },
+      "since": "6.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -6622,6 +6818,7 @@
         "name": "GetRollupJobResponse",
         "namespace": "x_pack.roll_up.get_rollup_job"
       },
+      "since": "6.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -6651,6 +6848,7 @@
         "name": "GetRollupCapabilitiesResponse",
         "namespace": "x_pack.roll_up.get_rollup_capabilities"
       },
+      "since": "6.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -6680,6 +6878,7 @@
         "name": "GetRollupIndexCapabilitiesResponse",
         "namespace": "x_pack.roll_up.get_rollup_index_capabilities"
       },
+      "since": "6.4.0",
       "stability": "experimental",
       "urls": [
         {
@@ -6703,6 +6902,7 @@
         "name": "CreateRollupJobResponse",
         "namespace": "x_pack.roll_up.create_rollup_job"
       },
+      "since": "6.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -6726,6 +6926,7 @@
         "name": "RollupSearchResponse",
         "namespace": "x_pack.roll_up.rollup_search"
       },
+      "since": "6.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -6761,6 +6962,7 @@
         "name": "StartRollupJobResponse",
         "namespace": "x_pack.roll_up.start_rollup_job"
       },
+      "since": "6.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -6784,6 +6986,7 @@
         "name": "StopRollupJobResponse",
         "namespace": "x_pack.roll_up.stop_rollup_job"
       },
+      "since": "6.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -6807,6 +7010,7 @@
         "name": "ExecutePainlessScriptResponse",
         "namespace": "modules.scripting.execute_painless_script"
       },
+      "since": "6.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -6831,6 +7035,7 @@
         "name": "ScrollResponse",
         "namespace": "search.scroll.scroll"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6866,6 +7071,7 @@
         "name": "SearchResponse",
         "namespace": "search.search"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6908,6 +7114,7 @@
         "name": "SearchShardsResponse",
         "namespace": "search.search_shards"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -6936,6 +7143,7 @@
       },
       "requestBodyRequired": true,
       "response": null,
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7058,6 +7266,7 @@
         "name": "AuthenticateResponse",
         "namespace": "x_pack.security.authenticate"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7081,6 +7290,7 @@
         "name": "ChangePasswordResponse",
         "namespace": "x_pack.security.user.change_password"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7146,6 +7356,7 @@
         "name": "ClearCachedRealmsResponse",
         "namespace": "x_pack.security.clear_cached_realms"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7169,6 +7380,7 @@
         "name": "ClearCachedRolesResponse",
         "namespace": "x_pack.security.role.clear_cached_roles"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7192,6 +7404,7 @@
         "name": "CreateApiKeyResponse",
         "namespace": "x_pack.security.api_key.create_api_key"
       },
+      "since": "6.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -7216,6 +7429,7 @@
         "name": "DeletePrivilegesResponse",
         "namespace": "x_pack.security.privileges.delete_privileges"
       },
+      "since": "6.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -7239,6 +7453,7 @@
         "name": "DeleteRoleResponse",
         "namespace": "x_pack.security.role.delete_role"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7262,6 +7477,7 @@
         "name": "DeleteRoleMappingResponse",
         "namespace": "x_pack.security.role_mapping.delete_role_mapping"
       },
+      "since": "5.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -7285,6 +7501,7 @@
         "name": "DeleteUserResponse",
         "namespace": "x_pack.security.user.delete_user"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7308,6 +7525,7 @@
         "name": "DisableUserResponse",
         "namespace": "x_pack.security.user.disable_user"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7332,6 +7550,7 @@
         "name": "EnableUserResponse",
         "namespace": "x_pack.security.user.enable_user"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7356,6 +7575,7 @@
         "name": "GetApiKeyResponse",
         "namespace": "x_pack.security.api_key.get_api_key"
       },
+      "since": "6.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -7379,6 +7599,7 @@
         "name": "GetBuiltinPrivilegesResponse",
         "namespace": "x_pack.security.privileges.get_builtin_privileges"
       },
+      "since": "7.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -7402,6 +7623,7 @@
         "name": "GetPrivilegesResponse",
         "namespace": "x_pack.security.privileges.get_privileges"
       },
+      "since": "6.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -7437,6 +7659,7 @@
         "name": "GetRoleResponse",
         "namespace": "x_pack.security.role.get_role"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7466,6 +7689,7 @@
         "name": "GetRoleMappingResponse",
         "namespace": "x_pack.security.role_mapping.get_role_mapping"
       },
+      "since": "5.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -7495,6 +7719,7 @@
         "name": "GetUserAccessTokenResponse",
         "namespace": "x_pack.security.user.get_user_access_token"
       },
+      "since": "5.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -7518,6 +7743,7 @@
         "name": "GetUserResponse",
         "namespace": "x_pack.security.user.get_user"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7547,6 +7773,7 @@
         "name": "GetUserPrivilegesResponse",
         "namespace": "x_pack.security.privileges.get_user_privileges"
       },
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -7587,6 +7814,7 @@
         "name": "HasPrivilegesResponse",
         "namespace": "x_pack.security.privileges.has_privileges"
       },
+      "since": "6.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -7618,6 +7846,7 @@
         "name": "InvalidateApiKeyResponse",
         "namespace": "x_pack.security.api_key.invalidate_api_key"
       },
+      "since": "6.7.0",
       "stability": "stable",
       "urls": [
         {
@@ -7641,6 +7870,7 @@
         "name": "InvalidateUserAccessTokenResponse",
         "namespace": "x_pack.security.user.invalidate_user_access_token"
       },
+      "since": "5.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -7664,6 +7894,7 @@
         "name": "PutPrivilegesResponse",
         "namespace": "x_pack.security.privileges.put_privileges"
       },
+      "since": "6.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -7688,6 +7919,7 @@
         "name": "PutRoleResponse",
         "namespace": "x_pack.security.role.put_role"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7712,6 +7944,7 @@
         "name": "PutRoleMappingResponse",
         "namespace": "x_pack.security.role_mapping.put_role_mapping"
       },
+      "since": "5.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -7736,6 +7969,7 @@
         "name": "PutUserResponse",
         "namespace": "x_pack.security.user.put_user"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -7760,6 +7994,7 @@
         "name": "DeleteSnapshotLifecycleResponse",
         "namespace": "x_pack.slm.delete_lifecycle"
       },
+      "since": "7.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -7783,6 +8018,7 @@
         "name": "ExecuteSnapshotLifecycleResponse",
         "namespace": "x_pack.slm.execute_lifecycle"
       },
+      "since": "7.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -7806,6 +8042,7 @@
         "name": "ExecuteRetentionResponse",
         "namespace": "x_pack.slm.execute_retention"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -7829,6 +8066,7 @@
         "name": "GetSnapshotLifecycleResponse",
         "namespace": "x_pack.slm.get_lifecycle"
       },
+      "since": "7.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -7858,6 +8096,7 @@
         "name": "GetSnapshotLifecycleStatsResponse",
         "namespace": "x_pack.slm.get_stats"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -7881,6 +8120,7 @@
         "name": "GetSnapshotLifecycleManagementStatusResponse",
         "namespace": "x_pack.slm.get_status"
       },
+      "since": "7.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -7904,6 +8144,7 @@
         "name": "PutSnapshotLifecycleResponse",
         "namespace": "x_pack.slm.put_lifecycle"
       },
+      "since": "7.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -7927,6 +8168,7 @@
         "name": "StartSnapshotLifecycleManagementResponse",
         "namespace": "x_pack.slm.start"
       },
+      "since": "7.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -7950,6 +8192,7 @@
         "name": "StopSnapshotLifecycleManagementResponse",
         "namespace": "x_pack.slm.stop"
       },
+      "since": "7.6.0",
       "stability": "stable",
       "urls": [
         {
@@ -7973,6 +8216,7 @@
         "name": "CleanupRepositoryResponse",
         "namespace": "modules.snapshot_and_restore.repositories.cleanup_repository"
       },
+      "since": "7.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -8013,6 +8257,7 @@
         "name": "SnapshotResponse",
         "namespace": "modules.snapshot_and_restore.snapshot.snapshot"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8037,6 +8282,7 @@
         "name": "CreateRepositoryResponse",
         "namespace": "modules.snapshot_and_restore.repositories.create_repository"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8061,6 +8307,7 @@
         "name": "DeleteSnapshotResponse",
         "namespace": "modules.snapshot_and_restore.snapshot.delete_snapshot"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8084,6 +8331,7 @@
         "name": "DeleteRepositoryResponse",
         "namespace": "modules.snapshot_and_restore.repositories.delete_repository"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8107,6 +8355,7 @@
         "name": "GetSnapshotResponse",
         "namespace": "modules.snapshot_and_restore.snapshot.get_snapshot"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8130,6 +8379,7 @@
         "name": "GetRepositoryResponse",
         "namespace": "modules.snapshot_and_restore.repositories.get_repository"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8159,6 +8409,7 @@
         "name": "RestoreResponse",
         "namespace": "modules.snapshot_and_restore.restore"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8182,6 +8433,7 @@
         "name": "SnapshotStatusResponse",
         "namespace": "modules.snapshot_and_restore.snapshot.snapshot_status"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8217,6 +8469,7 @@
         "name": "VerifyRepositoryResponse",
         "namespace": "modules.snapshot_and_restore.repositories.verify_repository"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8240,6 +8493,7 @@
         "name": "ClearSqlCursorResponse",
         "namespace": "x_pack.sql.clear_sql_cursor"
       },
+      "since": "6.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -8263,6 +8517,7 @@
         "name": "QuerySqlResponse",
         "namespace": "x_pack.sql.query_sql"
       },
+      "since": "6.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -8287,6 +8542,7 @@
         "name": "TranslateSqlResponse",
         "namespace": "x_pack.sql.translate_sql"
       },
+      "since": "6.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -8311,6 +8567,7 @@
         "name": "GetCertificatesResponse",
         "namespace": "x_pack.ssl.get_certificates"
       },
+      "since": "6.2.0",
       "stability": "stable",
       "urls": [
         {
@@ -8334,6 +8591,7 @@
         "name": "CancelTasksResponse",
         "namespace": "cluster.task_management.cancel_tasks"
       },
+      "since": "2.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -8363,6 +8621,7 @@
         "name": "GetTaskResponse",
         "namespace": "cluster.task_management.get_task"
       },
+      "since": "5.0.0",
       "stability": "experimental",
       "urls": [
         {
@@ -8386,6 +8645,7 @@
         "name": "ListTasksResponse",
         "namespace": "cluster.task_management.list_tasks"
       },
+      "since": "2.3.0",
       "stability": "experimental",
       "urls": [
         {
@@ -8409,6 +8669,7 @@
         "name": "TermVectorsResponse",
         "namespace": "document.single.term_vectors"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8462,6 +8723,7 @@
         "name": "DeleteTransformResponse",
         "namespace": "x_pack.transform.delete_transform"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -8485,6 +8747,7 @@
         "name": "GetTransformResponse",
         "namespace": "x_pack.transform.get_transform"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -8514,6 +8777,7 @@
         "name": "GetTransformStatsResponse",
         "namespace": "x_pack.transform.get_transform_stats"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -8537,6 +8801,7 @@
         "name": "PreviewTransformResponse",
         "namespace": "x_pack.transform.preview_transform"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -8560,6 +8825,7 @@
         "name": "PutTransformResponse",
         "namespace": "x_pack.transform.put_transform"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -8583,6 +8849,7 @@
         "name": "StartTransformResponse",
         "namespace": "x_pack.transform.start_transform"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -8606,6 +8873,7 @@
         "name": "StopTransformResponse",
         "namespace": "x_pack.transform.stop_transform"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -8629,6 +8897,7 @@
         "name": "UpdateTransformResponse",
         "namespace": "x_pack.transform.update_transform"
       },
+      "since": "7.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -8652,6 +8921,7 @@
         "name": "UpdateResponse",
         "namespace": "document.single.update"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8685,6 +8955,7 @@
         "name": "UpdateByQueryResponse",
         "namespace": "document.multiple.update_by_query"
       },
+      "since": "2.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -8715,6 +8986,7 @@
       },
       "requestBodyRequired": false,
       "response": null,
+      "since": "6.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -8738,6 +9010,7 @@
         "name": "AcknowledgeWatchResponse",
         "namespace": "x_pack.watcher.acknowledge_watch"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8769,6 +9042,7 @@
         "name": "ActivateWatchResponse",
         "namespace": "x_pack.watcher.activate_watch"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8793,6 +9067,7 @@
         "name": "DeactivateWatchResponse",
         "namespace": "x_pack.watcher.deactivate_watch"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8817,6 +9092,7 @@
         "name": "DeleteWatchResponse",
         "namespace": "x_pack.watcher.delete_watch"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8840,6 +9116,7 @@
         "name": "ExecuteWatchResponse",
         "namespace": "x_pack.watcher.execute_watch"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8871,6 +9148,7 @@
         "name": "GetWatchResponse",
         "namespace": "x_pack.watcher.get_watch"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8894,6 +9172,7 @@
         "name": "PutWatchResponse",
         "namespace": "x_pack.watcher.put_watch"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8918,6 +9197,7 @@
         "name": "StartWatcherResponse",
         "namespace": "x_pack.watcher.start_watcher"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8941,6 +9221,7 @@
         "name": "WatcherStatsResponse",
         "namespace": "x_pack.watcher.watcher_stats"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8970,6 +9251,7 @@
         "name": "StopWatcherResponse",
         "namespace": "x_pack.watcher.stop_watcher"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -8993,6 +9275,7 @@
         "name": "XPackInfoResponse",
         "namespace": "x_pack.info.x_pack_info"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {
@@ -9016,6 +9299,7 @@
         "name": "XPackUsageResponse",
         "namespace": "x_pack.info.x_pack_usage"
       },
+      "since": "0.0.0",
       "stability": "stable",
       "urls": [
         {

--- a/specification/compiler/model/build-model.ts
+++ b/specification/compiler/model/build-model.ts
@@ -37,6 +37,7 @@ import {
   modelType,
   isApi,
   getApiName,
+  getSinceValue,
   modelInherits,
   modelGenerics,
   modelEnumDeclaration,
@@ -60,6 +61,7 @@ const jsonSpec = buildJsonSpec()
 type MappingsType = Map<string, {
   request: model.TypeName
   response: model.TypeName | null
+  since: string
 }>
 
 export default function compileSpecification (): model.Model {
@@ -162,6 +164,7 @@ export default function compileSpecification (): model.Model {
     if (mapping != null) {
       endpoint.request = mapping.request
       endpoint.response = mapping.response
+      endpoint.since = mapping.since
     }
 
     model.endpoints.push(endpoint)
@@ -197,6 +200,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
     }
     // Store the mappings for the current endpoint
     mappings.set(getApiName(declaration), {
+      since: getSinceValue(declaration),
       request: { name, namespace: getNameSpace(declaration) },
       response: hasResponseDeclaration
         ? { name: `${name.slice(0, -7)}Response`, namespace: getNameSpace(declaration) }

--- a/specification/compiler/model/utils.ts
+++ b/specification/compiler/model/utils.ts
@@ -33,6 +33,7 @@ import {
   JSDoc,
   Node
 } from 'ts-morph'
+import semver from 'semver'
 import * as model from './metamodel'
 
 /**
@@ -245,12 +246,25 @@ export function isApi (declaration: ClassDeclaration): boolean {
 
 /**
  * Given a ClassDeclaration, returns the api name
- * stores in the rest_spec_name decorator.
+ * stored in the rest_spec_name decorator.
  */
 export function getApiName (declaration: ClassDeclaration): string {
   const decorator = declaration.getDecorator('rest_spec_name')
   assert(decorator, 'The rest_spec_name decorator does not exists')
   return decorator.getArguments()[0].getText().split("'")[1]
+}
+
+/**
+ * Given a ClassDeclaration, returns the since value
+ * stored in the since decorator and verifies if the value
+ * is a valid semver string.
+ */
+export function getSinceValue (declaration: ClassDeclaration): string {
+  const decorator = declaration.getDecorator('since')
+  assert(decorator, 'The since decorator does not exists')
+  const value = decorator.getArguments()[0].getText().split("'")[1]
+  assert(semver.valid(value), `The semver value is not valid: ${value}`)
+  return value
 }
 
 /**

--- a/specification/package-lock.json
+++ b/specification/package-lock.json
@@ -1424,7 +1424,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -1922,7 +1921,6 @@
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
       "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -2337,8 +2335,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yn": {
       "version": "3.1.1",

--- a/specification/package.json
+++ b/specification/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "safe-stable-stringify": "^1.1.1",
+    "semver": "^7.3.4",
     "ts-morph": "^9.1.0"
   },
   "engines": {

--- a/specification/specs/cat/cat_aliases/CatAliasesRequest.ts
+++ b/specification/specs/cat/cat_aliases/CatAliasesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.aliases')
+@since('0.0.0')
 class CatAliasesRequest extends CatRequestBase {
   path_parts?: {
     name?: Names

--- a/specification/specs/cat/cat_allocation/CatAllocationRequest.ts
+++ b/specification/specs/cat/cat_allocation/CatAllocationRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.allocation')
+@since('0.0.0')
 class CatAllocationRequest extends CatRequestBase {
   path_parts?: {
     node_id?: NodeIds

--- a/specification/specs/cat/cat_count/CatCountRequest.ts
+++ b/specification/specs/cat/cat_count/CatCountRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.count')
+@since('0.0.0')
 class CatCountRequest extends CatRequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/cat/cat_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/specs/cat/cat_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.ml_data_frame_analytics')
+@since('7.7.0')
 class CatDataFrameAnalyticsRequest extends CatRequestBase {
   path_parts?: {
     id?: Id

--- a/specification/specs/cat/cat_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/specs/cat/cat_datafeeds/CatDatafeedsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.ml_datafeeds')
+@since('7.7.0')
 class CatDatafeedsRequest extends CatRequestBase {
   path_parts?: {
     datafeed_id?: Id

--- a/specification/specs/cat/cat_fielddata/CatFielddataRequest.ts
+++ b/specification/specs/cat/cat_fielddata/CatFielddataRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.fielddata')
+@since('0.0.0')
 class CatFielddataRequest extends CatRequestBase {
   path_parts?: {
     fields?: Fields

--- a/specification/specs/cat/cat_health/CatHealthRequest.ts
+++ b/specification/specs/cat/cat_health/CatHealthRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.health')
+@since('0.0.0')
 class CatHealthRequest extends CatRequestBase {
   query_parameters?: {
     include_timestamp?: boolean

--- a/specification/specs/cat/cat_help/CatHelpRequest.ts
+++ b/specification/specs/cat/cat_help/CatHelpRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.help')
+@since('0.0.0')
 class CatHelpRequest extends CatRequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/cat/cat_indices/CatIndicesRequest.ts
+++ b/specification/specs/cat/cat_indices/CatIndicesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.indices')
+@since('0.0.0')
 class CatIndicesRequest extends CatRequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/cat/cat_jobs/CatJobsRequest.ts
+++ b/specification/specs/cat/cat_jobs/CatJobsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.ml_jobs')
+@since('7.7.0')
 class CatJobsRequest extends CatRequestBase {
   path_parts?: {
     job_id?: Id

--- a/specification/specs/cat/cat_master/CatMasterRequest.ts
+++ b/specification/specs/cat/cat_master/CatMasterRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.master')
+@since('0.0.0')
 class CatMasterRequest extends CatRequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/cat/cat_node_attributes/CatNodeAttributesRequest.ts
+++ b/specification/specs/cat/cat_node_attributes/CatNodeAttributesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.nodeattrs')
+@since('0.0.0')
 class CatNodeAttributesRequest extends CatRequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/cat/cat_nodes/CatNodesRequest.ts
+++ b/specification/specs/cat/cat_nodes/CatNodesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.nodes')
+@since('0.0.0')
 class CatNodesRequest extends CatRequestBase {
   query_parameters?: {
     bytes?: Bytes

--- a/specification/specs/cat/cat_pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/specs/cat/cat_pending_tasks/CatPendingTasksRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.pending_tasks')
+@since('0.0.0')
 class CatPendingTasksRequest extends CatRequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/cat/cat_plugins/CatPluginsRequest.ts
+++ b/specification/specs/cat/cat_plugins/CatPluginsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.plugins')
+@since('0.0.0')
 class CatPluginsRequest extends CatRequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/cat/cat_recovery/CatRecoveryRequest.ts
+++ b/specification/specs/cat/cat_recovery/CatRecoveryRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.recovery')
+@since('0.0.0')
 class CatRecoveryRequest extends CatRequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/cat/cat_repositories/CatRepositoriesRequest.ts
+++ b/specification/specs/cat/cat_repositories/CatRepositoriesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.repositories')
+@since('2.1.0')
 class CatRepositoriesRequest extends CatRequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/cat/cat_segments/CatSegmentsRequest.ts
+++ b/specification/specs/cat/cat_segments/CatSegmentsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.segments')
+@since('0.0.0')
 class CatSegmentsRequest extends CatRequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/cat/cat_shards/CatShardsRequest.ts
+++ b/specification/specs/cat/cat_shards/CatShardsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.shards')
+@since('0.0.0')
 class CatShardsRequest extends CatRequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/cat/cat_snapshots/CatSnapshotsRequest.ts
+++ b/specification/specs/cat/cat_snapshots/CatSnapshotsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.snapshots')
+@since('2.1.0')
 class CatSnapshotsRequest extends CatRequestBase {
   path_parts?: {
     repository?: Names

--- a/specification/specs/cat/cat_tasks/CatTasksRequest.ts
+++ b/specification/specs/cat/cat_tasks/CatTasksRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.tasks')
+@since('5.0.0')
 class CatTasksRequest extends CatRequestBase {
   query_parameters?: {
     actions?: string[]

--- a/specification/specs/cat/cat_templates/CatTemplatesRequest.ts
+++ b/specification/specs/cat/cat_templates/CatTemplatesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.templates')
+@since('5.2.0')
 class CatTemplatesRequest extends CatRequestBase {
   path_parts?: {
     name?: Name

--- a/specification/specs/cat/cat_thread_pool/CatThreadPoolRequest.ts
+++ b/specification/specs/cat/cat_thread_pool/CatThreadPoolRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.thread_pool')
+@since('0.0.0')
 class CatThreadPoolRequest extends CatRequestBase {
   path_parts?: {
     thread_pool_patterns?: Names

--- a/specification/specs/cat/cat_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/specs/cat/cat_trained_models/CatTrainedModelsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.ml_trained_models')
+@since('7.7.0')
 class CatTrainedModelsRequest extends CatRequestBase {
   path_parts?: {
     model_id?: Id

--- a/specification/specs/cat/cat_transforms/CatTransformsRequest.ts
+++ b/specification/specs/cat/cat_transforms/CatTransformsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cat.transforms')
+@since('7.7.0')
 class CatTransformsRequest extends CatRequestBase {
   path_parts?: {
     transform_id?: Id

--- a/specification/specs/cluster/cluster_allocation_explain/ClusterAllocationExplainRequest.ts
+++ b/specification/specs/cluster/cluster_allocation_explain/ClusterAllocationExplainRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cluster.allocation_explain')
+@since('5.0.0')
 class ClusterAllocationExplainRequest extends RequestBase {
   query_parameters?: {
     include_disk_info?: boolean

--- a/specification/specs/cluster/cluster_health/ClusterHealthRequest.ts
+++ b/specification/specs/cluster/cluster_health/ClusterHealthRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cluster.health')
+@since('0.0.0')
 class ClusterHealthRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/cluster/cluster_pending_tasks/ClusterPendingTasksRequest.ts
+++ b/specification/specs/cluster/cluster_pending_tasks/ClusterPendingTasksRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cluster.pending_tasks')
+@since('0.0.0')
 class ClusterPendingTasksRequest extends RequestBase {
   query_parameters?: {
     local?: boolean

--- a/specification/specs/cluster/cluster_reroute/ClusterRerouteRequest.ts
+++ b/specification/specs/cluster/cluster_reroute/ClusterRerouteRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cluster.reroute')
+@since('0.0.0')
 class ClusterRerouteRequest extends RequestBase {
   query_parameters?: {
     dry_run?: boolean

--- a/specification/specs/cluster/cluster_settings/cluster_get_settings/ClusterGetSettingsRequest.ts
+++ b/specification/specs/cluster/cluster_settings/cluster_get_settings/ClusterGetSettingsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cluster.get_settings')
+@since('0.0.0')
 class ClusterGetSettingsRequest extends RequestBase {
   query_parameters?: {
     flat_settings?: boolean

--- a/specification/specs/cluster/cluster_settings/cluster_put_settings/ClusterPutSettingsRequest.ts
+++ b/specification/specs/cluster/cluster_settings/cluster_put_settings/ClusterPutSettingsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cluster.put_settings')
+@since('0.0.0')
 class ClusterPutSettingsRequest extends RequestBase {
   query_parameters?: {
     flat_settings?: boolean

--- a/specification/specs/cluster/cluster_state/ClusterStateRequest.ts
+++ b/specification/specs/cluster/cluster_state/ClusterStateRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cluster.state')
+@since('0.0.0')
 class ClusterStateRequest extends RequestBase {
   path_parts?: {
     metric?: Metrics

--- a/specification/specs/cluster/cluster_stats/ClusterStatsRequest.ts
+++ b/specification/specs/cluster/cluster_stats/ClusterStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cluster.stats')
+@since('0.0.0')
 class ClusterStatsRequest extends RequestBase {
   path_parts?: {
     node_id?: NodeIds

--- a/specification/specs/cluster/nodes_hot_threads/NodesHotThreadsRequest.ts
+++ b/specification/specs/cluster/nodes_hot_threads/NodesHotThreadsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('nodes.hot_threads')
+@since('0.0.0')
 class NodesHotThreadsRequest extends RequestBase {
   path_parts?: {
     node_id?: NodeIds

--- a/specification/specs/cluster/nodes_info/NodesInfoRequest.ts
+++ b/specification/specs/cluster/nodes_info/NodesInfoRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('nodes.info')
+@since('0.0.0')
 class NodesInfoRequest extends RequestBase {
   path_parts?: {
     node_id?: NodeIds

--- a/specification/specs/cluster/nodes_stats/NodesStatsRequest.ts
+++ b/specification/specs/cluster/nodes_stats/NodesStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('nodes.stats')
+@since('0.0.0')
 class NodesStatsRequest extends RequestBase {
   path_parts?: {
     node_id?: NodeIds

--- a/specification/specs/cluster/nodes_usage/NodesUsageRequest.ts
+++ b/specification/specs/cluster/nodes_usage/NodesUsageRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('nodes.usage')
+@since('6.0.0')
 class NodesUsageRequest extends RequestBase {
   path_parts?: {
     node_id?: NodeIds

--- a/specification/specs/cluster/ping/PingRequest.ts
+++ b/specification/specs/cluster/ping/PingRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ping')
+@since('0.0.0')
 class PingRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/cluster/reload_secure_settings/ReloadSecureSettingsRequest.ts
+++ b/specification/specs/cluster/reload_secure_settings/ReloadSecureSettingsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('nodes.reload_secure_settings')
+@since('6.5.0')
 class ReloadSecureSettingsRequest extends RequestBase {
   path_parts?: {
     node_id?: NodeIds

--- a/specification/specs/cluster/remote_info/RemoteInfoRequest.ts
+++ b/specification/specs/cluster/remote_info/RemoteInfoRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('cluster.remote_info')
+@since('6.1.0')
 class RemoteInfoRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/cluster/root_node_info/RootNodeInfoRequest.ts
+++ b/specification/specs/cluster/root_node_info/RootNodeInfoRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('info')
+@since('0.0.0')
 class RootNodeInfoRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/cluster/task_management/cancel_tasks/CancelTasksRequest.ts
+++ b/specification/specs/cluster/task_management/cancel_tasks/CancelTasksRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('tasks.cancel')
+@since('2.3.0')
 class CancelTasksRequest extends RequestBase {
   path_parts?: {
     task_id?: TaskId

--- a/specification/specs/cluster/task_management/get_task/GetTaskRequest.ts
+++ b/specification/specs/cluster/task_management/get_task/GetTaskRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('tasks.get')
+@since('5.0.0')
 class GetTaskRequest extends RequestBase {
   path_parts?: {
     task_id: Id

--- a/specification/specs/cluster/task_management/list_tasks/ListTasksRequest.ts
+++ b/specification/specs/cluster/task_management/list_tasks/ListTasksRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('tasks.list')
+@since('2.3.0')
 class ListTasksRequest extends RequestBase {
   query_parameters?: {
     actions?: string[]

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -32,6 +32,9 @@ function request_parameter() {
 function namespace(ns: string) {
   return function (ns: any) {}
 }
+function since(ns: string) {
+  return function (ns: any) {}
+}
 
 type Uri = string
 type DateString = string

--- a/specification/specs/document/multiple/bulk/BulkRequest.ts
+++ b/specification/specs/document/multiple/bulk/BulkRequest.ts
@@ -22,6 +22,7 @@
  */
 @rest_spec_name('bulk')
 @class_serializer('BulkRequestFormatter')
+@since('0.0.0')
 class BulkRequest<TSource> extends RequestBase {
   path_parts?: {
     index?: IndexName

--- a/specification/specs/document/multiple/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/specs/document/multiple/delete_by_query/DeleteByQueryRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('delete_by_query')
+@since('5.0.0')
 class DeleteByQueryRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/document/multiple/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
+++ b/specification/specs/document/multiple/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('delete_by_query_rethrottle')
+@since('6.5.0')
 class DeleteByQueryRethrottleRequest extends RequestBase {
   path_parts?: {
     task_id: Id

--- a/specification/specs/document/multiple/multi_get/request/MultiGetRequest.ts
+++ b/specification/specs/document/multiple/multi_get/request/MultiGetRequest.ts
@@ -22,6 +22,7 @@
  */
 @rest_spec_name('mget')
 @class_serializer('MultiGetRequestFormatter')
+@since('0.0.0')
 class MultiGetRequest extends RequestBase {
   path_parts?: {
     index?: IndexName

--- a/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorsRequest.ts
+++ b/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('mtermvectors')
+@since('0.0.0')
 class MultiTermVectorsRequest extends RequestBase {
   path_parts?: {
     index?: IndexName

--- a/specification/specs/document/multiple/reindex/ReindexRequest.ts
+++ b/specification/specs/document/multiple/reindex/ReindexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('reindex')
+@since('2.3.0')
 class ReindexRequest extends RequestBase {
   query_parameters?: {
     refresh?: boolean

--- a/specification/specs/document/multiple/reindex_rethrottle/ReindexRethrottleRequest.ts
+++ b/specification/specs/document/multiple/reindex_rethrottle/ReindexRethrottleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('reindex_rethrottle')
+@since('2.4.0')
 class ReindexRethrottleRequest extends RequestBase {
   path_parts?: {
     task_id: Id

--- a/specification/specs/document/multiple/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/specs/document/multiple/update_by_query/UpdateByQueryRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('update_by_query')
+@since('2.4.0')
 class UpdateByQueryRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/document/multiple/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
+++ b/specification/specs/document/multiple/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('update_by_query_rethrottle')
+@since('6.5.0')
 class UpdateByQueryRethrottleRequest extends RequestBase {
   path_parts?: {
     task_id: Id

--- a/specification/specs/document/single/create/CreateRequest.ts
+++ b/specification/specs/document/single/create/CreateRequest.ts
@@ -22,6 +22,7 @@
  */
 @rest_spec_name('create')
 @class_serializer('CreateRequestFormatter`1')
+@since('5.0.0')
 class CreateRequest<TDocument> extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/document/single/delete/DeleteRequest.ts
+++ b/specification/specs/document/single/delete/DeleteRequest.ts
@@ -21,6 +21,7 @@
  * @type_stability stable
  */
 @rest_spec_name('delete')
+@since('0.0.0')
 class DeleteRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/document/single/exists/DocumentExistsRequest.ts
+++ b/specification/specs/document/single/exists/DocumentExistsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('exists')
+@since('0.0.0')
 class DocumentExistsRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/document/single/get/GetRequest.ts
+++ b/specification/specs/document/single/get/GetRequest.ts
@@ -21,6 +21,7 @@
  * @type_stability stable
  */
 @rest_spec_name('get')
+@since('0.0.0')
 class GetRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/document/single/index/IndexRequest.ts
+++ b/specification/specs/document/single/index/IndexRequest.ts
@@ -22,6 +22,7 @@
  */
 @rest_spec_name('index')
 @class_serializer('IndexRequestFormatter`1')
+@since('0.0.0')
 class IndexRequest<TDocument> extends RequestBase {
   path_parts?: {
     id?: Id

--- a/specification/specs/document/single/source/SourceRequest.ts
+++ b/specification/specs/document/single/source/SourceRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('get_source')
+@since('0.0.0')
 class SourceRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/document/single/source_exists/SourceExistsRequest.ts
+++ b/specification/specs/document/single/source_exists/SourceExistsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('exists_source')
+@since('5.4.0')
 class SourceExistsRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/document/single/term_vectors/TermVectorsRequest.ts
+++ b/specification/specs/document/single/term_vectors/TermVectorsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('termvectors')
+@since('0.0.0')
 class TermVectorsRequest<TDocument> extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/document/single/update/UpdateRequest.ts
+++ b/specification/specs/document/single/update/UpdateRequest.ts
@@ -21,6 +21,7 @@
  * @type_stability stable
  */
 @rest_spec_name('update')
+@since('0.0.0')
 class UpdateRequest<TDocument, TPartialDocument> extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/indices/alias_management/alias/BulkAliasRequest.ts
+++ b/specification/specs/indices/alias_management/alias/BulkAliasRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.update_aliases')
+@since('0.0.0')
 class BulkAliasRequest extends RequestBase {
   query_parameters?: {
     master_timeout?: Time

--- a/specification/specs/indices/alias_management/alias_exists/AliasExistsRequest.ts
+++ b/specification/specs/indices/alias_management/alias_exists/AliasExistsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.exists_alias')
+@since('0.0.0')
 class AliasExistsRequest extends RequestBase {
   path_parts?: {
     name: Names

--- a/specification/specs/indices/alias_management/delete_alias/DeleteAliasRequest.ts
+++ b/specification/specs/indices/alias_management/delete_alias/DeleteAliasRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.delete_alias')
+@since('0.0.0')
 class DeleteAliasRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/indices/alias_management/get_alias/GetAliasRequest.ts
+++ b/specification/specs/indices/alias_management/get_alias/GetAliasRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.get_alias')
+@since('0.0.0')
 class GetAliasRequest extends RequestBase {
   path_parts?: {
     name?: Names

--- a/specification/specs/indices/alias_management/put_alias/PutAliasRequest.ts
+++ b/specification/specs/indices/alias_management/put_alias/PutAliasRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.put_alias')
+@since('0.0.0')
 class PutAliasRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/indices/analyze/AnalyzeRequest.ts
+++ b/specification/specs/indices/analyze/AnalyzeRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.analyze')
+@since('0.0.0')
 class AnalyzeRequest extends RequestBase {
   path_parts?: {
     index?: IndexName

--- a/specification/specs/indices/index_management/clone_index/CloneIndexRequest.ts
+++ b/specification/specs/indices/index_management/clone_index/CloneIndexRequest.ts
@@ -21,6 +21,7 @@
  * @type_stability stable
  */
 @rest_spec_name('indices.clone')
+@since('7.4.0')
 class CloneIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/indices/index_management/create_index/CreateIndexRequest.ts
+++ b/specification/specs/indices/index_management/create_index/CreateIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.create')
+@since('0.0.0')
 class CreateIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/indices/index_management/delete_index/DeleteIndexRequest.ts
+++ b/specification/specs/indices/index_management/delete_index/DeleteIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.delete')
+@since('0.0.0')
 class DeleteIndexRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/indices/index_management/freeze_index/FreezeIndexRequest.ts
+++ b/specification/specs/indices/index_management/freeze_index/FreezeIndexRequest.ts
@@ -21,6 +21,7 @@
  * @type_stability stable
  */
 @rest_spec_name('indices.freeze')
+@since('6.6.0')
 class FreezeIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/indices/index_management/get_index/GetIndexRequest.ts
+++ b/specification/specs/indices/index_management/get_index/GetIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.get')
+@since('0.0.0')
 class GetIndexRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/indices/index_management/indices_exists/IndexExistsRequest.ts
+++ b/specification/specs/indices/index_management/indices_exists/IndexExistsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.exists')
+@since('0.0.0')
 class IndexExistsRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/indices/index_management/open_close_index/close_index/CloseIndexRequest.ts
+++ b/specification/specs/indices/index_management/open_close_index/close_index/CloseIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.close')
+@since('0.0.0')
 class CloseIndexRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/indices/index_management/open_close_index/open_index/OpenIndexRequest.ts
+++ b/specification/specs/indices/index_management/open_close_index/open_index/OpenIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.open')
+@since('0.0.0')
 class OpenIndexRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/indices/index_management/rollover_index/RolloverIndexRequest.ts
+++ b/specification/specs/indices/index_management/rollover_index/RolloverIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.rollover')
+@since('5.0.0')
 class RolloverIndexRequest extends RequestBase {
   path_parts?: {
     alias: Alias

--- a/specification/specs/indices/index_management/shrink_index/ShrinkIndexRequest.ts
+++ b/specification/specs/indices/index_management/shrink_index/ShrinkIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.shrink')
+@since('5.0.0')
 class ShrinkIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/indices/index_management/split_index/SplitIndexRequest.ts
+++ b/specification/specs/indices/index_management/split_index/SplitIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.split')
+@since('6.1.0')
 class SplitIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/indices/index_management/types_exists/TypeExistsRequest.ts
+++ b/specification/specs/indices/index_management/types_exists/TypeExistsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.exists_type')
+@since('0.0.0')
 class TypeExistsRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/indices/index_management/unfreeze_index/UnfreezeIndexRequest.ts
+++ b/specification/specs/indices/index_management/unfreeze_index/UnfreezeIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.unfreeze')
+@since('6.6.0')
 class UnfreezeIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/indices/index_settings/get_index_settings/GetIndexSettingsRequest.ts
+++ b/specification/specs/indices/index_settings/get_index_settings/GetIndexSettingsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.get_settings')
+@since('0.0.0')
 class GetIndexSettingsRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/index_settings/index_templates/delete_index_template/DeleteIndexTemplateRequest.ts
+++ b/specification/specs/indices/index_settings/index_templates/delete_index_template/DeleteIndexTemplateRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.delete_template')
+@since('0.0.0')
 class DeleteIndexTemplateRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/indices/index_settings/index_templates/get_index_template/GetIndexTemplateRequest.ts
+++ b/specification/specs/indices/index_settings/index_templates/get_index_template/GetIndexTemplateRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.get_template')
+@since('0.0.0')
 class GetIndexTemplateRequest extends RequestBase {
   path_parts?: {
     name?: Names

--- a/specification/specs/indices/index_settings/index_templates/index_template_exists/IndexTemplateExistsRequest.ts
+++ b/specification/specs/indices/index_settings/index_templates/index_template_exists/IndexTemplateExistsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.exists_template')
+@since('0.0.0')
 class IndexTemplateExistsRequest extends RequestBase {
   path_parts?: {
     name: Names

--- a/specification/specs/indices/index_settings/index_templates/put_index_template/PutIndexTemplateRequest.ts
+++ b/specification/specs/indices/index_settings/index_templates/put_index_template/PutIndexTemplateRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.put_template')
+@since('0.0.0')
 class PutIndexTemplateRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/indices/index_settings/update_index_settings/UpdateIndexSettingsRequest.ts
+++ b/specification/specs/indices/index_settings/update_index_settings/UpdateIndexSettingsRequest.ts
@@ -19,6 +19,7 @@
 
 @rest_spec_name('indices.put_settings')
 @class_serializer('UpdateIndexSettingsRequestFormatter')
+@since('0.0.0')
 class UpdateIndexSettingsRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/mapping_management/get_field_mapping/GetFieldMappingRequest.ts
+++ b/specification/specs/indices/mapping_management/get_field_mapping/GetFieldMappingRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.get_field_mapping')
+@since('0.0.0')
 class GetFieldMappingRequest extends RequestBase {
   path_parts?: {
     fields: Fields

--- a/specification/specs/indices/mapping_management/get_mapping/GetMappingRequest.ts
+++ b/specification/specs/indices/mapping_management/get_mapping/GetMappingRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.get_mapping')
+@since('0.0.0')
 class GetMappingRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/mapping_management/put_mapping/PutMappingRequest.ts
+++ b/specification/specs/indices/mapping_management/put_mapping/PutMappingRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.put_mapping')
+@since('0.0.0')
 class PutMappingRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/monitoring/indices_recovery/RecoveryStatusRequest.ts
+++ b/specification/specs/indices/monitoring/indices_recovery/RecoveryStatusRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.recovery')
+@since('0.0.0')
 class RecoveryStatusRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/monitoring/indices_segments/SegmentsRequest.ts
+++ b/specification/specs/indices/monitoring/indices_segments/SegmentsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.segments')
+@since('0.0.0')
 class SegmentsRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/monitoring/indices_shard_stores/IndicesShardStoresRequest.ts
+++ b/specification/specs/indices/monitoring/indices_shard_stores/IndicesShardStoresRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.shard_stores')
+@since('0.0.0')
 class IndicesShardStoresRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/monitoring/indices_stats/IndicesStatsRequest.ts
+++ b/specification/specs/indices/monitoring/indices_stats/IndicesStatsRequest.ts
@@ -21,6 +21,7 @@
  * @type_stability stable
  */
 @rest_spec_name('indices.stats')
+@since('0.0.0')
 class IndicesStatsRequest extends RequestBase {
   path_parts?: {
     metric?: Metrics

--- a/specification/specs/indices/reload_search_analyzers/ReloadSearchAnalyzersRequest.ts
+++ b/specification/specs/indices/reload_search_analyzers/ReloadSearchAnalyzersRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.reload_search_analyzers')
+@since('7.3.0')
 class ReloadSearchAnalyzersRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/indices/status_management/clear_cache/ClearCacheRequest.ts
+++ b/specification/specs/indices/status_management/clear_cache/ClearCacheRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.clear_cache')
+@since('0.0.0')
 class ClearCacheRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/status_management/flush/FlushRequest.ts
+++ b/specification/specs/indices/status_management/flush/FlushRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.flush')
+@since('0.0.0')
 class FlushRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/status_management/force_merge/ForceMergeRequest.ts
+++ b/specification/specs/indices/status_management/force_merge/ForceMergeRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.forcemerge')
+@since('2.1.0')
 class ForceMergeRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/status_management/refresh/RefreshRequest.ts
+++ b/specification/specs/indices/status_management/refresh/RefreshRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.refresh')
+@since('0.0.0')
 class RefreshRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/indices/status_management/synced_flush/SyncedFlushRequest.ts
+++ b/specification/specs/indices/status_management/synced_flush/SyncedFlushRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.flush_synced')
+@since('0.0.0')
 class SyncedFlushRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/ingest/delete_pipeline/DeletePipelineRequest.ts
+++ b/specification/specs/ingest/delete_pipeline/DeletePipelineRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ingest.delete_pipeline')
+@since('5.0.0')
 class DeletePipelineRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/ingest/get_pipeline/GetPipelineRequest.ts
+++ b/specification/specs/ingest/get_pipeline/GetPipelineRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ingest.get_pipeline')
+@since('5.0.0')
 class GetPipelineRequest extends RequestBase {
   path_parts?: {
     id?: Id

--- a/specification/specs/ingest/processor/GrokProcessorPatternsRequest.ts
+++ b/specification/specs/ingest/processor/GrokProcessorPatternsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ingest.processor_grok')
+@since('6.1.0')
 class GrokProcessorPatternsRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/ingest/put_pipeline/PutPipelineRequest.ts
+++ b/specification/specs/ingest/put_pipeline/PutPipelineRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ingest.put_pipeline')
+@since('5.0.0')
 class PutPipelineRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/ingest/simulate_pipeline/SimulatePipelineRequest.ts
+++ b/specification/specs/ingest/simulate_pipeline/SimulatePipelineRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ingest.simulate')
+@since('5.0.0')
 class SimulatePipelineRequest extends RequestBase {
   path_parts?: {
     id?: Id

--- a/specification/specs/modules/scripting/delete_script/DeleteScriptRequest.ts
+++ b/specification/specs/modules/scripting/delete_script/DeleteScriptRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('delete_script')
+@since('0.0.0')
 class DeleteScriptRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/modules/scripting/execute_painless_script/ExecutePainlessScriptRequest.ts
+++ b/specification/specs/modules/scripting/execute_painless_script/ExecutePainlessScriptRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('scripts_painless_execute')
+@since('6.3.0')
 class ExecutePainlessScriptRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/modules/scripting/get_script/GetScriptRequest.ts
+++ b/specification/specs/modules/scripting/get_script/GetScriptRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('get_script')
+@since('0.0.0')
 class GetScriptRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/modules/scripting/put_script/PutScriptRequest.ts
+++ b/specification/specs/modules/scripting/put_script/PutScriptRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('put_script')
+@since('0.0.0')
 class PutScriptRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/modules/snapshot_and_restore/repositories/cleanup_repository/CleanupRepositoryRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/repositories/cleanup_repository/CleanupRepositoryRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('snapshot.cleanup_repository')
+@since('7.4.0')
 class CleanupRepositoryRequest extends RequestBase {
   path_parts?: {
     repository: Name

--- a/specification/specs/modules/snapshot_and_restore/repositories/create_repository/CreateRepositoryRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/repositories/create_repository/CreateRepositoryRequest.ts
@@ -19,6 +19,7 @@
 
 @rest_spec_name('snapshot.create_repository')
 @class_serializer('CreateRepositoryFormatter')
+@since('0.0.0')
 class CreateRepositoryRequest extends RequestBase {
   path_parts?: {
     repository: Name

--- a/specification/specs/modules/snapshot_and_restore/repositories/delete_repository/DeleteRepositoryRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/repositories/delete_repository/DeleteRepositoryRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('snapshot.delete_repository')
+@since('0.0.0')
 class DeleteRepositoryRequest extends RequestBase {
   path_parts?: {
     repository: Names

--- a/specification/specs/modules/snapshot_and_restore/repositories/get_repository/GetRepositoryRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/repositories/get_repository/GetRepositoryRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('snapshot.get_repository')
+@since('0.0.0')
 class GetRepositoryRequest extends RequestBase {
   path_parts?: {
     repository?: Names

--- a/specification/specs/modules/snapshot_and_restore/repositories/verify_repository/VerifyRepositoryRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/repositories/verify_repository/VerifyRepositoryRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('snapshot.verify_repository')
+@since('0.0.0')
 class VerifyRepositoryRequest extends RequestBase {
   path_parts?: {
     repository: Name

--- a/specification/specs/modules/snapshot_and_restore/restore/RestoreRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/restore/RestoreRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('snapshot.restore')
+@since('0.0.0')
 class RestoreRequest extends RequestBase {
   path_parts?: {
     repository: Name

--- a/specification/specs/modules/snapshot_and_restore/snapshot/delete_snapshot/DeleteSnapshotRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/snapshot/delete_snapshot/DeleteSnapshotRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('snapshot.delete')
+@since('0.0.0')
 class DeleteSnapshotRequest extends RequestBase {
   path_parts?: {
     repository: Name

--- a/specification/specs/modules/snapshot_and_restore/snapshot/get_snapshot/GetSnapshotRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/snapshot/get_snapshot/GetSnapshotRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('snapshot.get')
+@since('0.0.0')
 class GetSnapshotRequest extends RequestBase {
   path_parts?: {
     repository: Name

--- a/specification/specs/modules/snapshot_and_restore/snapshot/snapshot/SnapshotRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/snapshot/snapshot/SnapshotRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('snapshot.create')
+@since('0.0.0')
 class SnapshotRequest extends RequestBase {
   path_parts?: {
     repository: Name

--- a/specification/specs/modules/snapshot_and_restore/snapshot/snapshot_status/SnapshotStatusRequest.ts
+++ b/specification/specs/modules/snapshot_and_restore/snapshot/snapshot_status/SnapshotStatusRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('snapshot.status')
+@since('0.0.0')
 class SnapshotStatusRequest extends RequestBase {
   path_parts?: {
     repository?: Name

--- a/specification/specs/search/count/CountRequest.ts
+++ b/specification/specs/search/count/CountRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('count')
+@since('0.0.0')
 class CountRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/search/explain/ExplainRequest.ts
+++ b/specification/specs/search/explain/ExplainRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('explain')
+@since('0.0.0')
 class ExplainRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/search/field_capabilities/FieldCapabilitiesRequest.ts
+++ b/specification/specs/search/field_capabilities/FieldCapabilitiesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('field_caps')
+@since('5.4.0')
 class FieldCapabilitiesRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/search/multi_search/MultiSearchRequest.ts
+++ b/specification/specs/search/multi_search/MultiSearchRequest.ts
@@ -19,6 +19,7 @@
 
 @rest_spec_name('msearch')
 @class_serializer('MultiSearchFormatter')
+@since('0.0.0')
 class MultiSearchRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/search/multi_search_template/MultiSearchTemplateRequest.ts
+++ b/specification/specs/search/multi_search_template/MultiSearchTemplateRequest.ts
@@ -19,6 +19,7 @@
 
 @rest_spec_name('msearch_template')
 @class_serializer('MultiSearchTemplateFormatter')
+@since('5.0.0')
 class MultiSearchTemplateRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/search/scroll/clear_scroll/ClearScrollRequest.ts
+++ b/specification/specs/search/scroll/clear_scroll/ClearScrollRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('clear_scroll')
+@since('0.0.0')
 class ClearScrollRequest extends RequestBase {
   path_parts?: {
     scroll_id?: Ids

--- a/specification/specs/search/scroll/scroll/ScrollRequest.ts
+++ b/specification/specs/search/scroll/scroll/ScrollRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('scroll')
+@since('0.0.0')
 class ScrollRequest extends RequestBase {
   path_parts?: {
     scroll_id?: Id

--- a/specification/specs/search/search/SearchRequest.ts
+++ b/specification/specs/search/search/SearchRequest.ts
@@ -21,6 +21,7 @@
  * @type_stability stable
  */
 @rest_spec_name('search')
+@since('0.0.0')
 class SearchRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/search/search_shards/SearchShardsRequest.ts
+++ b/specification/specs/search/search_shards/SearchShardsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('search_shards')
+@since('0.0.0')
 class SearchShardsRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/search/search_template/SearchTemplateRequest.ts
+++ b/specification/specs/search/search_template/SearchTemplateRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('search_template')
+@since('0.0.0')
 class SearchTemplateRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/search/search_template/render_search_template/RenderSearchTemplateRequest.ts
+++ b/specification/specs/search/search_template/render_search_template/RenderSearchTemplateRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('render_search_template')
+@since('0.0.0')
 class RenderSearchTemplateRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/search/validate/ValidateQueryRequest.ts
+++ b/specification/specs/search/validate/ValidateQueryRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('indices.validate_query')
+@since('0.0.0')
 class ValidateQueryRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/x_pack/async_search/delete/AsyncSearchDeleteRequest.ts
+++ b/specification/specs/x_pack/async_search/delete/AsyncSearchDeleteRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('async_search.delete')
+@since('7.7.0')
 class AsyncSearchDeleteRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/x_pack/async_search/get/AsyncSearchGetRequest.ts
+++ b/specification/specs/x_pack/async_search/get/AsyncSearchGetRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('async_search.get')
+@since('7.7.0')
 class AsyncSearchGetRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/x_pack/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/specs/x_pack/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('async_search.submit')
+@since('7.7.0')
 class AsyncSearchSubmitRequest extends RequestBase {
   path_parts?: {
     index?: Indices

--- a/specification/specs/x_pack/cross_cluster_replication/auto_follow/create_auto_follow_pattern/CreateAutoFollowPatternRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/auto_follow/create_auto_follow_pattern/CreateAutoFollowPatternRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.put_auto_follow_pattern')
+@since('6.5.0')
 class CreateAutoFollowPatternRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/cross_cluster_replication/auto_follow/delete_auto_follow_pattern/DeleteAutoFollowPatternRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/auto_follow/delete_auto_follow_pattern/DeleteAutoFollowPatternRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.delete_auto_follow_pattern')
+@since('6.5.0')
 class DeleteAutoFollowPatternRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/cross_cluster_replication/auto_follow/get_auto_follow_pattern/GetAutoFollowPatternRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/auto_follow/get_auto_follow_pattern/GetAutoFollowPatternRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.get_auto_follow_pattern')
+@since('6.5.0')
 class GetAutoFollowPatternRequest extends RequestBase {
   path_parts?: {
     name?: Name

--- a/specification/specs/x_pack/cross_cluster_replication/auto_follow/pause_auto_follow_pattern/PauseAutoFollowPatternRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/auto_follow/pause_auto_follow_pattern/PauseAutoFollowPatternRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.pause_auto_follow_pattern')
+@since('7.5.0')
 class PauseAutoFollowPatternRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/cross_cluster_replication/auto_follow/resume_auto_follow_pattern/ResumeAutoFollowPatternRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/auto_follow/resume_auto_follow_pattern/ResumeAutoFollowPatternRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.resume_auto_follow_pattern')
+@since('7.5.0')
 class ResumeAutoFollowPatternRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/cross_cluster_replication/follow/create_follow_index/CreateFollowIndexRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/follow/create_follow_index/CreateFollowIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.follow')
+@since('6.5.0')
 class CreateFollowIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/x_pack/cross_cluster_replication/follow/follow_index_stats/FollowIndexStatsRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/follow/follow_index_stats/FollowIndexStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.follow_stats')
+@since('6.5.0')
 class FollowIndexStatsRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/x_pack/cross_cluster_replication/follow/follow_info/FollowInfoRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/follow/follow_info/FollowInfoRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.follow_info')
+@since('6.7.0')
 class FollowInfoRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/x_pack/cross_cluster_replication/follow/forget_follower_index/ForgetFollowerIndexRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/follow/forget_follower_index/ForgetFollowerIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.forget_follower')
+@since('6.7.0')
 class ForgetFollowerIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/x_pack/cross_cluster_replication/follow/pause_follow_index/PauseFollowIndexRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/follow/pause_follow_index/PauseFollowIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.pause_follow')
+@since('6.5.0')
 class PauseFollowIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/x_pack/cross_cluster_replication/follow/resume_follow_index/ResumeFollowIndexRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/follow/resume_follow_index/ResumeFollowIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.resume_follow')
+@since('6.5.0')
 class ResumeFollowIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/x_pack/cross_cluster_replication/follow/unfollow_index/UnfollowIndexRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/follow/unfollow_index/UnfollowIndexRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.unfollow')
+@since('6.5.0')
 class UnfollowIndexRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/x_pack/cross_cluster_replication/stats/CcrStatsRequest.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/stats/CcrStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ccr.stats')
+@since('6.5.0')
 class CcrStatsRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/enrich/delete_policy/DeleteEnrichPolicyRequest.ts
+++ b/specification/specs/x_pack/enrich/delete_policy/DeleteEnrichPolicyRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('enrich.delete_policy')
+@since('7.5.0')
 class DeleteEnrichPolicyRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/enrich/execute_policy/ExecuteEnrichPolicyRequest.ts
+++ b/specification/specs/x_pack/enrich/execute_policy/ExecuteEnrichPolicyRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('enrich.execute_policy')
+@since('7.5.0')
 class ExecuteEnrichPolicyRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/enrich/get_policy/GetEnrichPolicyRequest.ts
+++ b/specification/specs/x_pack/enrich/get_policy/GetEnrichPolicyRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('enrich.get_policy')
+@since('7.5.0')
 class GetEnrichPolicyRequest extends RequestBase {
   path_parts?: {
     name?: Names

--- a/specification/specs/x_pack/enrich/put_policy/PutEnrichPolicyRequest.ts
+++ b/specification/specs/x_pack/enrich/put_policy/PutEnrichPolicyRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('enrich.put_policy')
+@since('7.5.0')
 class PutEnrichPolicyRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/enrich/stats/EnrichStatsRequest.ts
+++ b/specification/specs/x_pack/enrich/stats/EnrichStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('enrich.stats')
+@since('7.5.0')
 class EnrichStatsRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/graph/explore/GraphExploreRequest.ts
+++ b/specification/specs/x_pack/graph/explore/GraphExploreRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('graph.explore')
+@since('0.0.0')
 class GraphExploreRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/x_pack/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
+++ b/specification/specs/x_pack/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.delete_lifecycle')
+@since('6.6.0')
 class DeleteLifecycleRequest extends RequestBase {
   path_parts?: {
     policy: Name

--- a/specification/specs/x_pack/ilm/explain_lifecycle/ExplainLifecycleRequest.ts
+++ b/specification/specs/x_pack/ilm/explain_lifecycle/ExplainLifecycleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.explain_lifecycle')
+@since('6.6.0')
 class ExplainLifecycleRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/x_pack/ilm/get_lifecycle/GetLifecycleRequest.ts
+++ b/specification/specs/x_pack/ilm/get_lifecycle/GetLifecycleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.get_lifecycle')
+@since('6.6.0')
 class GetLifecycleRequest extends RequestBase {
   path_parts?: {
     policy?: Name

--- a/specification/specs/x_pack/ilm/get_status/GetIlmStatusRequest.ts
+++ b/specification/specs/x_pack/ilm/get_status/GetIlmStatusRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.get_status')
+@since('6.6.0')
 class GetIlmStatusRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/ilm/move_to_step/MoveToStepRequest.ts
+++ b/specification/specs/x_pack/ilm/move_to_step/MoveToStepRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.move_to_step')
+@since('6.6.0')
 class MoveToStepRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/x_pack/ilm/put_lifecycle/PutLifecycleRequest.ts
+++ b/specification/specs/x_pack/ilm/put_lifecycle/PutLifecycleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.put_lifecycle')
+@since('6.6.0')
 class PutLifecycleRequest extends RequestBase {
   path_parts?: {
     policy: Name

--- a/specification/specs/x_pack/ilm/remove_policy/RemovePolicyRequest.ts
+++ b/specification/specs/x_pack/ilm/remove_policy/RemovePolicyRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.remove_policy')
+@since('6.6.0')
 class RemovePolicyRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/x_pack/ilm/retry/RetryIlmRequest.ts
+++ b/specification/specs/x_pack/ilm/retry/RetryIlmRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.retry')
+@since('6.6.0')
 class RetryIlmRequest extends RequestBase {
   path_parts?: {
     index: IndexName

--- a/specification/specs/x_pack/ilm/start/StartIlmRequest.ts
+++ b/specification/specs/x_pack/ilm/start/StartIlmRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.start')
+@since('6.6.0')
 class StartIlmRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/ilm/stop/StopIlmRequest.ts
+++ b/specification/specs/x_pack/ilm/stop/StopIlmRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ilm.stop')
+@since('6.6.0')
 class StopIlmRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/info/x_pack_info/XPackInfoRequest.ts
+++ b/specification/specs/x_pack/info/x_pack_info/XPackInfoRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('xpack.info')
+@since('0.0.0')
 class XPackInfoRequest extends RequestBase {
   query_parameters?: {
     categories?: string[]

--- a/specification/specs/x_pack/info/x_pack_usage/XPackUsageRequest.ts
+++ b/specification/specs/x_pack/info/x_pack_usage/XPackUsageRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('xpack.usage')
+@since('0.0.0')
 class XPackUsageRequest extends RequestBase {
   query_parameters?: {
     master_timeout?: Time

--- a/specification/specs/x_pack/license/delete_license/DeleteLicenseRequest.ts
+++ b/specification/specs/x_pack/license/delete_license/DeleteLicenseRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('license.delete')
+@since('0.0.0')
 class DeleteLicenseRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/license/get_basic_license_status/GetBasicLicenseStatusRequest.ts
+++ b/specification/specs/x_pack/license/get_basic_license_status/GetBasicLicenseStatusRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('license.get_basic_status')
+@since('6.3.0')
 class GetBasicLicenseStatusRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/license/get_license/GetLicenseRequest.ts
+++ b/specification/specs/x_pack/license/get_license/GetLicenseRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('license.get')
+@since('0.0.0')
 class GetLicenseRequest extends RequestBase {
   query_parameters?: {
     accept_enterprise?: boolean

--- a/specification/specs/x_pack/license/get_trial_license_status/GetTrialLicenseStatusRequest.ts
+++ b/specification/specs/x_pack/license/get_trial_license_status/GetTrialLicenseStatusRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('license.get_trial_status')
+@since('6.1.0')
 class GetTrialLicenseStatusRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/license/post_license/PostLicenseRequest.ts
+++ b/specification/specs/x_pack/license/post_license/PostLicenseRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('license.post')
+@since('0.0.0')
 class PostLicenseRequest extends RequestBase {
   query_parameters?: {
     acknowledge?: boolean

--- a/specification/specs/x_pack/license/start_basic_license/StartBasicLicenseRequest.ts
+++ b/specification/specs/x_pack/license/start_basic_license/StartBasicLicenseRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('license.post_start_basic')
+@since('6.3.0')
 class StartBasicLicenseRequest extends RequestBase {
   query_parameters?: {
     acknowledge?: boolean

--- a/specification/specs/x_pack/license/start_trial_license/StartTrialLicenseRequest.ts
+++ b/specification/specs/x_pack/license/start_trial_license/StartTrialLicenseRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('license.post_start_trial')
+@since('6.1.0')
 class StartTrialLicenseRequest extends RequestBase {
   query_parameters?: {
     acknowledge?: boolean

--- a/specification/specs/x_pack/machine_learning/close_job/CloseJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/close_job/CloseJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.close_job')
+@since('5.4.0')
 class CloseJobRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/delete_calendar/DeleteCalendarRequest.ts
+++ b/specification/specs/x_pack/machine_learning/delete_calendar/DeleteCalendarRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.delete_calendar')
+@since('6.2.0')
 class DeleteCalendarRequest extends RequestBase {
   path_parts?: {
     calendar_id: Id

--- a/specification/specs/x_pack/machine_learning/delete_calendar_event/DeleteCalendarEventRequest.ts
+++ b/specification/specs/x_pack/machine_learning/delete_calendar_event/DeleteCalendarEventRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.delete_calendar_event')
+@since('6.2.0')
 class DeleteCalendarEventRequest extends RequestBase {
   path_parts?: {
     calendar_id: Id

--- a/specification/specs/x_pack/machine_learning/delete_calendar_job/DeleteCalendarJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/delete_calendar_job/DeleteCalendarJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.delete_calendar_job')
+@since('6.2.0')
 class DeleteCalendarJobRequest extends RequestBase {
   path_parts?: {
     calendar_id: Id

--- a/specification/specs/x_pack/machine_learning/delete_datafeed/DeleteDatafeedRequest.ts
+++ b/specification/specs/x_pack/machine_learning/delete_datafeed/DeleteDatafeedRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.delete_datafeed')
+@since('5.4.0')
 class DeleteDatafeedRequest extends RequestBase {
   path_parts?: {
     datafeed_id: Id

--- a/specification/specs/x_pack/machine_learning/delete_expired_data/DeleteExpiredDataRequest.ts
+++ b/specification/specs/x_pack/machine_learning/delete_expired_data/DeleteExpiredDataRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.delete_expired_data')
+@since('5.4.0')
 class DeleteExpiredDataRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/machine_learning/delete_filter/DeleteFilterRequest.ts
+++ b/specification/specs/x_pack/machine_learning/delete_filter/DeleteFilterRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.delete_filter')
+@since('5.4.0')
 class DeleteFilterRequest extends RequestBase {
   path_parts?: {
     filter_id: Id

--- a/specification/specs/x_pack/machine_learning/delete_forecast/DeleteForecastRequest.ts
+++ b/specification/specs/x_pack/machine_learning/delete_forecast/DeleteForecastRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.delete_forecast')
+@since('6.5.0')
 class DeleteForecastRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/delete_job/DeleteJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/delete_job/DeleteJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.delete_job')
+@since('5.4.0')
 class DeleteJobRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/delete_model_snapshot/DeleteModelSnapshotRequest.ts
+++ b/specification/specs/x_pack/machine_learning/delete_model_snapshot/DeleteModelSnapshotRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.delete_model_snapshot')
+@since('5.4.0')
 class DeleteModelSnapshotRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/estimate_model_memory/EstimateModelMemoryRequest.ts
+++ b/specification/specs/x_pack/machine_learning/estimate_model_memory/EstimateModelMemoryRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.estimate_model_memory')
+@since('7.7.0')
 class EstimateModelMemoryRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/x_pack/machine_learning/flush_job/FlushJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/flush_job/FlushJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.flush_job')
+@since('5.4.0')
 class FlushJobRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/forecast_job/ForecastJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/forecast_job/ForecastJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.forecast')
+@since('6.1.0')
 class ForecastJobRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/get_anomaly_records/GetAnomalyRecordsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_anomaly_records/GetAnomalyRecordsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_records')
+@since('5.4.0')
 class GetAnomalyRecordsRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/get_buckets/GetBucketsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_buckets/GetBucketsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_buckets')
+@since('5.4.0')
 class GetBucketsRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/get_calendar_events/GetCalendarEventsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_calendar_events/GetCalendarEventsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_calendar_events')
+@since('6.2.0')
 class GetCalendarEventsRequest extends RequestBase {
   path_parts?: {
     calendar_id: Id

--- a/specification/specs/x_pack/machine_learning/get_calendars/GetCalendarsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_calendars/GetCalendarsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_calendars')
+@since('6.2.0')
 class GetCalendarsRequest extends RequestBase {
   path_parts?: {
     calendar_id?: Id

--- a/specification/specs/x_pack/machine_learning/get_categories/GetCategoriesRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_categories/GetCategoriesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_categories')
+@since('5.4.0')
 class GetCategoriesRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/get_datafeed_stats/GetDatafeedStatsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_datafeed_stats/GetDatafeedStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_datafeed_stats')
+@since('5.4.0')
 class GetDatafeedStatsRequest extends RequestBase {
   path_parts?: {
     datafeed_id?: Id

--- a/specification/specs/x_pack/machine_learning/get_datafeeds/GetDatafeedsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_datafeeds/GetDatafeedsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_datafeeds')
+@since('5.4.0')
 class GetDatafeedsRequest extends RequestBase {
   path_parts?: {
     datafeed_id?: Id

--- a/specification/specs/x_pack/machine_learning/get_filters/GetFiltersRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_filters/GetFiltersRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_filters')
+@since('5.4.0')
 class GetFiltersRequest extends RequestBase {
   path_parts?: {
     filter_id?: Id

--- a/specification/specs/x_pack/machine_learning/get_influencers/GetInfluencersRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_influencers/GetInfluencersRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_influencers')
+@since('5.4.0')
 class GetInfluencersRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/get_job_stats/GetJobStatsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_job_stats/GetJobStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_job_stats')
+@since('5.4.0')
 class GetJobStatsRequest extends RequestBase {
   path_parts?: {
     job_id?: Id

--- a/specification/specs/x_pack/machine_learning/get_jobs/GetJobsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_jobs/GetJobsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_jobs')
+@since('5.4.0')
 class GetJobsRequest extends RequestBase {
   path_parts?: {
     job_id?: Id

--- a/specification/specs/x_pack/machine_learning/get_model_snapshots/GetModelSnapshotsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_model_snapshots/GetModelSnapshotsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_model_snapshots')
+@since('5.4.0')
 class GetModelSnapshotsRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/get_overall_buckets/GetOverallBucketsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_overall_buckets/GetOverallBucketsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.get_overall_buckets')
+@since('6.1.0')
 class GetOverallBucketsRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/machine_learning_info/MachineLearningInfoRequest.ts
+++ b/specification/specs/x_pack/machine_learning/machine_learning_info/MachineLearningInfoRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.info')
+@since('6.3.0')
 class MachineLearningInfoRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/machine_learning/open_job/OpenJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/open_job/OpenJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.open_job')
+@since('5.4.0')
 class OpenJobRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/post_calendar_events/PostCalendarEventsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/post_calendar_events/PostCalendarEventsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.post_calendar_events')
+@since('6.2.0')
 class PostCalendarEventsRequest extends RequestBase {
   path_parts?: {
     calendar_id: Id

--- a/specification/specs/x_pack/machine_learning/post_job_data/PostJobDataRequest.ts
+++ b/specification/specs/x_pack/machine_learning/post_job_data/PostJobDataRequest.ts
@@ -19,6 +19,7 @@
 
 @rest_spec_name('ml.post_data')
 @class_serializer('PostJobDataFormatter')
+@since('5.4.0')
 class PostJobDataRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/preview_datafeed/PreviewDatafeedRequest.ts
+++ b/specification/specs/x_pack/machine_learning/preview_datafeed/PreviewDatafeedRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.preview_datafeed')
+@since('5.4.0')
 class PreviewDatafeedRequest extends RequestBase {
   path_parts?: {
     datafeed_id: Id

--- a/specification/specs/x_pack/machine_learning/put_calendar/PutCalendarRequest.ts
+++ b/specification/specs/x_pack/machine_learning/put_calendar/PutCalendarRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.put_calendar')
+@since('6.2.0')
 class PutCalendarRequest extends RequestBase {
   path_parts?: {
     calendar_id: Id

--- a/specification/specs/x_pack/machine_learning/put_calendar_job/PutCalendarJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/put_calendar_job/PutCalendarJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.put_calendar_job')
+@since('6.2.0')
 class PutCalendarJobRequest extends RequestBase {
   path_parts?: {
     calendar_id: Id

--- a/specification/specs/x_pack/machine_learning/put_datafeed/PutDatafeedRequest.ts
+++ b/specification/specs/x_pack/machine_learning/put_datafeed/PutDatafeedRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.put_datafeed')
+@since('5.4.0')
 class PutDatafeedRequest extends RequestBase {
   path_parts?: {
     datafeed_id: Id

--- a/specification/specs/x_pack/machine_learning/put_filter/PutFilterRequest.ts
+++ b/specification/specs/x_pack/machine_learning/put_filter/PutFilterRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.put_filter')
+@since('5.4.0')
 class PutFilterRequest extends RequestBase {
   path_parts?: {
     filter_id: Id

--- a/specification/specs/x_pack/machine_learning/put_job/PutJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/put_job/PutJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.put_job')
+@since('5.4.0')
 class PutJobRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/revert_model_snapshot/RevertModelSnapshotRequest.ts
+++ b/specification/specs/x_pack/machine_learning/revert_model_snapshot/RevertModelSnapshotRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.revert_model_snapshot')
+@since('5.4.0')
 class RevertModelSnapshotRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/set_upgrade_mode/SetUpgradeModeRequest.ts
+++ b/specification/specs/x_pack/machine_learning/set_upgrade_mode/SetUpgradeModeRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.set_upgrade_mode')
+@since('6.7.0')
 class SetUpgradeModeRequest extends RequestBase {
   query_parameters?: {
     enabled?: boolean

--- a/specification/specs/x_pack/machine_learning/start_datafeed/StartDatafeedRequest.ts
+++ b/specification/specs/x_pack/machine_learning/start_datafeed/StartDatafeedRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.start_datafeed')
+@since('5.4.0')
 class StartDatafeedRequest extends RequestBase {
   path_parts?: {
     datafeed_id: Id

--- a/specification/specs/x_pack/machine_learning/stop_datafeed/StopDatafeedRequest.ts
+++ b/specification/specs/x_pack/machine_learning/stop_datafeed/StopDatafeedRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.stop_datafeed')
+@since('5.4.0')
 class StopDatafeedRequest extends RequestBase {
   path_parts?: {
     datafeed_id: Id

--- a/specification/specs/x_pack/machine_learning/update_data_feed/UpdateDatafeedRequest.ts
+++ b/specification/specs/x_pack/machine_learning/update_data_feed/UpdateDatafeedRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.update_datafeed')
+@since('5.4.0')
 class UpdateDatafeedRequest extends RequestBase {
   path_parts?: {
     datafeed_id: Id

--- a/specification/specs/x_pack/machine_learning/update_filter/UpdateFilterRequest.ts
+++ b/specification/specs/x_pack/machine_learning/update_filter/UpdateFilterRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.update_filter')
+@since('6.4.0')
 class UpdateFilterRequest extends RequestBase {
   path_parts?: {
     filter_id: Id

--- a/specification/specs/x_pack/machine_learning/update_job/UpdateJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/update_job/UpdateJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.update_job')
+@since('5.4.0')
 class UpdateJobRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/update_model_snapshot/UpdateModelSnapshotRequest.ts
+++ b/specification/specs/x_pack/machine_learning/update_model_snapshot/UpdateModelSnapshotRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.update_model_snapshot')
+@since('5.4.0')
 class UpdateModelSnapshotRequest extends RequestBase {
   path_parts?: {
     job_id: Id

--- a/specification/specs/x_pack/machine_learning/validate_detector/ValidateDetectorRequest.ts
+++ b/specification/specs/x_pack/machine_learning/validate_detector/ValidateDetectorRequest.ts
@@ -19,6 +19,7 @@
 
 @rest_spec_name('ml.validate_detector')
 @class_serializer('ValidateDetectorRequestFormatter')
+@since('5.4.0')
 class ValidateDetectorRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/x_pack/machine_learning/validate_job/ValidateJobRequest.ts
+++ b/specification/specs/x_pack/machine_learning/validate_job/ValidateJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ml.validate')
+@since('5.4.0')
 class ValidateJobRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/x_pack/migration/deprecation_info/DeprecationInfoRequest.ts
+++ b/specification/specs/x_pack/migration/deprecation_info/DeprecationInfoRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('migration.deprecations')
+@since('6.1.0')
 class DeprecationInfoRequest extends RequestBase {
   path_parts?: {
     index?: IndexName

--- a/specification/specs/x_pack/roll_up/create_rollup_job/CreateRollupJobRequest.ts
+++ b/specification/specs/x_pack/roll_up/create_rollup_job/CreateRollupJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('rollup.put_job')
+@since('6.3.0')
 class CreateRollupJobRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/x_pack/roll_up/delete_rollup_job/DeleteRollupJobRequest.ts
+++ b/specification/specs/x_pack/roll_up/delete_rollup_job/DeleteRollupJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('rollup.delete_job')
+@since('6.3.0')
 class DeleteRollupJobRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/x_pack/roll_up/get_rollup_capabilities/GetRollupCapabilitiesRequest.ts
+++ b/specification/specs/x_pack/roll_up/get_rollup_capabilities/GetRollupCapabilitiesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('rollup.get_rollup_caps')
+@since('6.3.0')
 class GetRollupCapabilitiesRequest extends RequestBase {
   path_parts?: {
     id?: Id

--- a/specification/specs/x_pack/roll_up/get_rollup_index_capabilities/GetRollupIndexCapabilitiesRequest.ts
+++ b/specification/specs/x_pack/roll_up/get_rollup_index_capabilities/GetRollupIndexCapabilitiesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('rollup.get_rollup_index_caps')
+@since('6.4.0')
 class GetRollupIndexCapabilitiesRequest extends RequestBase {
   path_parts?: {
     index: Id

--- a/specification/specs/x_pack/roll_up/get_rollup_job/GetRollupJobRequest.ts
+++ b/specification/specs/x_pack/roll_up/get_rollup_job/GetRollupJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('rollup.get_jobs')
+@since('6.3.0')
 class GetRollupJobRequest extends RequestBase {
   path_parts?: {
     id?: Id

--- a/specification/specs/x_pack/roll_up/rollup_search/RollupSearchRequest.ts
+++ b/specification/specs/x_pack/roll_up/rollup_search/RollupSearchRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('rollup.rollup_search')
+@since('6.3.0')
 class RollupSearchRequest extends RequestBase {
   path_parts?: {
     index: Indices

--- a/specification/specs/x_pack/roll_up/start_rollup_job/StartRollupJobRequest.ts
+++ b/specification/specs/x_pack/roll_up/start_rollup_job/StartRollupJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('rollup.start_job')
+@since('6.3.0')
 class StartRollupJobRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/x_pack/roll_up/stop_rollup_job/StopRollupJobRequest.ts
+++ b/specification/specs/x_pack/roll_up/stop_rollup_job/StopRollupJobRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('rollup.stop_job')
+@since('6.3.0')
 class StopRollupJobRequest extends RequestBase {
   path_parts?: {
     id: Id

--- a/specification/specs/x_pack/security/api_key/create_api_key/CreateApiKeyRequest.ts
+++ b/specification/specs/x_pack/security/api_key/create_api_key/CreateApiKeyRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.create_api_key')
+@since('6.7.0')
 class CreateApiKeyRequest extends RequestBase {
   query_parameters?: {
     refresh?: Refresh

--- a/specification/specs/x_pack/security/api_key/get_api_key/GetApiKeyRequest.ts
+++ b/specification/specs/x_pack/security/api_key/get_api_key/GetApiKeyRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.get_api_key')
+@since('6.7.0')
 class GetApiKeyRequest extends RequestBase {
   query_parameters?: {
     id?: string

--- a/specification/specs/x_pack/security/api_key/invalidate_api_key/InvalidateApiKeyRequest.ts
+++ b/specification/specs/x_pack/security/api_key/invalidate_api_key/InvalidateApiKeyRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.invalidate_api_key')
+@since('6.7.0')
 class InvalidateApiKeyRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/x_pack/security/authenticate/AuthenticateRequest.ts
+++ b/specification/specs/x_pack/security/authenticate/AuthenticateRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.authenticate')
+@since('0.0.0')
 class AuthenticateRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/security/clear_cached_realms/ClearCachedRealmsRequest.ts
+++ b/specification/specs/x_pack/security/clear_cached_realms/ClearCachedRealmsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.clear_cached_realms')
+@since('0.0.0')
 class ClearCachedRealmsRequest extends RequestBase {
   path_parts?: {
     realms: Names

--- a/specification/specs/x_pack/security/privileges/delete_privileges/DeletePrivilegesRequest.ts
+++ b/specification/specs/x_pack/security/privileges/delete_privileges/DeletePrivilegesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.delete_privileges')
+@since('6.4.0')
 class DeletePrivilegesRequest extends RequestBase {
   path_parts?: {
     application: Name

--- a/specification/specs/x_pack/security/privileges/get_builtin_privileges/GetBuiltinPrivilegesRequest.ts
+++ b/specification/specs/x_pack/security/privileges/get_builtin_privileges/GetBuiltinPrivilegesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.get_builtin_privileges')
+@since('7.3.0')
 class GetBuiltinPrivilegesRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/security/privileges/get_privileges/GetPrivilegesRequest.ts
+++ b/specification/specs/x_pack/security/privileges/get_privileges/GetPrivilegesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.get_privileges')
+@since('6.4.0')
 class GetPrivilegesRequest extends RequestBase {
   path_parts?: {
     application?: Name

--- a/specification/specs/x_pack/security/privileges/get_user_privileges/GetUserPrivilegesRequest.ts
+++ b/specification/specs/x_pack/security/privileges/get_user_privileges/GetUserPrivilegesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.get_user_privileges')
+@since('6.5.0')
 class GetUserPrivilegesRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/security/privileges/has_privileges/HasPrivilegesRequest.ts
+++ b/specification/specs/x_pack/security/privileges/has_privileges/HasPrivilegesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.has_privileges')
+@since('6.4.0')
 class HasPrivilegesRequest extends RequestBase {
   path_parts?: {
     user?: Name

--- a/specification/specs/x_pack/security/privileges/put_privileges/PutPrivilegesRequest.ts
+++ b/specification/specs/x_pack/security/privileges/put_privileges/PutPrivilegesRequest.ts
@@ -19,6 +19,7 @@
 
 @rest_spec_name('security.put_privileges')
 @class_serializer('PutPrivilegesFormatter')
+@since('6.4.0')
 class PutPrivilegesRequest extends RequestBase {
   query_parameters?: {
     refresh?: Refresh

--- a/specification/specs/x_pack/security/role/clear_cached_roles/ClearCachedRolesRequest.ts
+++ b/specification/specs/x_pack/security/role/clear_cached_roles/ClearCachedRolesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.clear_cached_roles')
+@since('0.0.0')
 class ClearCachedRolesRequest extends RequestBase {
   path_parts?: {
     name: Names

--- a/specification/specs/x_pack/security/role/delete_role/DeleteRoleRequest.ts
+++ b/specification/specs/x_pack/security/role/delete_role/DeleteRoleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.delete_role')
+@since('0.0.0')
 class DeleteRoleRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/security/role/get_role/GetRoleRequest.ts
+++ b/specification/specs/x_pack/security/role/get_role/GetRoleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.get_role')
+@since('0.0.0')
 class GetRoleRequest extends RequestBase {
   path_parts?: {
     name?: Name

--- a/specification/specs/x_pack/security/role/put_role/PutRoleRequest.ts
+++ b/specification/specs/x_pack/security/role/put_role/PutRoleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.put_role')
+@since('0.0.0')
 class PutRoleRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/security/role_mapping/delete_role_mapping/DeleteRoleMappingRequest.ts
+++ b/specification/specs/x_pack/security/role_mapping/delete_role_mapping/DeleteRoleMappingRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.delete_role_mapping')
+@since('5.5.0')
 class DeleteRoleMappingRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/security/role_mapping/get_role_mapping/GetRoleMappingRequest.ts
+++ b/specification/specs/x_pack/security/role_mapping/get_role_mapping/GetRoleMappingRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.get_role_mapping')
+@since('5.5.0')
 class GetRoleMappingRequest extends RequestBase {
   path_parts?: {
     name?: Name

--- a/specification/specs/x_pack/security/role_mapping/put_role_mapping/PutRoleMappingRequest.ts
+++ b/specification/specs/x_pack/security/role_mapping/put_role_mapping/PutRoleMappingRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.put_role_mapping')
+@since('5.5.0')
 class PutRoleMappingRequest extends RequestBase {
   path_parts?: {
     name: Name

--- a/specification/specs/x_pack/security/user/change_password/ChangePasswordRequest.ts
+++ b/specification/specs/x_pack/security/user/change_password/ChangePasswordRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.change_password')
+@since('0.0.0')
 class ChangePasswordRequest extends RequestBase {
   path_parts?: {
     username?: Name

--- a/specification/specs/x_pack/security/user/delete_user/DeleteUserRequest.ts
+++ b/specification/specs/x_pack/security/user/delete_user/DeleteUserRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.delete_user')
+@since('0.0.0')
 class DeleteUserRequest extends RequestBase {
   path_parts?: {
     username: Name

--- a/specification/specs/x_pack/security/user/disable_user/DisableUserRequest.ts
+++ b/specification/specs/x_pack/security/user/disable_user/DisableUserRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.disable_user')
+@since('0.0.0')
 class DisableUserRequest extends RequestBase {
   path_parts?: {
     username: Name

--- a/specification/specs/x_pack/security/user/enable_user/EnableUserRequest.ts
+++ b/specification/specs/x_pack/security/user/enable_user/EnableUserRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.enable_user')
+@since('0.0.0')
 class EnableUserRequest extends RequestBase {
   path_parts?: {
     username: Name

--- a/specification/specs/x_pack/security/user/get_user/GetUserRequest.ts
+++ b/specification/specs/x_pack/security/user/get_user/GetUserRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.get_user')
+@since('0.0.0')
 class GetUserRequest extends RequestBase {
   path_parts?: {
     username?: Names

--- a/specification/specs/x_pack/security/user/get_user_access_token/GetUserAccessTokenRequest.ts
+++ b/specification/specs/x_pack/security/user/get_user_access_token/GetUserAccessTokenRequest.ts
@@ -20,6 +20,7 @@
 // TODO: once the compiler can handle it, the body should use the commented classes in this file
 
 @rest_spec_name('security.get_token')
+@since('5.5.0')
 class GetUserAccessTokenRequest extends RequestBase {
   query_parameters?: {}
   // body: AccessTokenGrantTypePassword | AccessTokenGrantTypeClientCredentials | AccessTokenGrantTypeKerberos | AccessTokenGrantTypeRefresh

--- a/specification/specs/x_pack/security/user/invalidate_user_access_token/InvalidateUserAccessTokenRequest.ts
+++ b/specification/specs/x_pack/security/user/invalidate_user_access_token/InvalidateUserAccessTokenRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.invalidate_token')
+@since('5.5.0')
 class InvalidateUserAccessTokenRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/x_pack/security/user/put_user/PutUserRequest.ts
+++ b/specification/specs/x_pack/security/user/put_user/PutUserRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('security.put_user')
+@since('0.0.0')
 class PutUserRequest extends RequestBase {
   path_parts?: {
     username: Name

--- a/specification/specs/x_pack/slm/delete_lifecycle/DeleteSnapshotLifecycleRequest.ts
+++ b/specification/specs/x_pack/slm/delete_lifecycle/DeleteSnapshotLifecycleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('slm.delete_lifecycle')
+@since('7.4.0')
 class DeleteSnapshotLifecycleRequest extends RequestBase {
   path_parts?: {
     policy_id: Name

--- a/specification/specs/x_pack/slm/execute_lifecycle/ExecuteSnapshotLifecycleRequest.ts
+++ b/specification/specs/x_pack/slm/execute_lifecycle/ExecuteSnapshotLifecycleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('slm.execute_lifecycle')
+@since('7.4.0')
 class ExecuteSnapshotLifecycleRequest extends RequestBase {
   path_parts?: {
     policy_id: Name

--- a/specification/specs/x_pack/slm/execute_retention/ExecuteRetentionRequest.ts
+++ b/specification/specs/x_pack/slm/execute_retention/ExecuteRetentionRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('slm.execute_retention')
+@since('7.5.0')
 class ExecuteRetentionRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/slm/get_lifecycle/GetSnapshotLifecycleRequest.ts
+++ b/specification/specs/x_pack/slm/get_lifecycle/GetSnapshotLifecycleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('slm.get_lifecycle')
+@since('7.4.0')
 class GetSnapshotLifecycleRequest extends RequestBase {
   path_parts?: {
     policy_id?: Names

--- a/specification/specs/x_pack/slm/get_stats/GetSnapshotLifecycleStatsRequest.ts
+++ b/specification/specs/x_pack/slm/get_stats/GetSnapshotLifecycleStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('slm.get_stats')
+@since('7.5.0')
 class GetSnapshotLifecycleStatsRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/slm/get_status/GetSnapshotLifecycleManagementStatusRequest.ts
+++ b/specification/specs/x_pack/slm/get_status/GetSnapshotLifecycleManagementStatusRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('slm.get_status')
+@since('7.6.0')
 class GetSnapshotLifecycleManagementStatusRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/slm/put_lifecycle/PutSnapshotLifecycleRequest.ts
+++ b/specification/specs/x_pack/slm/put_lifecycle/PutSnapshotLifecycleRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('slm.put_lifecycle')
+@since('7.4.0')
 class PutSnapshotLifecycleRequest extends RequestBase {
   path_parts?: {
     policy_id: Name

--- a/specification/specs/x_pack/slm/start/StartSnapshotLifecycleManagementRequest.ts
+++ b/specification/specs/x_pack/slm/start/StartSnapshotLifecycleManagementRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('slm.start')
+@since('7.6.0')
 class StartSnapshotLifecycleManagementRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/slm/stop/StopSnapshotLifecycleManagementRequest.ts
+++ b/specification/specs/x_pack/slm/stop/StopSnapshotLifecycleManagementRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('slm.stop')
+@since('7.6.0')
 class StopSnapshotLifecycleManagementRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/sql/clear_sql_cursor/ClearSqlCursorRequest.ts
+++ b/specification/specs/x_pack/sql/clear_sql_cursor/ClearSqlCursorRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('sql.clear_cursor')
+@since('6.3.0')
 class ClearSqlCursorRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/x_pack/sql/query_sql/QuerySqlRequest.ts
+++ b/specification/specs/x_pack/sql/query_sql/QuerySqlRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('sql.query')
+@since('6.3.0')
 class QuerySqlRequest extends RequestBase {
   query_parameters?: {
     format?: string

--- a/specification/specs/x_pack/sql/translate_sql/TranslateSqlRequest.ts
+++ b/specification/specs/x_pack/sql/translate_sql/TranslateSqlRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('sql.translate')
+@since('6.3.0')
 class TranslateSqlRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/x_pack/ssl/get_certificates/GetCertificatesRequest.ts
+++ b/specification/specs/x_pack/ssl/get_certificates/GetCertificatesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('ssl.certificates')
+@since('6.2.0')
 class GetCertificatesRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/transform/delete_transform/DeleteTransformRequest.ts
+++ b/specification/specs/x_pack/transform/delete_transform/DeleteTransformRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('transform.delete_transform')
+@since('7.5.0')
 class DeleteTransformRequest extends RequestBase {
   path_parts?: {
     transform_id: Name

--- a/specification/specs/x_pack/transform/get_transform/GetTransformRequest.ts
+++ b/specification/specs/x_pack/transform/get_transform/GetTransformRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('transform.get_transform')
+@since('7.5.0')
 class GetTransformRequest extends RequestBase {
   path_parts?: {
     transform_id?: Name

--- a/specification/specs/x_pack/transform/get_transform_stats/GetTransformStatsRequest.ts
+++ b/specification/specs/x_pack/transform/get_transform_stats/GetTransformStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('transform.get_transform_stats')
+@since('7.5.0')
 class GetTransformStatsRequest extends RequestBase {
   path_parts?: {
     transform_id: Name

--- a/specification/specs/x_pack/transform/preview_transform/PreviewTransformRequest.ts
+++ b/specification/specs/x_pack/transform/preview_transform/PreviewTransformRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('transform.preview_transform')
+@since('7.5.0')
 class PreviewTransformRequest extends RequestBase {
   query_parameters?: {}
   body?: {

--- a/specification/specs/x_pack/transform/put_transform/PutTransformRequest.ts
+++ b/specification/specs/x_pack/transform/put_transform/PutTransformRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('transform.put_transform')
+@since('7.5.0')
 class PutTransformRequest extends RequestBase {
   path_parts?: {
     transform_id: Name

--- a/specification/specs/x_pack/transform/start_transform/StartTransformRequest.ts
+++ b/specification/specs/x_pack/transform/start_transform/StartTransformRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('transform.start_transform')
+@since('7.5.0')
 class StartTransformRequest extends RequestBase {
   path_parts?: {
     transform_id: Name

--- a/specification/specs/x_pack/transform/stop_transform/StopTransformRequest.ts
+++ b/specification/specs/x_pack/transform/stop_transform/StopTransformRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('transform.stop_transform')
+@since('7.5.0')
 class StopTransformRequest extends RequestBase {
   path_parts?: {
     transform_id: Name

--- a/specification/specs/x_pack/transform/update_transform/UpdateTransformRequest.ts
+++ b/specification/specs/x_pack/transform/update_transform/UpdateTransformRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('transform.update_transform')
+@since('7.5.0')
 class UpdateTransformRequest extends RequestBase {
   path_parts?: {
     transform_id: Name

--- a/specification/specs/x_pack/watcher/acknowledge_watch/AcknowledgeWatchRequest.ts
+++ b/specification/specs/x_pack/watcher/acknowledge_watch/AcknowledgeWatchRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.ack_watch')
+@since('0.0.0')
 class AcknowledgeWatchRequest extends RequestBase {
   path_parts?: {
     watch_id: Name

--- a/specification/specs/x_pack/watcher/activate_watch/ActivateWatchRequest.ts
+++ b/specification/specs/x_pack/watcher/activate_watch/ActivateWatchRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.activate_watch')
+@since('0.0.0')
 class ActivateWatchRequest extends RequestBase {
   path_parts?: {
     watch_id: Name

--- a/specification/specs/x_pack/watcher/deactivate_watch/DeactivateWatchRequest.ts
+++ b/specification/specs/x_pack/watcher/deactivate_watch/DeactivateWatchRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.deactivate_watch')
+@since('0.0.0')
 class DeactivateWatchRequest extends RequestBase {
   path_parts?: {
     watch_id: Name

--- a/specification/specs/x_pack/watcher/delete_watch/DeleteWatchRequest.ts
+++ b/specification/specs/x_pack/watcher/delete_watch/DeleteWatchRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.delete_watch')
+@since('0.0.0')
 class DeleteWatchRequest extends RequestBase {
   path_parts?: {
     id: Name

--- a/specification/specs/x_pack/watcher/execute_watch/ExecuteWatchRequest.ts
+++ b/specification/specs/x_pack/watcher/execute_watch/ExecuteWatchRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.execute_watch')
+@since('0.0.0')
 class ExecuteWatchRequest extends RequestBase {
   path_parts?: {
     id?: Name

--- a/specification/specs/x_pack/watcher/get_watch/GetWatchRequest.ts
+++ b/specification/specs/x_pack/watcher/get_watch/GetWatchRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.get_watch')
+@since('0.0.0')
 class GetWatchRequest extends RequestBase {
   path_parts?: {
     id: Name

--- a/specification/specs/x_pack/watcher/put_watch/PutWatchRequest.ts
+++ b/specification/specs/x_pack/watcher/put_watch/PutWatchRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.put_watch')
+@since('0.0.0')
 class PutWatchRequest extends RequestBase {
   path_parts?: {
     id: Name

--- a/specification/specs/x_pack/watcher/start_watcher/StartWatcherRequest.ts
+++ b/specification/specs/x_pack/watcher/start_watcher/StartWatcherRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.start')
+@since('0.0.0')
 class StartWatcherRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/watcher/stop_watcher/StopWatcherRequest.ts
+++ b/specification/specs/x_pack/watcher/stop_watcher/StopWatcherRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.stop')
+@since('0.0.0')
 class StopWatcherRequest extends RequestBase {
   query_parameters?: {}
   body?: {}

--- a/specification/specs/x_pack/watcher/watcher_stats/WatcherStatsRequest.ts
+++ b/specification/specs/x_pack/watcher/watcher_stats/WatcherStatsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 @rest_spec_name('watcher.stats')
+@since('0.0.0')
 class WatcherStatsRequest extends RequestBase {
   path_parts?: {
     metric?: Metrics


### PR DESCRIPTION
This pr adds a new decorator named `since`. Its value describes when an API has been added to Elasticsearch. The compiler will check if is a valid semver value and add it to the JSON model.

I've used an internal script to generate the first round of `since` values, if I wasn't able to get the value, the default value will be `0.0.0`.

Closes: https://github.com/elastic/elastic-client-generator/issues/8