### PR TITLE
Cleanup the usage of `Fields`

### DIFF
--- a/output/dangling-types/dangling.csv
+++ b/output/dangling-types/dangling.csv
@@ -2,7 +2,6 @@ TimeSpan,common.ts
 short,common.ts
 ScrollIds,common.ts
 ActionIds,common.ts
-TypeName,common.ts
 TypeNames,common.ts
 LongId,common.ts
 IndexMetrics,common.ts

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -12001,13 +12001,10 @@
           "name": "influencers",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -14098,13 +14095,10 @@
             "name": "docvalue_fields",
             "required": false,
             "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Field",
-                  "namespace": "internal"
-                }
+              "kind": "instance_of",
+              "type": {
+                "name": "Fields",
+                "namespace": "internal"
               }
             }
           },
@@ -14460,13 +14454,10 @@
             "name": "stored_fields",
             "required": false,
             "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Field",
-                  "namespace": "internal"
-                }
+              "kind": "instance_of",
+              "type": {
+                "name": "Fields",
+                "namespace": "internal"
               }
             }
           },
@@ -16698,52 +16689,22 @@
           "name": "_source_excludes",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Field",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Field",
-                    "namespace": "internal"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
+            }
           }
         },
         {
           "name": "_source_includes",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Field",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Field",
-                    "namespace": "internal"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
+            }
           }
         },
         {
@@ -25482,13 +25443,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -30833,13 +30791,10 @@
           "name": "copy_to",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -32417,13 +32372,10 @@
           "name": "target_fields",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -35248,13 +35200,10 @@
           "name": "source_excludes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -35262,13 +35211,10 @@
           "name": "source_includes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -38829,13 +38775,10 @@
           "name": "source_excludes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -38843,13 +38786,10 @@
           "name": "source_includes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -38857,13 +38797,10 @@
           "name": "stored_fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -39809,13 +39746,10 @@
           "name": "enrich_fields",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -43043,13 +42977,10 @@
           "name": "except",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -43057,13 +42988,10 @@
           "name": "grant",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         }
@@ -54351,13 +54279,10 @@
           "name": "matched_fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -54814,13 +54739,10 @@
           "name": "fields",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -59059,13 +58981,10 @@
           "name": "docvalue_fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -59138,13 +59057,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -63123,13 +63039,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -64406,13 +64319,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -65408,13 +65318,10 @@
           "name": "terms",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         }
@@ -65802,13 +65709,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -66812,13 +66716,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -67334,13 +67235,10 @@
           "name": "fields",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -67551,13 +67449,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -70577,13 +70472,10 @@
           "name": "completion_fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -70591,13 +70483,10 @@
           "name": "fielddata_fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -70605,13 +70494,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -80483,13 +80369,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -83150,13 +83033,10 @@
           "name": "_source",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         }
@@ -83981,13 +83861,10 @@
           "name": "field",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -88840,13 +88717,10 @@
           "name": "stored_fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -94106,13 +93980,10 @@
           "name": "source_fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         }
@@ -94271,13 +94142,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -97084,13 +96952,10 @@
           "name": "source_excludes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -97098,13 +96963,10 @@
           "name": "source_includes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -102260,13 +102122,10 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -102974,13 +102833,10 @@
           "name": "fields",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         }
@@ -104487,13 +104343,10 @@
           "name": "docvalue_fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -104696,13 +104549,10 @@
           "name": "stored_fields",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -107433,13 +107283,10 @@
           "name": "source_excludes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -107447,13 +107294,10 @@
           "name": "source_includes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -108962,13 +108806,10 @@
           "name": "_source_excludes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         },
@@ -108976,13 +108817,10 @@
           "name": "_source_includes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "internal"
             }
           }
         }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -302,7 +302,7 @@ export interface AnalysisConfig {
   categorization_field_name: Field
   categorization_filters: Array<string>
   detectors: Array<Detector>
-  influencers: Array<Field>
+  influencers: Fields
   latency: Time
   multivariate_by_fields: boolean
   summary_count_field_name: Field
@@ -533,7 +533,7 @@ export interface AsyncSearchSubmitRequest extends CommonQueryParameters {
     collapse?: FieldCollapse
     default_operator?: DefaultOperator
     df?: string
-    docvalue_fields?: Array<Field>
+    docvalue_fields?: Fields
     expand_wildcards?: ExpandWildcards
     explain?: boolean
     from?: integer
@@ -562,7 +562,7 @@ export interface AsyncSearchSubmitRequest extends CommonQueryParameters {
     sort?: Array<Sort>
     _source?: boolean | SourceFilter
     stats?: Array<string>
-    stored_fields?: Array<Field>
+    stored_fields?: Fields
     suggest?: Record<string, SuggestBucket>
     suggest_field?: Field
     suggest_mode?: SuggestMode
@@ -814,8 +814,8 @@ export interface BulkRequest<TSource = unknown> extends CommonQueryParameters {
   refresh?: Refresh
   routing?: Routing
   _source?: boolean
-  _source_excludes?: Field | Array<Field>
-  _source_includes?: Field | Array<Field>
+  _source_excludes?: Fields
+  _source_includes?: Fields
   timeout?: Time
   type_query_string?: string
   wait_for_active_shards?: string
@@ -1697,7 +1697,7 @@ export interface ClearCacheRequest extends CommonQueryParameters {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   fielddata?: boolean
-  fields?: Array<Field>
+  fields?: Fields
   ignore_unavailable?: boolean
   query?: boolean
   request?: boolean
@@ -2298,7 +2298,7 @@ export interface CoordinatorStats {
 }
 
 export interface CorePropertyBase extends PropertyBase {
-  copy_to: Array<Field>
+  copy_to: Fields
   fields: Record<PropertyName, PropertyBase>
   similarity: string
   store: boolean
@@ -2469,7 +2469,7 @@ export interface CsvProcessor extends ProcessorBase {
   ignore_missing: boolean
   quote: string
   separator: string
-  target_fields: Array<Field>
+  target_fields: Fields
   trim: boolean
 }
 
@@ -2768,8 +2768,8 @@ export interface DeleteByQueryRequest extends CommonQueryParameters {
   slices?: long
   sort?: Array<string>
   source_enabled?: boolean
-  source_excludes?: Array<Field>
-  source_includes?: Array<Field>
+  source_excludes?: Fields
+  source_includes?: Fields
   stats?: Array<string>
   terminate_after?: long
   timeout?: Time
@@ -3187,9 +3187,9 @@ export interface DocumentExistsRequest extends CommonQueryParameters {
   refresh?: boolean
   routing?: Routing
   source_enabled?: boolean
-  source_excludes?: Array<Field>
-  source_includes?: Array<Field>
-  stored_fields?: Array<Field>
+  source_excludes?: Fields
+  source_includes?: Fields
+  stored_fields?: Fields
   version?: long
   version_type?: VersionType
 }
@@ -3308,7 +3308,7 @@ export interface EnableUserResponse {
 }
 
 export interface EnrichPolicy {
-  enrich_fields: Array<Field>
+  enrich_fields: Fields
   indices: Indices
   match_field: Field
   query?: string
@@ -3686,8 +3686,8 @@ export interface FieldNamesField {
 }
 
 export interface FieldSecurity {
-  except: Array<Field>
-  grant: Array<Field>
+  except: Fields
+  grant: Fields
 }
 
 export interface FieldSecuritySettings {
@@ -4945,7 +4945,7 @@ export interface HighlightField {
   fragment_offset?: integer
   fragment_size?: integer
   highlight_query?: QueryContainer
-  matched_fields?: Array<Field>
+  matched_fields?: Fields
   max_fragment_length?: integer
   no_match_size?: integer
   number_of_fragments?: integer
@@ -4995,7 +4995,7 @@ export interface HistogramProperty extends PropertyBase {
 }
 
 export interface HistogramRollupGrouping {
-  fields: Array<Field>
+  fields: Fields
   interval: long
 }
 
@@ -5467,13 +5467,13 @@ export interface InnerHits {
   size?: integer
   from?: integer
   collapse?: FieldCollapse
-  docvalue_fields?: Array<Field>
+  docvalue_fields?: Fields
   explain?: boolean
   highlight?: Highlight
   ignore_unmapped?: boolean
   script_fields?: Record<string, ScriptField>
   seq_no_primary_term?: boolean
-  fields?: Array<Field>
+  fields?: Fields
   sort?: Array<Record<string, Sort | SortOrder>>
   _source?: boolean | SourceFilter
   version?: boolean
@@ -5933,7 +5933,7 @@ export type Like = string | LikeDocument
 
 export interface LikeDocument {
   doc?: any
-  fields?: Array<Field>
+  fields?: Fields
   _id?: Id
   _index?: IndexName
   per_field_analyzer?: Record<Field, string>
@@ -6081,7 +6081,7 @@ export interface MatchQuery extends QueryBase {
 export type MatchType = 'simple' | 'regex'
 
 export interface MatrixAggregation {
-  fields?: Array<Field>
+  fields?: Fields
   missing?: Record<Field, double>
 }
 
@@ -6186,7 +6186,7 @@ export type ModelCategorizationStatus = 'ok' | 'warn'
 export type ModelMemoryStatus = 'ok' | 'soft_limit' | 'hard_limit'
 
 export interface ModelPlotConfig {
-  terms: Array<Field>
+  terms: Fields
 }
 
 export interface ModelPlotConfigEnabled {
@@ -6228,7 +6228,7 @@ export type Month = 'january' | 'february' | 'march' | 'april' | 'may' | 'june' 
 export interface MoreLikeThisQuery extends QueryBase {
   analyzer?: string
   boost_terms?: double
-  fields?: Array<Field>
+  fields?: Fields
   include?: boolean
   like?: Array<Like>
   max_doc_freq?: integer
@@ -6335,7 +6335,7 @@ export interface MultiMatchQuery extends QueryBase {
   analyzer?: string
   auto_generate_synonyms_phrase_query?: boolean
   cutoff_frequency?: double
-  fields?: Array<Field>
+  fields?: Fields
   fuzziness?: Fuzziness
   fuzzy_rewrite?: MultiTermQueryRewrite
   fuzzy_transpositions?: boolean
@@ -6388,7 +6388,7 @@ export type MultiTermQueryRewrite = string
 
 export interface MultiTermVectorOperation {
   doc: object
-  fields: Array<Field>
+  fields: Fields
   field_statistics: boolean
   filter: TermVectorFilter
   _id: Id
@@ -6405,7 +6405,7 @@ export interface MultiTermVectorOperation {
 export interface MultiTermVectorsRequest extends CommonQueryParameters {
   index?: IndexName
   type?: Type
-  fields?: Array<Field>
+  fields?: Fields
   field_statistics?: boolean
   offsets?: boolean
   payloads?: boolean
@@ -6755,9 +6755,9 @@ export interface NodesStatsRequest extends CommonQueryParameters {
   node_id?: NodeIds
   metric?: Metrics
   index_metric?: Metrics
-  completion_fields?: Array<Field>
-  fielddata_fields?: Array<Field>
-  fields?: Array<Field>
+  completion_fields?: Fields
+  fielddata_fields?: Fields
+  fields?: Fields
   groups?: boolean
   include_segment_file_sizes?: boolean
   level?: Level
@@ -7813,7 +7813,7 @@ export interface QueryStringQuery extends QueryBase {
   default_operator?: Operator
   enable_position_increments?: boolean
   escape?: boolean
-  fields?: Array<Field>
+  fields?: Fields
   fuzziness?: Fuzziness
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer
@@ -8112,7 +8112,7 @@ export interface ReindexSource {
   size: integer
   slice?: SlicedScroll
   sort?: Array<Sort>
-  _source?: Array<Field>
+  _source?: Fields
 }
 
 export interface ReindexStatus {
@@ -8207,7 +8207,7 @@ export interface RemovePolicyResponse {
 }
 
 export interface RemoveProcessor extends ProcessorBase {
-  field: Array<Field>
+  field: Fields
   ignore_missing: boolean
 }
 
@@ -8722,7 +8722,7 @@ export interface SearchRequest extends CommonQueryParameters {
   search_type?: SearchType
   sequence_number_primary_term?: boolean
   stats?: Array<string>
-  stored_fields?: Array<Field>
+  stored_fields?: Fields
   suggest_field?: Field
   suggest_mode?: SuggestMode
   suggest_size?: long
@@ -9330,7 +9330,7 @@ export interface SignificantTextAggregation {
   shard_min_doc_count?: long
   shard_size?: integer
   size?: integer
-  source_fields?: Array<Field>
+  source_fields?: Fields
 }
 
 export interface SimpleAnalyzer extends AnalyzerBase {
@@ -9347,7 +9347,7 @@ export interface SimpleQueryStringQuery extends QueryBase {
   analyze_wildcard?: boolean
   auto_generate_synonyms_phrase_query?: boolean
   default_operator?: Operator
-  fields?: Array<Field>
+  fields?: Fields
   flags?: SimpleQueryStringFlags
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer
@@ -9670,8 +9670,8 @@ export interface SourceExistsRequest extends CommonQueryParameters {
   refresh?: boolean
   routing?: Routing
   source_enabled?: boolean
-  source_excludes?: Array<Field>
-  source_includes?: Array<Field>
+  source_excludes?: Fields
+  source_includes?: Fields
   version?: long
   version_type?: VersionType
 }
@@ -10275,7 +10275,7 @@ export interface TermVectorsRequest<TDocument = unknown> extends CommonQueryPara
   index: IndexName
   id?: Id
   type?: Type
-  fields?: Array<Field>
+  fields?: Fields
   field_statistics?: boolean
   offsets?: boolean
   payloads?: boolean
@@ -10351,7 +10351,7 @@ export interface TermsQuery extends QueryBase {
 }
 
 export interface TermsRollupGrouping {
-  fields: Array<Field>
+  fields: Fields
 }
 
 export interface TermsSetQuery extends QueryBase {
@@ -10490,7 +10490,7 @@ export interface TopHitsAggregate extends AggregateBase {
 }
 
 export interface TopHitsAggregation {
-  docvalue_fields?: Array<Field>
+  docvalue_fields?: Fields
   explain?: boolean
   from?: integer
   highlight?: Highlight
@@ -10498,7 +10498,7 @@ export interface TopHitsAggregation {
   size?: integer
   sort?: string | Record<Field, Sort | SortOrder | NestedSort> | Array<Record<string, Sort | SortOrder | Record<Field, NestedSort>>>
   _source?: boolean | SourceFilter | Field
-  stored_fields?: Array<Field>
+  stored_fields?: Fields
   track_scores?: boolean
   version?: boolean
   seq_no_primary_term?: boolean
@@ -10807,8 +10807,8 @@ export interface UpdateByQueryRequest extends CommonQueryParameters {
   slices?: long
   sort?: Array<string>
   source_enabled?: boolean
-  source_excludes?: Array<Field>
-  source_includes?: Array<Field>
+  source_excludes?: Fields
+  source_includes?: Fields
   stats?: Array<string>
   terminate_after?: long
   timeout?: Time
@@ -10956,8 +10956,8 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
   timeout?: Time
   wait_for_active_shards?: string
   _source?: boolean | string | Array<string>
-  _source_excludes?: Array<Field>
-  _source_includes?: Array<Field>
+  _source_excludes?: Fields
+  _source_includes?: Fields
   body: {
     detect_noop?: boolean
     doc?: TPartialDocument

--- a/specification/specs/aggregations/bucket/significant_text/SignificantTextAggregation.ts
+++ b/specification/specs/aggregations/bucket/significant_text/SignificantTextAggregation.ts
@@ -33,5 +33,5 @@ class SignificantTextAggregation {
   shard_min_doc_count?: long
   shard_size?: integer
   size?: integer
-  source_fields?: Field[]
+  source_fields?: Fields
 }

--- a/specification/specs/aggregations/matrix/MatrixAggregation.ts
+++ b/specification/specs/aggregations/matrix/MatrixAggregation.ts
@@ -18,6 +18,6 @@
  */
 
 class MatrixAggregation {
-  fields?: Field[]
+  fields?: Fields
   missing?: Dictionary<Field, double>
 }

--- a/specification/specs/aggregations/metric/top_hits/TopHitsAggregation.ts
+++ b/specification/specs/aggregations/metric/top_hits/TopHitsAggregation.ts
@@ -18,7 +18,7 @@
  */
 
 class TopHitsAggregation {
-  docvalue_fields?: Field[]
+  docvalue_fields?: Fields
   explain?: boolean
   from?: integer
   highlight?: Highlight
@@ -31,7 +31,7 @@ class TopHitsAggregation {
         SingleKeyDictionary<Sort | SortOrder | Dictionary<Field, NestedSort>>
       >
   _source?: boolean | SourceFilter | Field
-  stored_fields?: Field[]
+  stored_fields?: Fields
   track_scores?: boolean
   version?: boolean
   seq_no_primary_term?: boolean

--- a/specification/specs/cluster/nodes_stats/NodesStatsRequest.ts
+++ b/specification/specs/cluster/nodes_stats/NodesStatsRequest.ts
@@ -29,9 +29,9 @@ interface NodesStatsRequest extends RequestBase {
     index_metric?: Metrics
   }
   query_parameters?: {
-    completion_fields?: Field[]
-    fielddata_fields?: Field[]
-    fields?: Field[]
+    completion_fields?: Fields
+    fielddata_fields?: Fields
+    fields?: Fields
     groups?: boolean
     include_segment_file_sizes?: boolean
     level?: Level

--- a/specification/specs/document/multiple/bulk/BulkRequest.ts
+++ b/specification/specs/document/multiple/bulk/BulkRequest.ts
@@ -33,8 +33,8 @@ interface BulkRequest<TSource> extends RequestBase {
     refresh?: Refresh
     routing?: Routing
     _source?: boolean
-    _source_excludes?: Field | Field[]
-    _source_includes?: Field | Field[]
+    _source_excludes?: Fields
+    _source_includes?: Fields
     timeout?: Time
     type_query_string?: string
     wait_for_active_shards?: string

--- a/specification/specs/document/multiple/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/specs/document/multiple/delete_by_query/DeleteByQueryRequest.ts
@@ -52,8 +52,8 @@ interface DeleteByQueryRequest extends RequestBase {
     slices?: long
     sort?: string[]
     source_enabled?: boolean
-    source_excludes?: Field[]
-    source_includes?: Field[]
+    source_excludes?: Fields
+    source_includes?: Fields
     stats?: string[]
     terminate_after?: long
     timeout?: Time

--- a/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorOperation.ts
+++ b/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorOperation.ts
@@ -20,7 +20,7 @@
 class MultiTermVectorOperation {
   /** @prop_serializer SourceFormatter`1 */
   doc: any
-  fields: Field[]
+  fields: Fields
   field_statistics: boolean
   filter: TermVectorFilter
   _id: Id

--- a/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorsRequest.ts
+++ b/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorsRequest.ts
@@ -28,7 +28,7 @@ interface MultiTermVectorsRequest extends RequestBase {
     type?: Type
   }
   query_parameters?: {
-    fields?: Field[]
+    fields?: Fields
     field_statistics?: boolean
     offsets?: boolean
     payloads?: boolean

--- a/specification/specs/document/multiple/reindex/ReindexSource.ts
+++ b/specification/specs/document/multiple/reindex/ReindexSource.ts
@@ -24,5 +24,5 @@ class ReindexSource {
   size: integer
   slice?: SlicedScroll
   sort?: Sort[]
-  _source?: Field[]
+  _source?: Fields
 }

--- a/specification/specs/document/multiple/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/specs/document/multiple/update_by_query/UpdateByQueryRequest.ts
@@ -53,8 +53,8 @@ interface UpdateByQueryRequest extends RequestBase {
     slices?: long
     sort?: string[]
     source_enabled?: boolean
-    source_excludes?: Field[]
-    source_includes?: Field[]
+    source_excludes?: Fields
+    source_includes?: Fields
     stats?: string[]
     terminate_after?: long
     timeout?: Time

--- a/specification/specs/document/single/exists/DocumentExistsRequest.ts
+++ b/specification/specs/document/single/exists/DocumentExistsRequest.ts
@@ -34,9 +34,9 @@ interface DocumentExistsRequest extends RequestBase {
     refresh?: boolean
     routing?: Routing
     source_enabled?: boolean
-    source_excludes?: Field[]
-    source_includes?: Field[]
-    stored_fields?: Field[]
+    source_excludes?: Fields
+    source_includes?: Fields
+    stored_fields?: Fields
     version?: long
     version_type?: VersionType
   }

--- a/specification/specs/document/single/source_exists/SourceExistsRequest.ts
+++ b/specification/specs/document/single/source_exists/SourceExistsRequest.ts
@@ -34,8 +34,8 @@ interface SourceExistsRequest extends RequestBase {
     refresh?: boolean
     routing?: Routing
     source_enabled?: boolean
-    source_excludes?: Field[]
-    source_includes?: Field[]
+    source_excludes?: Fields
+    source_includes?: Fields
     version?: long
     version_type?: VersionType
   }

--- a/specification/specs/document/single/term_vectors/TermVectorsRequest.ts
+++ b/specification/specs/document/single/term_vectors/TermVectorsRequest.ts
@@ -29,7 +29,7 @@ interface TermVectorsRequest<TDocument> extends RequestBase {
     type?: Type
   }
   query_parameters?: {
-    fields?: Field[]
+    fields?: Fields
     field_statistics?: boolean
     offsets?: boolean
     payloads?: boolean

--- a/specification/specs/document/single/update/UpdateRequest.ts
+++ b/specification/specs/document/single/update/UpdateRequest.ts
@@ -40,8 +40,8 @@ interface UpdateRequest<TDocument, TPartialDocument> extends RequestBase {
     timeout?: Time
     wait_for_active_shards?: string
     _source?: Union<boolean, Union<string, string[]>>
-    _source_excludes?: Field[]
-    _source_includes?: Field[]
+    _source_excludes?: Fields
+    _source_includes?: Fields
   }
   body?: {
     detect_noop?: boolean

--- a/specification/specs/indices/status_management/clear_cache/ClearCacheRequest.ts
+++ b/specification/specs/indices/status_management/clear_cache/ClearCacheRequest.ts
@@ -30,7 +30,7 @@ interface ClearCacheRequest extends RequestBase {
     allow_no_indices?: boolean
     expand_wildcards?: ExpandWildcards
     fielddata?: boolean
-    fields?: Field[]
+    fields?: Fields
     ignore_unavailable?: boolean
     query?: boolean
     request?: boolean

--- a/specification/specs/ingest/processors/CsvProcessor.ts
+++ b/specification/specs/ingest/processors/CsvProcessor.ts
@@ -23,6 +23,6 @@ class CsvProcessor extends ProcessorBase {
   ignore_missing: boolean
   quote: string
   separator: string
-  target_fields: Field[]
+  target_fields: Fields
   trim: boolean
 }

--- a/specification/specs/ingest/processors/RemoveProcessor.ts
+++ b/specification/specs/ingest/processors/RemoveProcessor.ts
@@ -18,6 +18,6 @@
  */
 
 class RemoveProcessor extends ProcessorBase {
-  field: Field[]
+  field: Fields
   ignore_missing: boolean
 }

--- a/specification/specs/mapping/types/CorePropertyBase.ts
+++ b/specification/specs/mapping/types/CorePropertyBase.ts
@@ -18,7 +18,7 @@
  */
 
 class CorePropertyBase extends PropertyBase {
-  copy_to: Field[]
+  copy_to: Fields
   fields: Dictionary<PropertyName, PropertyBase>
   similarity: string
   store: boolean

--- a/specification/specs/query_dsl/full_text/multi_match/MultiMatchQuery.ts
+++ b/specification/specs/query_dsl/full_text/multi_match/MultiMatchQuery.ts
@@ -21,7 +21,7 @@ class MultiMatchQuery extends QueryBase {
   analyzer?: string
   auto_generate_synonyms_phrase_query?: boolean
   cutoff_frequency?: double
-  fields?: Field[]
+  fields?: Fields
   fuzziness?: Fuzziness
   fuzzy_rewrite?: MultiTermQueryRewrite
   fuzzy_transpositions?: boolean

--- a/specification/specs/query_dsl/full_text/query_string/QueryStringQuery.ts
+++ b/specification/specs/query_dsl/full_text/query_string/QueryStringQuery.ts
@@ -26,7 +26,7 @@ class QueryStringQuery extends QueryBase {
   default_operator?: Operator
   enable_position_increments?: boolean
   escape?: boolean
-  fields?: Field[]
+  fields?: Fields
   fuzziness?: Fuzziness
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer

--- a/specification/specs/query_dsl/full_text/simple_query_string/SimpleQueryStringQuery.ts
+++ b/specification/specs/query_dsl/full_text/simple_query_string/SimpleQueryStringQuery.ts
@@ -22,7 +22,7 @@ class SimpleQueryStringQuery extends QueryBase {
   analyze_wildcard?: boolean
   auto_generate_synonyms_phrase_query?: boolean
   default_operator?: Operator
-  fields?: Field[]
+  fields?: Fields
   flags?: SimpleQueryStringFlags
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer

--- a/specification/specs/query_dsl/specialized/more_like_this/MoreLikeThisQuery.ts
+++ b/specification/specs/query_dsl/specialized/more_like_this/MoreLikeThisQuery.ts
@@ -20,7 +20,7 @@
 class MoreLikeThisQuery extends QueryBase {
   analyzer?: string
   boost_terms?: double
-  fields?: Field[]
+  fields?: Fields
   include?: boolean
   like?: Like[]
   max_doc_freq?: integer

--- a/specification/specs/query_dsl/specialized/more_like_this/like/LikeDocument.ts
+++ b/specification/specs/query_dsl/specialized/more_like_this/like/LikeDocument.ts
@@ -20,7 +20,7 @@
 class LikeDocument {
   /** @prop_serializer SourceFormatter`1 */
   doc?: UserDefinedValue
-  fields?: Field[]
+  fields?: Fields
   _id?: Id
   _index?: IndexName
   per_field_analyzer?: Dictionary<Field, string>

--- a/specification/specs/search/search/SearchRequest.ts
+++ b/specification/specs/search/search/SearchRequest.ts
@@ -51,7 +51,7 @@ interface SearchRequest extends RequestBase {
     search_type?: SearchType
     sequence_number_primary_term?: boolean
     stats?: string[]
-    stored_fields?: Field[]
+    stored_fields?: Fields
     suggest_field?: Field
     suggest_mode?: SuggestMode
     suggest_size?: long

--- a/specification/specs/search/search/highlighting/HighlightField.ts
+++ b/specification/specs/search/search/highlighting/HighlightField.ts
@@ -29,7 +29,7 @@ class HighlightField {
   fragment_offset?: integer
   fragment_size?: integer
   highlight_query?: QueryContainer
-  matched_fields?: Field[]
+  matched_fields?: Fields
   max_fragment_length?: integer
   no_match_size?: integer
   number_of_fragments?: integer

--- a/specification/specs/search/search/inner_hits/InnerHits.ts
+++ b/specification/specs/search/search/inner_hits/InnerHits.ts
@@ -22,13 +22,13 @@ class InnerHits {
   size?: integer
   from?: integer
   collapse?: FieldCollapse
-  docvalue_fields?: Field[]
+  docvalue_fields?: Fields
   explain?: boolean
   highlight?: Highlight
   ignore_unmapped?: boolean
   script_fields?: Dictionary<string, ScriptField>
   seq_no_primary_term?: boolean
-  fields?: Field[]
+  fields?: Fields
   sort?: Array<SingleKeyDictionary<Union<Sort, SortOrder>>>
   _source?: Union<boolean, SourceFilter>
   version?: boolean

--- a/specification/specs/x_pack/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/specs/x_pack/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -37,7 +37,7 @@ interface AsyncSearchSubmitRequest extends RequestBase {
     collapse?: FieldCollapse
     default_operator?: DefaultOperator
     df?: string
-    docvalue_fields?: Field[]
+    docvalue_fields?: Fields
     expand_wildcards?: ExpandWildcards
     explain?: boolean
     from?: integer
@@ -67,7 +67,7 @@ interface AsyncSearchSubmitRequest extends RequestBase {
     sort?: Sort[]
     _source?: Union<boolean, SourceFilter>
     stats?: string[]
-    stored_fields?: Field[]
+    stored_fields?: Fields
     suggest?: Dictionary<string, SuggestBucket>
     suggest_field?: Field
     suggest_mode?: SuggestMode

--- a/specification/specs/x_pack/enrich/EnrichPolicy.ts
+++ b/specification/specs/x_pack/enrich/EnrichPolicy.ts
@@ -18,7 +18,7 @@
  */
 
 class EnrichPolicy {
-  enrich_fields: Field[]
+  enrich_fields: Fields
   indices: Indices
   match_field: Field
   query?: string

--- a/specification/specs/x_pack/machine_learning/job/config/AnalysisConfig.ts
+++ b/specification/specs/x_pack/machine_learning/job/config/AnalysisConfig.ts
@@ -22,7 +22,7 @@ class AnalysisConfig {
   categorization_field_name: Field
   categorization_filters: string[]
   detectors: Detector[]
-  influencers: Field[]
+  influencers: Fields
   latency: Time
   multivariate_by_fields: boolean
   summary_count_field_name: Field

--- a/specification/specs/x_pack/machine_learning/job/config/ModelPlotConfig.ts
+++ b/specification/specs/x_pack/machine_learning/job/config/ModelPlotConfig.ts
@@ -18,5 +18,5 @@
  */
 
 class ModelPlotConfig {
-  terms: Field[]
+  terms: Fields
 }

--- a/specification/specs/x_pack/roll_up/rollup_configuration/HistogramRollupGrouping.ts
+++ b/specification/specs/x_pack/roll_up/rollup_configuration/HistogramRollupGrouping.ts
@@ -18,6 +18,6 @@
  */
 
 class HistogramRollupGrouping {
-  fields: Field[]
+  fields: Fields
   interval: long
 }

--- a/specification/specs/x_pack/roll_up/rollup_configuration/TermsRollupGrouping.ts
+++ b/specification/specs/x_pack/roll_up/rollup_configuration/TermsRollupGrouping.ts
@@ -18,5 +18,5 @@
  */
 
 class TermsRollupGrouping {
-  fields: Field[]
+  fields: Fields
 }

--- a/specification/specs/x_pack/security/role/FieldSecurity.ts
+++ b/specification/specs/x_pack/security/role/FieldSecurity.ts
@@ -18,6 +18,6 @@
  */
 
 class FieldSecurity {
-  except: Field[]
-  grant: Field[]
+  except: Fields
+  grant: Fields
 }


### PR DESCRIPTION
The `Fields` type was expressed ambiguously with the union `Field | Field[]`. This PR removes all union occurrences and replaces them with an explicit type `Fields`.