### PR TITLE
Cleanup of Type & Types

### DIFF
--- a/output/dangling-types/dangling.csv
+++ b/output/dangling-types/dangling.csv
@@ -2,6 +2,7 @@ TimeSpan,common.ts
 short,common.ts
 ScrollIds,common.ts
 ActionIds,common.ts
+TypeName,common.ts
 TypeNames,common.ts
 LongId,common.ts
 IndexMetrics,common.ts

--- a/output/dangling-types/dangling.csv
+++ b/output/dangling-types/dangling.csv
@@ -2,7 +2,7 @@ TimeSpan,common.ts
 short,common.ts
 ScrollIds,common.ts
 ActionIds,common.ts
-Types,common.ts
+TypeNames,common.ts
 LongId,common.ts
 IndexMetrics,common.ts
 Timestamp,common.ts

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -30962,7 +30962,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -34970,7 +34970,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -48707,7 +48707,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -49916,7 +49916,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -52935,7 +52935,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -58571,7 +58571,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -66922,7 +66922,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -67111,7 +67111,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -88450,7 +88450,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -89633,7 +89633,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -106083,6 +106083,20 @@
       ]
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "Type",
+        "namespace": "internal"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "string",
+          "namespace": "internal"
+        }
+      }
+    },
+    {
       "annotations": {
         "stability": "TODO"
       },
@@ -106122,7 +106136,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -106532,7 +106546,7 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Type",
               "namespace": "internal"
             }
           },
@@ -106541,7 +106555,7 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
+                "name": "Type",
                 "namespace": "internal"
               }
             }
@@ -107007,7 +107021,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }
@@ -109673,7 +109687,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeNames",
+              "name": "Types",
               "namespace": "internal"
             }
           }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -16643,7 +16643,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -32100,7 +32100,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -36832,7 +36832,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -38763,7 +38763,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -41798,7 +41798,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -50652,7 +50652,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -54774,7 +54774,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -57082,7 +57082,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -66221,7 +66221,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -66337,7 +66337,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -66440,7 +66440,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -67417,7 +67417,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -77137,7 +77137,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -86234,7 +86234,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -96895,7 +96895,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -97189,7 +97189,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -102126,7 +102126,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -108680,7 +108680,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "TypeName",
+              "name": "Type",
               "namespace": "internal"
             }
           }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -809,7 +809,7 @@ export interface BulkOperationContainer {
 
 export interface BulkRequest<TSource = unknown> extends CommonQueryParameters {
   index?: IndexName
-  type?: TypeName
+  type?: Type
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
@@ -2431,7 +2431,7 @@ export interface CreateRepositoryResponse extends AcknowledgedResponseBase {
 export interface CreateRequest<TDocument = unknown> extends CommonQueryParameters {
   id: Id
   index: IndexName
-  type?: TypeName
+  type?: Type
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
@@ -2955,7 +2955,7 @@ export interface DeleteRepositoryResponse extends AcknowledgedResponseBase {
 export interface DeleteRequest extends CommonQueryParameters {
   id: Id
   index: IndexName
-  type?: TypeName
+  type?: Type
   if_primary_term?: long
   if_seq_no?: long
   refresh?: Refresh
@@ -3181,7 +3181,7 @@ export interface DocValuesPropertyBase extends CorePropertyBase {
 export interface DocumentExistsRequest extends CommonQueryParameters {
   id: Id
   index: IndexName
-  type?: TypeName
+  type?: Type
   preference?: string
   realtime?: boolean
   refresh?: boolean
@@ -3529,7 +3529,7 @@ export interface ExplainLifecycleResponse {
 export interface ExplainRequest extends CommonQueryParameters {
   id: Id
   index: IndexName
-  type?: TypeName
+  type?: Type
   analyzer?: string
   analyze_wildcard?: boolean
   default_operator?: DefaultOperator
@@ -4538,7 +4538,7 @@ export interface GetRepositoryResponse {
 export interface GetRequest extends CommonQueryParameters {
   id: Id
   index: IndexName
-  type?: TypeName
+  type?: Type
   preference?: string
   realtime?: boolean
   refresh?: boolean
@@ -4988,7 +4988,7 @@ export interface Hit<TDocument = unknown> {
   _index: IndexName
   _id: Id
   _score?: double
-  _type?: TypeName
+  _type?: Type
   _explanation?: Explanation
   fields?: Record<string, any>
   highlight?: Record<string, Array<string>>
@@ -5250,7 +5250,7 @@ export interface IndexPrivilegesCheck {
 export interface IndexRequest<TDocument = unknown> extends CommonQueryParameters {
   id?: Id
   index: IndexName
-  type?: TypeName
+  type?: Type
   if_primary_term?: long
   if_seq_no?: long
   op_type?: OpType
@@ -6272,7 +6272,7 @@ export interface MultiGetHit<TDocument = unknown> {
   _routing?: Routing
   _seq_no?: long
   _source?: TDocument
-  _type?: TypeName
+  _type?: Type
   _version?: long
 }
 
@@ -6283,14 +6283,14 @@ export interface MultiGetOperation {
   routing?: Routing
   _source?: boolean | Fields | MultiGetSourceFilter
   stored_fields?: Fields
-  _type?: TypeName
+  _type?: Type
   version?: long
   version_type?: VersionType
 }
 
 export interface MultiGetRequest extends CommonQueryParameters {
   index?: IndexName
-  type?: TypeName
+  type?: Type
   preference?: string
   realtime?: boolean
   refresh?: boolean
@@ -6388,7 +6388,7 @@ export interface MultiTermVectorOperation {
 
 export interface MultiTermVectorsRequest extends CommonQueryParameters {
   index?: IndexName
-  type?: TypeName
+  type?: Type
   fields?: Array<Field>
   field_statistics?: boolean
   offsets?: boolean
@@ -7481,7 +7481,7 @@ export interface PutLifecycleResponse extends AcknowledgedResponseBase {
 
 export interface PutMappingRequest extends CommonQueryParameters {
   index?: Indices
-  type?: TypeName
+  type?: Type
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
@@ -8465,7 +8465,7 @@ export type RollupMetric = 'min' | 'max' | 'sum' | 'avg' | 'value_count'
 
 export interface RollupSearchRequest extends CommonQueryParameters {
   index: Indices
-  type?: TypeName
+  type?: Type
   total_hits_as_integer?: boolean
   typed_keys?: boolean
   body: {
@@ -9648,7 +9648,7 @@ export type SortSpecialField = '_score' | '_doc'
 export interface SourceExistsRequest extends CommonQueryParameters {
   id: Id
   index: IndexName
-  type?: TypeName
+  type?: Type
   preference?: string
   realtime?: boolean
   refresh?: boolean
@@ -9678,7 +9678,7 @@ export interface SourceFilter {
 export interface SourceRequest extends CommonQueryParameters {
   id: Id
   index: IndexName
-  type?: TypeName
+  type?: Type
   preference?: string
   realtime?: boolean
   refresh?: boolean
@@ -10258,7 +10258,7 @@ export interface TermVectorTerm {
 export interface TermVectorsRequest<TDocument = unknown> extends CommonQueryParameters {
   index: IndexName
   id?: Id
-  type?: TypeName
+  type?: Type
   fields?: Array<Field>
   field_statistics?: boolean
   offsets?: boolean
@@ -10928,7 +10928,7 @@ export interface UpdateModelSnapshotResponse extends AcknowledgedResponseBase {
 export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> extends CommonQueryParameters {
   id: Id
   index: IndexName
-  type?: TypeName
+  type?: Type
   if_primary_term?: long
   if_seq_no?: long
   lang?: string

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2308,7 +2308,7 @@ export type CountFunction = 'Count' | 'HighCount' | 'LowCount'
 
 export interface CountRequest extends CommonQueryParameters {
   index?: Indices
-  type?: TypeNames
+  type?: Types
   allow_no_indices?: boolean
   analyzer?: string
   analyze_wildcard?: boolean
@@ -2743,7 +2743,7 @@ export interface DeleteAutoFollowPatternResponse extends AcknowledgedResponseBas
 
 export interface DeleteByQueryRequest extends CommonQueryParameters {
   index: Indices
-  type?: TypeNames
+  type?: Types
   allow_no_indices?: boolean
   analyzer?: string
   analyze_wildcard?: boolean
@@ -4335,7 +4335,7 @@ export interface GetEnrichPolicyResponse {
 export interface GetFieldMappingRequest extends CommonQueryParameters {
   fields: Fields
   index?: Indices
-  type?: TypeNames
+  type?: Types
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
@@ -4462,7 +4462,7 @@ export interface GetLifecycleResponse extends DictionaryResponseBase<string, Lif
 
 export interface GetMappingRequest extends CommonQueryParameters {
   index?: Indices
-  type?: TypeNames
+  type?: Types
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
@@ -4783,7 +4783,7 @@ export interface GraphExploreControls {
 
 export interface GraphExploreRequest extends CommonQueryParameters {
   index: Indices
-  type?: TypeNames
+  type?: Types
   routing?: Routing
   timeout?: Time
   body?: {
@@ -5406,7 +5406,7 @@ export interface IndicesStatsRequest extends CommonQueryParameters {
   include_segment_file_sizes?: boolean
   include_unloaded_segments?: boolean
   level?: Level
-  types?: TypeNames
+  types?: Types
 }
 
 export interface IndicesStatsResponse {
@@ -6338,7 +6338,7 @@ export interface MultiMatchQuery extends QueryBase {
 
 export interface MultiSearchRequest extends CommonQueryParameters {
   index?: Indices
-  type?: TypeNames
+  type?: Types
   ccs_minimize_roundtrips?: boolean
   max_concurrent_searches?: long
   max_concurrent_shard_requests?: long
@@ -6357,7 +6357,7 @@ export interface MultiSearchResponse {
 
 export interface MultiSearchTemplateRequest extends CommonQueryParameters {
   index?: Indices
-  type?: TypeNames
+  type?: Types
   ccs_minimize_roundtrips?: boolean
   max_concurrent_searches?: long
   search_type?: SearchType
@@ -8682,7 +8682,7 @@ export interface SearchProfile {
 
 export interface SearchRequest extends CommonQueryParameters {
   index?: Indices
-  type?: TypeNames
+  type?: Types
   allow_no_indices?: boolean
   allow_partial_search_results?: boolean
   analyzer?: string
@@ -8816,7 +8816,7 @@ export interface SearchStats {
 
 export interface SearchTemplateRequest extends CommonQueryParameters {
   index?: Indices
-  type?: TypeNames
+  type?: Types
   allow_no_indices?: boolean
   ccs_minimize_roundtrips?: boolean
   expand_wildcards?: ExpandWildcards
@@ -10681,9 +10681,11 @@ export interface TruncateTokenFilter extends TokenFilterBase {
   length: integer
 }
 
+export type Type = string
+
 export interface TypeExistsRequest extends CommonQueryParameters {
   index: Indices
-  type: TypeNames
+  type: Types
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
@@ -10720,7 +10722,7 @@ export interface TypeQuery extends QueryBase {
   value: string
 }
 
-export type Types = string | Array<string>
+export type Types = Type | Array<Type>
 
 export interface UaxEmailUrlTokenizer extends TokenizerBase {
   max_token_length: integer
@@ -10763,7 +10765,7 @@ export interface UniqueTokenFilter extends TokenFilterBase {
 
 export interface UpdateByQueryRequest extends CommonQueryParameters {
   index: Indices
-  type?: TypeNames
+  type?: Types
   allow_no_indices?: boolean
   analyzer?: string
   analyze_wildcard?: boolean
@@ -11043,7 +11045,7 @@ export interface ValidateJobResponse extends AcknowledgedResponseBase {
 
 export interface ValidateQueryRequest extends CommonQueryParameters {
   index?: Indices
-  type?: TypeNames
+  type?: Types
   allow_no_indices?: boolean
   all_shards?: boolean
   analyzer?: string

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -104,7 +104,8 @@ type Indices = string | string[]
 
 type TypeName = string
 type TypeNames = string | string[]
-type Types = string | string[]
+type Type = string
+type Types = Type | Type[]
 
 type Routing = string | number
 type LongId = string

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -102,8 +102,8 @@ type Ids = string | number | string[]
 type IndexName = string
 type Indices = string | string[]
 
-type TypeName = string
-type TypeNames = string | string[]
+type TypeName = string // TODO remove and use Type
+type TypeNames = string | string[] // TODO remove and use Types
 type Type = string
 type Types = Type | Type[]
 

--- a/specification/specs/document/multiple/bulk/BulkRequest.ts
+++ b/specification/specs/document/multiple/bulk/BulkRequest.ts
@@ -26,7 +26,7 @@
 interface BulkRequest<TSource> extends RequestBase {
   path_parts?: {
     index?: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     pipeline?: string

--- a/specification/specs/document/multiple/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/specs/document/multiple/delete_by_query/DeleteByQueryRequest.ts
@@ -25,7 +25,7 @@
 interface DeleteByQueryRequest extends RequestBase {
   path_parts?: {
     index: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/document/multiple/multi_get/request/MultiGetRequest.ts
+++ b/specification/specs/document/multiple/multi_get/request/MultiGetRequest.ts
@@ -26,7 +26,7 @@
 interface MultiGetRequest extends RequestBase {
   path_parts?: {
     index?: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     preference?: string
@@ -60,7 +60,7 @@ class MultiGetOperation {
   routing?: Routing
   _source?: boolean | Fields | MultiGetSourceFilter
   stored_fields?: Fields
-  _type?: TypeName
+  _type?: Type
   version?: long
   version_type?: VersionType
 }

--- a/specification/specs/document/multiple/multi_get/response/MultiGetResponse.ts
+++ b/specification/specs/document/multiple/multi_get/response/MultiGetResponse.ts
@@ -35,6 +35,6 @@ class MultiGetHit<TDocument> {
   _routing?: Routing
   _seq_no?: long
   _source?: TDocument
-  _type?: TypeName
+  _type?: Type
   _version?: long
 }

--- a/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorsRequest.ts
+++ b/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorsRequest.ts
@@ -25,7 +25,7 @@
 interface MultiTermVectorsRequest extends RequestBase {
   path_parts?: {
     index?: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     fields?: Field[]

--- a/specification/specs/document/multiple/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/specs/document/multiple/update_by_query/UpdateByQueryRequest.ts
@@ -25,7 +25,7 @@
 interface UpdateByQueryRequest extends RequestBase {
   path_parts?: {
     index: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/document/single/create/CreateRequest.ts
+++ b/specification/specs/document/single/create/CreateRequest.ts
@@ -27,7 +27,7 @@ interface CreateRequest<TDocument> extends RequestBase {
   path_parts?: {
     id: Id
     index: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     pipeline?: string

--- a/specification/specs/document/single/delete/DeleteRequest.ts
+++ b/specification/specs/document/single/delete/DeleteRequest.ts
@@ -26,7 +26,7 @@ interface DeleteRequest extends RequestBase {
   path_parts?: {
     id: Id
     index: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     if_primary_term?: long

--- a/specification/specs/document/single/exists/DocumentExistsRequest.ts
+++ b/specification/specs/document/single/exists/DocumentExistsRequest.ts
@@ -26,7 +26,7 @@ interface DocumentExistsRequest extends RequestBase {
   path_parts?: {
     id: Id
     index: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     preference?: string

--- a/specification/specs/document/single/get/GetRequest.ts
+++ b/specification/specs/document/single/get/GetRequest.ts
@@ -26,7 +26,7 @@ interface GetRequest extends RequestBase {
   path_parts?: {
     id: Id
     index: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     preference?: string

--- a/specification/specs/document/single/index/IndexRequest.ts
+++ b/specification/specs/document/single/index/IndexRequest.ts
@@ -27,7 +27,7 @@ interface IndexRequest<TDocument> extends RequestBase {
   path_parts?: {
     id?: Id
     index: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     if_primary_term?: long

--- a/specification/specs/document/single/source/SourceRequest.ts
+++ b/specification/specs/document/single/source/SourceRequest.ts
@@ -26,7 +26,7 @@ interface SourceRequest extends RequestBase {
   path_parts?: {
     id: Id
     index: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     preference?: string

--- a/specification/specs/document/single/source_exists/SourceExistsRequest.ts
+++ b/specification/specs/document/single/source_exists/SourceExistsRequest.ts
@@ -26,7 +26,7 @@ interface SourceExistsRequest extends RequestBase {
   path_parts?: {
     id: Id
     index: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     preference?: string

--- a/specification/specs/document/single/term_vectors/TermVectorsRequest.ts
+++ b/specification/specs/document/single/term_vectors/TermVectorsRequest.ts
@@ -26,7 +26,7 @@ interface TermVectorsRequest<TDocument> extends RequestBase {
   path_parts?: {
     index: IndexName
     id?: Id
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     fields?: Field[]

--- a/specification/specs/document/single/update/UpdateRequest.ts
+++ b/specification/specs/document/single/update/UpdateRequest.ts
@@ -26,7 +26,7 @@ interface UpdateRequest<TDocument, TPartialDocument> extends RequestBase {
   path_parts?: {
     id: Id
     index: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     if_primary_term?: long

--- a/specification/specs/indices/index_management/types_exists/TypeExistsRequest.ts
+++ b/specification/specs/indices/index_management/types_exists/TypeExistsRequest.ts
@@ -25,7 +25,7 @@
 interface TypeExistsRequest extends RequestBase {
   path_parts?: {
     index: Indices
-    type: TypeNames
+    type: Types
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/indices/mapping_management/get_field_mapping/GetFieldMappingRequest.ts
+++ b/specification/specs/indices/mapping_management/get_field_mapping/GetFieldMappingRequest.ts
@@ -26,7 +26,7 @@ interface GetFieldMappingRequest extends RequestBase {
   path_parts?: {
     fields: Fields
     index?: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/indices/mapping_management/get_mapping/GetMappingRequest.ts
+++ b/specification/specs/indices/mapping_management/get_mapping/GetMappingRequest.ts
@@ -25,7 +25,7 @@
 interface GetMappingRequest extends RequestBase {
   path_parts?: {
     index?: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/indices/mapping_management/put_mapping/PutMappingRequest.ts
+++ b/specification/specs/indices/mapping_management/put_mapping/PutMappingRequest.ts
@@ -25,7 +25,7 @@
 interface PutMappingRequest extends RequestBase {
   path_parts?: {
     index?: Indices
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/indices/monitoring/indices_stats/IndicesStatsRequest.ts
+++ b/specification/specs/indices/monitoring/indices_stats/IndicesStatsRequest.ts
@@ -37,7 +37,7 @@ interface IndicesStatsRequest extends RequestBase {
     include_segment_file_sizes?: boolean
     include_unloaded_segments?: boolean
     level?: Level
-    types?: TypeNames
+    types?: Types
   }
   body?: {}
 }

--- a/specification/specs/search/count/CountRequest.ts
+++ b/specification/specs/search/count/CountRequest.ts
@@ -25,7 +25,7 @@
 interface CountRequest extends RequestBase {
   path_parts?: {
     index?: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/search/explain/ExplainRequest.ts
+++ b/specification/specs/search/explain/ExplainRequest.ts
@@ -26,7 +26,7 @@ interface ExplainRequest extends RequestBase {
   path_parts?: {
     id: Id
     index: IndexName
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     analyzer?: string

--- a/specification/specs/search/multi_search/MultiSearchRequest.ts
+++ b/specification/specs/search/multi_search/MultiSearchRequest.ts
@@ -26,7 +26,7 @@
 interface MultiSearchRequest extends RequestBase {
   path_parts?: {
     index?: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     ccs_minimize_roundtrips?: boolean

--- a/specification/specs/search/multi_search_template/MultiSearchTemplateRequest.ts
+++ b/specification/specs/search/multi_search_template/MultiSearchTemplateRequest.ts
@@ -26,7 +26,7 @@
 interface MultiSearchTemplateRequest extends RequestBase {
   path_parts?: {
     index?: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     ccs_minimize_roundtrips?: boolean

--- a/specification/specs/search/search/SearchRequest.ts
+++ b/specification/specs/search/search/SearchRequest.ts
@@ -25,7 +25,7 @@
 interface SearchRequest extends RequestBase {
   path_parts?: {
     index?: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/search/search/hits/Hit.ts
+++ b/specification/specs/search/search/hits/Hit.ts
@@ -22,7 +22,7 @@ class Hit<TDocument> {
   _id: Id
 
   _score?: double
-  _type?: TypeName
+  _type?: Type
 
   _explanation?: Explanation
   fields?: Dictionary<string, UserDefinedValue>

--- a/specification/specs/search/search_template/SearchTemplateRequest.ts
+++ b/specification/specs/search/search_template/SearchTemplateRequest.ts
@@ -25,7 +25,7 @@
 interface SearchTemplateRequest extends RequestBase {
   path_parts?: {
     index?: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/search/validate/ValidateQueryRequest.ts
+++ b/specification/specs/search/validate/ValidateQueryRequest.ts
@@ -25,7 +25,7 @@
 interface ValidateQueryRequest extends RequestBase {
   path_parts?: {
     index?: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     allow_no_indices?: boolean

--- a/specification/specs/x_pack/graph/explore/GraphExploreRequest.ts
+++ b/specification/specs/x_pack/graph/explore/GraphExploreRequest.ts
@@ -25,7 +25,7 @@
 interface GraphExploreRequest extends RequestBase {
   path_parts?: {
     index: Indices
-    type?: TypeNames
+    type?: Types
   }
   query_parameters?: {
     routing?: Routing

--- a/specification/specs/x_pack/roll_up/rollup_search/RollupSearchRequest.ts
+++ b/specification/specs/x_pack/roll_up/rollup_search/RollupSearchRequest.ts
@@ -25,7 +25,7 @@
 interface RollupSearchRequest extends RequestBase {
   path_parts?: {
     index: Indices
-    type?: TypeName
+    type?: Type
   }
   query_parameters?: {
     total_hits_as_integer?: boolean


### PR DESCRIPTION
The type `Type` and `Types` (array of Type) were ambiguous with `TypeName` and `TypeNames`. This PR removes the latter and replaces all occurrences with the former.