### PR TITLE
Validate several Watcher endpoints

### DIFF
--- a/output/dangling-types/dangling.csv
+++ b/output/dangling-types/dangling.csv
@@ -5,7 +5,6 @@ ActionIds,common.ts
 TypeNames,common.ts
 LongId,common.ts
 IndexMetrics,common.ts
-Timestamp,common.ts
 CustomResponseBuilderBase,common/CustomResponseBuilderBase.ts
 ElasticsearchUrlFormatter,common/ElasticsearchUrlFormatter.ts
 HttpMethod,common/HttpMethod.ts
@@ -129,6 +128,7 @@ RareFunction,x_pack/machine_learning/job/detectors/RareFunction.ts
 SumFunction,x_pack/machine_learning/job/detectors/SumFunction.ts
 TimeFunction,x_pack/machine_learning/job/detectors/TimeFunction.ts
 DataAttachmentFormat,x_pack/watcher/action/email/DataAttachmentFormat.ts
+SlackActionMessageResult,x_pack/watcher/execution/slack/SlackActionMessageResult.ts
 DateRangeProperty,mapping/types/core/range/date_range/DateRangeProperty.ts
 DoubleRangeProperty,mapping/types/core/range/double_range/DoubleRangeProperty.ts
 FloatRangeProperty,mapping/types/core/range/float_range/FloatRangeProperty.ts

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -9495,7 +9495,7 @@
       "properties": [
         {
           "name": "action_type",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -9506,7 +9506,7 @@
         },
         {
           "name": "condition",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -9517,7 +9517,7 @@
         },
         {
           "name": "foreach",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -9528,7 +9528,7 @@
         },
         {
           "name": "max_iterations",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -9539,7 +9539,7 @@
         },
         {
           "name": "name",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -9550,7 +9550,7 @@
         },
         {
           "name": "throttle_period",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -9560,13 +9560,35 @@
           }
         },
         {
+          "name": "throttle_period_in_millis",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "EpochMillis",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "transform",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "TransformContainer",
               "namespace": "x_pack.watcher.transform"
+            }
+          }
+        },
+        {
+          "name": "index",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ActionIndex",
+              "namespace": "x_pack.watcher.action"
             }
           }
         }
@@ -9646,6 +9668,26 @@
     {
       "kind": "interface",
       "name": {
+        "name": "ActionIndex",
+        "namespace": "x_pack.watcher.action"
+      },
+      "properties": [
+        {
+          "name": "index",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "ActionStatus",
         "namespace": "x_pack.watcher.acknowledge_watch"
       },
@@ -9663,7 +9705,7 @@
         },
         {
           "name": "last_execution",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -9674,7 +9716,7 @@
         },
         {
           "name": "last_successful_execution",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -9685,7 +9727,7 @@
         },
         {
           "name": "last_throttle",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -9811,7 +9853,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "DateString",
+              "name": "Timestamp",
               "namespace": "internal"
             }
           }
@@ -9832,7 +9874,7 @@
             "key": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
+                "name": "IndexName",
                 "namespace": "internal"
               }
             },
@@ -9854,6 +9896,17 @@
             "type": {
               "name": "ActivationState",
               "namespace": "x_pack.watcher.acknowledge_watch"
+            }
+          }
+        },
+        {
+          "name": "version",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
             }
           }
         }
@@ -30719,7 +30772,7 @@
       "properties": [
         {
           "name": "always",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -30730,7 +30783,7 @@
         },
         {
           "name": "array_compare",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -30741,7 +30794,7 @@
         },
         {
           "name": "compare",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -30752,7 +30805,7 @@
         },
         {
           "name": "never",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -30763,7 +30816,7 @@
         },
         {
           "name": "script",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -40176,7 +40229,7 @@
       "properties": [
         {
           "name": "account",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -40198,7 +40251,7 @@
         },
         {
           "name": "reason",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -40273,7 +40326,7 @@
       "properties": [
         {
           "name": "bcc",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -40287,7 +40340,7 @@
         },
         {
           "name": "body",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -40298,7 +40351,7 @@
         },
         {
           "name": "cc",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -40312,7 +40365,7 @@
         },
         {
           "name": "from",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -40327,14 +40380,14 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
         },
         {
           "name": "priority",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -40345,7 +40398,7 @@
         },
         {
           "name": "reply_to",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -41681,7 +41734,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -41870,7 +41923,7 @@
       "properties": [
         {
           "name": "email",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -41885,14 +41938,14 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
         },
         {
           "name": "index",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -41903,7 +41956,7 @@
         },
         {
           "name": "logging",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -41914,7 +41967,7 @@
         },
         {
           "name": "pagerduty",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -41925,7 +41978,7 @@
         },
         {
           "name": "reason",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -41936,7 +41989,7 @@
         },
         {
           "name": "slack",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -41969,7 +42022,7 @@
         },
         {
           "name": "webhook",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -54149,14 +54202,14 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
         },
         {
           "name": "status",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -54167,12 +54220,45 @@
         },
         {
           "name": "watch",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "Watch",
               "namespace": "x_pack.watcher"
+            }
+          }
+        },
+        {
+          "name": "_primary_term",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "_seq_no",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "_version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
             }
           }
         }
@@ -58060,17 +58146,6 @@
       },
       "properties": [
         {
-          "name": "id",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "response",
           "required": true,
           "type": {
@@ -58107,7 +58182,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -58141,6 +58216,17 @@
             "kind": "instance_of",
             "type": {
               "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -60732,7 +60818,7 @@
       "properties": [
         {
           "name": "chain",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -60743,7 +60829,7 @@
         },
         {
           "name": "http",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -60754,7 +60840,7 @@
         },
         {
           "name": "search",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -60765,7 +60851,7 @@
         },
         {
           "name": "simple",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -88840,7 +88926,7 @@
       "properties": [
         {
           "name": "cron",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -88851,7 +88937,7 @@
         },
         {
           "name": "daily",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -88862,7 +88948,7 @@
         },
         {
           "name": "hourly",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -88873,7 +88959,7 @@
         },
         {
           "name": "interval",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -88884,7 +88970,7 @@
         },
         {
           "name": "monthly",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -88898,7 +88984,7 @@
         },
         {
           "name": "weekly",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -88912,7 +88998,7 @@
         },
         {
           "name": "yearly",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -88958,7 +89044,7 @@
         },
         {
           "name": "triggered_time",
-          "required": true,
+          "required": false,
           "type": {
             "items": [
               {
@@ -89221,7 +89307,7 @@
         },
         {
           "name": "params",
-          "required": true,
+          "required": false,
           "type": {
             "key": {
               "kind": "instance_of",
@@ -89233,6 +89319,17 @@
             "kind": "dictionary_of",
             "value": {
               "kind": "user_defined_value"
+            }
+          }
+        },
+        {
+          "name": "source",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
           }
         }
@@ -96949,19 +97046,8 @@
           }
         },
         {
-          "name": "reason",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "request",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -96972,34 +97058,12 @@
         },
         {
           "name": "response",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "HttpInputResponseResult",
               "namespace": "x_pack.watcher.execution"
-            }
-          }
-        },
-        {
-          "name": "status",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Status",
-              "namespace": "x_pack.watcher.execution"
-            }
-          }
-        },
-        {
-          "name": "to",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
             }
           }
         }
@@ -97014,7 +97078,7 @@
       "properties": [
         {
           "name": "account",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97024,16 +97088,13 @@
           }
         },
         {
-          "name": "sent_messages",
+          "name": "message",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "SlackActionMessageResult",
-                "namespace": "x_pack.watcher.execution.slack"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "SlackMessage",
+              "namespace": "x_pack.watcher.action.slack"
             }
           }
         }
@@ -97048,7 +97109,7 @@
       "properties": [
         {
           "name": "author_icon",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97059,7 +97120,7 @@
         },
         {
           "name": "author_link",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97081,7 +97142,7 @@
         },
         {
           "name": "color",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97092,7 +97153,7 @@
         },
         {
           "name": "fallback",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97103,7 +97164,7 @@
         },
         {
           "name": "fields",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -97117,7 +97178,7 @@
         },
         {
           "name": "footer",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97128,7 +97189,7 @@
         },
         {
           "name": "footer_icon",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97139,7 +97200,7 @@
         },
         {
           "name": "image_url",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97150,7 +97211,7 @@
         },
         {
           "name": "pretext",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97161,7 +97222,7 @@
         },
         {
           "name": "text",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97172,7 +97233,7 @@
         },
         {
           "name": "thumb_url",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97194,7 +97255,7 @@
         },
         {
           "name": "title_link",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97205,7 +97266,7 @@
         },
         {
           "name": "ts",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97312,7 +97373,7 @@
         },
         {
           "name": "dynamic_attachments",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -97334,7 +97395,7 @@
         },
         {
           "name": "icon",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -113315,7 +113376,7 @@
             "key": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
+                "name": "IndexName",
                 "namespace": "internal"
               }
             },
@@ -113353,7 +113414,7 @@
         },
         {
           "name": "metadata",
-          "required": true,
+          "required": false,
           "type": {
             "key": {
               "kind": "instance_of",
@@ -113370,7 +113431,7 @@
         },
         {
           "name": "status",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -113381,7 +113442,7 @@
         },
         {
           "name": "throttle_period",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -113392,7 +113453,7 @@
         },
         {
           "name": "transform",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -113535,7 +113596,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -113668,7 +113729,7 @@
             "key": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
+                "name": "IndexName",
                 "namespace": "internal"
               }
             },
@@ -113684,7 +113745,7 @@
         },
         {
           "name": "last_checked",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -113695,7 +113756,7 @@
         },
         {
           "name": "last_met_condition",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -113722,6 +113783,17 @@
             "kind": "instance_of",
             "type": {
               "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "execution_state",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
               "namespace": "internal"
             }
           }
@@ -113962,7 +114034,7 @@
         },
         {
           "name": "response",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -40,13 +40,15 @@ export interface AcknowledgedResponseBase {
 export type AcknowledgementState = 'awaits_successful_execution' | 'ackable' | 'acked'
 
 export interface Action {
-  action_type: ActionType
-  condition: ConditionContainer
-  foreach: string
-  max_iterations: integer
-  name: string
-  throttle_period: Time
-  transform: TransformContainer
+  action_type?: ActionType
+  condition?: ConditionContainer
+  foreach?: string
+  max_iterations?: integer
+  name?: string
+  throttle_period?: Time
+  throttle_period_in_millis?: EpochMillis
+  transform?: TransformContainer
+  index: ActionIndex
 }
 
 export type ActionExecutionMode = 'simulate' | 'force_simulate' | 'execute' | 'force_execute' | 'skip'
@@ -55,11 +57,15 @@ export type ActionExecutionState = 'awaits_execution' | 'checking' | 'execution_
 
 export type ActionIds = string
 
+export interface ActionIndex {
+  index: IndexName
+}
+
 export interface ActionStatus {
   ack: AcknowledgeState
-  last_execution: ExecutionState
-  last_successful_execution: ExecutionState
-  last_throttle: ThrottleState
+  last_execution?: ExecutionState
+  last_successful_execution?: ExecutionState
+  last_throttle?: ThrottleState
 }
 
 export type ActionType = 'email' | 'webhook' | 'index' | 'logging' | 'slack' | 'pagerduty'
@@ -74,12 +80,13 @@ export interface ActivateWatchResponse {
 
 export interface ActivationState {
   active: boolean
-  timestamp: DateString
+  timestamp: Timestamp
 }
 
 export interface ActivationStatus {
-  actions: Record<string, ActionStatus>
+  actions: Record<IndexName, ActionStatus>
   state: ActivationState
+  version: integer
 }
 
 export interface AdaptiveSelectionStats {
@@ -2270,11 +2277,11 @@ export interface Condition {
 }
 
 export interface ConditionContainer {
-  always: AlwaysCondition
-  array_compare: ArrayCompareCondition
-  compare: CompareCondition
-  never: NeverCondition
-  script: ScriptCondition
+  always?: AlwaysCondition
+  array_compare?: ArrayCompareCondition
+  compare?: CompareCondition
+  never?: NeverCondition
+  script?: ScriptCondition
 }
 
 export type ConditionOperator = 'gt' | 'gte' | 'lt' | 'lte'
@@ -3326,9 +3333,9 @@ export interface ElisionTokenFilter extends TokenFilterBase {
 }
 
 export interface EmailActionResult {
-  account: string
+  account?: string
   message: EmailResult
-  reason: string
+  reason?: string
 }
 
 export interface EmailBody {
@@ -3339,13 +3346,13 @@ export interface EmailBody {
 export type EmailPriority = 'lowest' | 'low' | 'normal' | 'high' | 'highest'
 
 export interface EmailResult {
-  bcc: Array<string>
-  body: EmailBody
-  cc: Array<string>
-  from: string
-  id: string
-  priority: EmailPriority
-  reply_to: Array<string>
+  bcc?: Array<string>
+  body?: EmailBody
+  cc?: Array<string>
+  from?: string
+  id: Id
+  priority?: EmailPriority
+  reply_to?: Array<string>
   sent_date: DateString
   subject: string
   to: Array<string>
@@ -3496,7 +3503,7 @@ export interface ExecuteWatchRequest extends CommonQueryParameters {
 }
 
 export interface ExecuteWatchResponse {
-  _id: string
+  _id: Id
   watch_record: WatchRecord
 }
 
@@ -3521,16 +3528,16 @@ export interface ExecutionResult {
 }
 
 export interface ExecutionResultAction {
-  email: EmailActionResult
-  id: string
-  index: IndexActionResult
-  logging: LoggingActionResult
-  pagerduty: PagerDutyActionResult
-  reason: string
-  slack: SlackActionResult
+  email?: EmailActionResult
+  id: Id
+  index?: IndexActionResult
+  logging?: LoggingActionResult
+  pagerduty?: PagerDutyActionResult
+  reason?: string
+  slack?: SlackActionResult
   status: Status
   type: ActionType
-  webhook: WebhookActionResult
+  webhook?: WebhookActionResult
 }
 
 export interface ExecutionResultCondition {
@@ -4894,9 +4901,12 @@ export interface GetWatchRequest extends CommonQueryParameters {
 
 export interface GetWatchResponse {
   found: boolean
-  _id: string
-  status: WatchStatus
-  watch: Watch
+  _id: Id
+  status?: WatchStatus
+  watch?: Watch
+  _primary_term?: integer
+  _seq_no?: integer
+  _version?: integer
 }
 
 export interface GlobalAggregation extends BucketAggregationBase {
@@ -5341,16 +5351,16 @@ export interface IlmUsage {
 }
 
 export interface IndexActionResult {
-  id: string
   response: IndexActionResultIndexResponse
 }
 
 export interface IndexActionResultIndexResponse {
   created: boolean
-  id: string
+  id: Id
   index: IndexName
   result: Result
   version: integer
+  type?: Type
 }
 
 export interface IndexAliases {
@@ -5632,10 +5642,10 @@ export interface Input {
 }
 
 export interface InputContainer {
-  chain: ChainInput
-  http: HttpInput
-  search: SearchInput
-  simple: SimpleInput
+  chain?: ChainInput
+  http?: HttpInput
+  search?: SearchInput
+  simple?: SimpleInput
 }
 
 export type InputType = 'http' | 'search' | 'simple'
@@ -8724,18 +8734,18 @@ export interface ScheduleBase {
 }
 
 export interface ScheduleContainer {
-  cron: CronExpression
-  daily: DailySchedule
-  hourly: HourlySchedule
-  interval: Interval
-  monthly: Array<TimeOfMonth>
-  weekly: Array<TimeOfWeek>
-  yearly: Array<TimeOfYear>
+  cron?: CronExpression
+  daily?: DailySchedule
+  hourly?: HourlySchedule
+  interval?: Interval
+  monthly?: Array<TimeOfMonth>
+  weekly?: Array<TimeOfWeek>
+  yearly?: Array<TimeOfYear>
 }
 
 export interface ScheduleTriggerEvent {
   scheduled_time: DateString | string
-  triggered_time: DateString | string
+  triggered_time?: DateString | string
 }
 
 export interface ScheduledEvent {
@@ -8767,7 +8777,8 @@ export interface ScriptBase {
 
 export interface ScriptCondition {
   lang: string
-  params: Record<string, any>
+  params?: Record<string, any>
+  source: string
 }
 
 export interface ScriptField {
@@ -9601,34 +9612,31 @@ export interface SizeField {
 
 export interface SlackActionMessageResult {
   message: SlackMessage
-  reason: string
-  request: HttpInputRequestResult
-  response: HttpInputResponseResult
-  status: Status
-  to: string
+  request?: HttpInputRequestResult
+  response?: HttpInputResponseResult
 }
 
 export interface SlackActionResult {
-  account: string
-  sent_messages: Array<SlackActionMessageResult>
+  account?: string
+  message: SlackMessage
 }
 
 export interface SlackAttachment {
-  author_icon: string
-  author_link: string
+  author_icon?: string
+  author_link?: string
   author_name: string
-  color: string
-  fallback: string
-  fields: Array<SlackAttachmentField>
-  footer: string
-  footer_icon: string
-  image_url: string
-  pretext: string
-  text: string
-  thumb_url: string
+  color?: string
+  fallback?: string
+  fields?: Array<SlackAttachmentField>
+  footer?: string
+  footer_icon?: string
+  image_url?: string
+  pretext?: string
+  text?: string
+  thumb_url?: string
   title: string
-  title_link: string
-  ts: DateString
+  title_link?: string
+  ts?: DateString
 }
 
 export interface SlackAttachmentField {
@@ -9644,9 +9652,9 @@ export interface SlackDynamicAttachment {
 
 export interface SlackMessage {
   attachments: Array<SlackAttachment>
-  dynamic_attachments: SlackDynamicAttachment
+  dynamic_attachments?: SlackDynamicAttachment
   from: string
-  icon: string
+  icon?: string
   text: string
   to: Array<string>
 }
@@ -11369,13 +11377,13 @@ export interface WarmerStats {
 }
 
 export interface Watch {
-  actions: Record<string, Action>
+  actions: Record<IndexName, Action>
   condition: ConditionContainer
   input: InputContainer
-  metadata: Record<string, any>
-  status: WatchStatus
-  throttle_period: string
-  transform: TransformContainer
+  metadata?: Record<string, any>
+  status?: WatchStatus
+  throttle_period?: string
+  transform?: TransformContainer
   trigger: TriggerContainer
 }
 
@@ -11389,7 +11397,7 @@ export interface WatchRecord {
   state: ActionExecutionState
   trigger_event: TriggerEventResult
   user: string
-  watch_id: string
+  watch_id: Id
 }
 
 export interface WatchRecordQueuedStats {
@@ -11406,11 +11414,12 @@ export interface WatchRecordStats extends WatchRecordQueuedStats {
 }
 
 export interface WatchStatus {
-  actions: Record<string, ActionStatus>
-  last_checked: DateString
-  last_met_condition: DateString
+  actions: Record<IndexName, ActionStatus>
+  last_checked?: DateString
+  last_met_condition?: DateString
   state: ActivationState
   version: integer
+  execution_state?: string
 }
 
 export interface WatcherNodeStats {
@@ -11438,7 +11447,7 @@ export interface WatcherStatsResponse {
 
 export interface WebhookActionResult {
   request: HttpInputRequestResult
-  response: HttpInputResponseResult
+  response?: HttpInputResponseResult
 }
 
 export interface WeightScoreFunction extends ScoreFunctionBase {

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -40,6 +40,7 @@ type Uri = string
 
 // Date/Time
 type DateString = string
+type Timestamp = string
 type TimeSpan = string
 type EpochMillis = string | long
 
@@ -124,7 +125,6 @@ type NodeIds = string
 type PropertyName = string
 type RelationName = string
 type TaskId = string
-type Timestamp = string
 type Fuzziness = string | integer
 type MultiTermQueryRewrite = string
 type GeoTilePrecision = number

--- a/specification/specs/x_pack/watcher/Watch.ts
+++ b/specification/specs/x_pack/watcher/Watch.ts
@@ -18,12 +18,12 @@
  */
 
 class Watch {
-  actions: Dictionary<string, Action>
+  actions: Dictionary<IndexName, Action>
   condition: ConditionContainer
   input: InputContainer
-  metadata: Dictionary<string, UserDefinedValue>
-  status: WatchStatus
-  throttle_period: string
-  transform: TransformContainer
+  metadata?: Dictionary<string, UserDefinedValue>
+  status?: WatchStatus
+  throttle_period?: string
+  transform?: TransformContainer
   trigger: TriggerContainer
 }

--- a/specification/specs/x_pack/watcher/acknowledge_watch/ActionStatus.ts
+++ b/specification/specs/x_pack/watcher/acknowledge_watch/ActionStatus.ts
@@ -21,5 +21,5 @@ class ActionStatus {
   ack: AcknowledgeState
   last_execution: ExecutionState
   last_successful_execution: ExecutionState
-  last_throttle: ThrottleState
+  last_throttle?: ThrottleState
 }

--- a/specification/specs/x_pack/watcher/acknowledge_watch/ActionStatus.ts
+++ b/specification/specs/x_pack/watcher/acknowledge_watch/ActionStatus.ts
@@ -19,7 +19,7 @@
 
 class ActionStatus {
   ack: AcknowledgeState
-  last_execution: ExecutionState
-  last_successful_execution: ExecutionState
+  last_execution?: ExecutionState
+  last_successful_execution?: ExecutionState
   last_throttle?: ThrottleState
 }

--- a/specification/specs/x_pack/watcher/acknowledge_watch/ActivationState.ts
+++ b/specification/specs/x_pack/watcher/acknowledge_watch/ActivationState.ts
@@ -19,5 +19,5 @@
 
 class ActivationState {
   active: boolean
-  timestamp: DateString
+  timestamp: Timestamp
 }

--- a/specification/specs/x_pack/watcher/acknowledge_watch/WatchStatus.ts
+++ b/specification/specs/x_pack/watcher/acknowledge_watch/WatchStatus.ts
@@ -18,9 +18,10 @@
  */
 
 class WatchStatus {
-  actions: Dictionary<string, ActionStatus>
+  actions: Dictionary<IndexName, ActionStatus>
   last_checked: DateString
   last_met_condition: DateString
   state: ActivationState
   version: integer
+  execution_state: string // TODO find execution states in enum in server codebase
 }

--- a/specification/specs/x_pack/watcher/acknowledge_watch/WatchStatus.ts
+++ b/specification/specs/x_pack/watcher/acknowledge_watch/WatchStatus.ts
@@ -19,9 +19,9 @@
 
 class WatchStatus {
   actions: Dictionary<IndexName, ActionStatus>
-  last_checked: DateString
-  last_met_condition: DateString
+  last_checked?: DateString
+  last_met_condition?: DateString
   state: ActivationState
   version: integer
-  execution_state: string // TODO find execution states in enum in server codebase
+  execution_state?: string // TODO find execution states in enum in server codebase
 }

--- a/specification/specs/x_pack/watcher/action/Action.ts
+++ b/specification/specs/x_pack/watcher/action/Action.ts
@@ -18,11 +18,17 @@
  */
 
 class Action {
-  action_type: ActionType
-  condition: ConditionContainer
-  foreach: string
-  max_iterations: integer
-  name: string
-  throttle_period: Time
-  transform: TransformContainer
+  action_type?: ActionType
+  condition?: ConditionContainer
+  foreach?: string
+  max_iterations?: integer
+  name?: string
+  throttle_period?: Time
+  throttle_period_in_millis?: EpochMillis
+  transform?: TransformContainer
+  index: ActionIndex
+}
+
+class ActionIndex {
+  index: IndexName
 }

--- a/specification/specs/x_pack/watcher/action/slack/SlackAttachment.ts
+++ b/specification/specs/x_pack/watcher/action/slack/SlackAttachment.ts
@@ -18,20 +18,20 @@
  */
 
 class SlackAttachment {
-  author_icon: string
-  author_link: string
+  author_icon?: string
+  author_link?: string
   author_name: string
-  color: string
-  fallback: string
-  fields: SlackAttachmentField[]
-  footer: string
-  footer_icon: string
-  image_url: string
-  pretext: string
-  text: string
-  thumb_url: string
+  color?: string
+  fallback?: string
+  fields?: SlackAttachmentField[]
+  footer?: string
+  footer_icon?: string
+  image_url?: string
+  pretext?: string
+  text?: string
+  thumb_url?: string
   title: string
-  title_link: string
+  title_link?: string
   /** @prop_serializer NullableDateTimeOffsetEpochSecondsFormatter */
-  ts: DateString
+  ts?: DateString
 }

--- a/specification/specs/x_pack/watcher/action/slack/SlackMessage.ts
+++ b/specification/specs/x_pack/watcher/action/slack/SlackMessage.ts
@@ -19,9 +19,9 @@
 
 class SlackMessage {
   attachments: SlackAttachment[]
-  dynamic_attachments: SlackDynamicAttachment
+  dynamic_attachments?: SlackDynamicAttachment
   from: string
-  icon: string
+  icon?: string
   text: string
   to: string[]
 }

--- a/specification/specs/x_pack/watcher/activate_watch/ActivationStatus.ts
+++ b/specification/specs/x_pack/watcher/activate_watch/ActivationStatus.ts
@@ -18,6 +18,7 @@
  */
 
 class ActivationStatus {
-  actions: Dictionary<string, ActionStatus>
+  actions: Dictionary<IndexName, ActionStatus>
   state: ActivationState
+  version: integer
 }

--- a/specification/specs/x_pack/watcher/condition/ConditionContainer.ts
+++ b/specification/specs/x_pack/watcher/condition/ConditionContainer.ts
@@ -18,9 +18,9 @@
  */
 
 class ConditionContainer {
-  always: AlwaysCondition
-  array_compare: ArrayCompareCondition
-  compare: CompareCondition
-  never: NeverCondition
-  script: ScriptCondition
+  always?: AlwaysCondition
+  array_compare?: ArrayCompareCondition
+  compare?: CompareCondition
+  never?: NeverCondition
+  script?: ScriptCondition
 }

--- a/specification/specs/x_pack/watcher/condition/ScriptCondition.ts
+++ b/specification/specs/x_pack/watcher/condition/ScriptCondition.ts
@@ -20,5 +20,6 @@
 @class_serializer('ScriptConditionFormatter')
 class ScriptCondition {
   lang: string
-  params: Dictionary<string, UserDefinedValue>
+  params?: Dictionary<string, UserDefinedValue>
+  source: string
 }

--- a/specification/specs/x_pack/watcher/execute_watch/ExecuteWatchResponse.ts
+++ b/specification/specs/x_pack/watcher/execute_watch/ExecuteWatchResponse.ts
@@ -18,6 +18,6 @@
  */
 
 class ExecuteWatchResponse extends ResponseBase {
-  _id: string
+  _id: Id
   watch_record: WatchRecord
 }

--- a/specification/specs/x_pack/watcher/execute_watch/ExecutionResultAction.ts
+++ b/specification/specs/x_pack/watcher/execute_watch/ExecutionResultAction.ts
@@ -18,14 +18,14 @@
  */
 
 class ExecutionResultAction {
-  email: EmailActionResult
-  id: string
-  index: IndexActionResult
-  logging: LoggingActionResult
-  pagerduty: PagerDutyActionResult
-  reason: string
-  slack: SlackActionResult
+  email?: EmailActionResult
+  id: Id
+  index?: IndexActionResult
+  logging?: LoggingActionResult
+  pagerduty?: PagerDutyActionResult
+  reason?: string
+  slack?: SlackActionResult
   status: Status
   type: ActionType
-  webhook: WebhookActionResult
+  webhook?: WebhookActionResult
 }

--- a/specification/specs/x_pack/watcher/execute_watch/WatchRecord.ts
+++ b/specification/specs/x_pack/watcher/execute_watch/WatchRecord.ts
@@ -27,5 +27,5 @@ class WatchRecord {
   state: ActionExecutionState
   trigger_event: TriggerEventResult
   user: string
-  watch_id: string
+  watch_id: Id
 }

--- a/specification/specs/x_pack/watcher/execution/email/EmailActionResult.ts
+++ b/specification/specs/x_pack/watcher/execution/email/EmailActionResult.ts
@@ -18,7 +18,7 @@
  */
 
 class EmailActionResult {
-  account: string
+  account?: string
   message: EmailResult
-  reason: string
+  reason?: string // TODO: not sure if this needed
 }

--- a/specification/specs/x_pack/watcher/execution/email/EmailResult.ts
+++ b/specification/specs/x_pack/watcher/execution/email/EmailResult.ts
@@ -18,13 +18,13 @@
  */
 
 class EmailResult {
-  bcc: string[]
-  body: EmailBody
-  cc: string[]
-  from: string
-  id: string
-  priority: EmailPriority
-  reply_to: string[]
+  bcc?: string[]
+  body?: EmailBody
+  cc?: string[]
+  from?: string
+  id: Id
+  priority?: EmailPriority
+  reply_to?: string[]
   sent_date: DateString
   subject: string
   to: string[]

--- a/specification/specs/x_pack/watcher/execution/index/IndexActionResult.ts
+++ b/specification/specs/x_pack/watcher/execution/index/IndexActionResult.ts
@@ -18,6 +18,5 @@
  */
 
 class IndexActionResult {
-  id: string
   response: IndexActionResultIndexResponse
 }

--- a/specification/specs/x_pack/watcher/execution/index/IndexActionResultIndexResponse.ts
+++ b/specification/specs/x_pack/watcher/execution/index/IndexActionResultIndexResponse.ts
@@ -19,8 +19,9 @@
 
 class IndexActionResultIndexResponse {
   created: boolean
-  id: string
+  id: Id
   index: IndexName
   result: Result
   version: integer
+  type?: Type
 }

--- a/specification/specs/x_pack/watcher/execution/slack/SlackActionMessageResult.ts
+++ b/specification/specs/x_pack/watcher/execution/slack/SlackActionMessageResult.ts
@@ -19,9 +19,6 @@
 
 class SlackActionMessageResult {
   message: SlackMessage
-  reason: string
-  request: HttpInputRequestResult
-  response: HttpInputResponseResult
-  status: Status
-  to: string
+  request?: HttpInputRequestResult
+  response?: HttpInputResponseResult
 }

--- a/specification/specs/x_pack/watcher/execution/slack/SlackActionResult.ts
+++ b/specification/specs/x_pack/watcher/execution/slack/SlackActionResult.ts
@@ -18,6 +18,7 @@
  */
 
 class SlackActionResult {
-  account: string
-  sent_messages: SlackActionMessageResult[]
+  account?: string
+//  sent_messages?: SlackActionMessageResult[] TODO: not sure if this needed
+  message: SlackMessage
 }

--- a/specification/specs/x_pack/watcher/execution/slack/SlackActionResult.ts
+++ b/specification/specs/x_pack/watcher/execution/slack/SlackActionResult.ts
@@ -19,6 +19,6 @@
 
 class SlackActionResult {
   account?: string
-//  sent_messages?: SlackActionMessageResult[] TODO: not sure if this needed
+  //  sent_messages?: SlackActionMessageResult[] TODO: not sure if this needed
   message: SlackMessage
 }

--- a/specification/specs/x_pack/watcher/execution/webhook/WebhookActionResult.ts
+++ b/specification/specs/x_pack/watcher/execution/webhook/WebhookActionResult.ts
@@ -19,5 +19,5 @@
 
 class WebhookActionResult {
   request: HttpInputRequestResult
-  response: HttpInputResponseResult
+  response?: HttpInputResponseResult
 }

--- a/specification/specs/x_pack/watcher/get_watch/GetWatchResponse.ts
+++ b/specification/specs/x_pack/watcher/get_watch/GetWatchResponse.ts
@@ -19,7 +19,10 @@
 
 class GetWatchResponse extends ResponseBase {
   found: boolean
-  _id: string
-  status: WatchStatus
-  watch: Watch
+  _id: Id
+  status?: WatchStatus
+  watch?: Watch
+  _primary_term?: integer
+  _seq_no?: integer
+  _version?: integer
 }

--- a/specification/specs/x_pack/watcher/input/InputContainer.ts
+++ b/specification/specs/x_pack/watcher/input/InputContainer.ts
@@ -18,8 +18,8 @@
  */
 
 class InputContainer {
-  chain: ChainInput
-  http: HttpInput
-  search: SearchInput
-  simple: SimpleInput
+  chain?: ChainInput
+  http?: HttpInput
+  search?: SearchInput
+  simple?: SimpleInput
 }

--- a/specification/specs/x_pack/watcher/schedule/ScheduleContainer.ts
+++ b/specification/specs/x_pack/watcher/schedule/ScheduleContainer.ts
@@ -18,11 +18,11 @@
  */
 
 class ScheduleContainer {
-  cron: CronExpression
-  daily: DailySchedule
-  hourly: HourlySchedule
-  interval: Interval
-  monthly: TimeOfMonth[]
-  weekly: TimeOfWeek[]
-  yearly: TimeOfYear[]
+  cron?: CronExpression
+  daily?: DailySchedule
+  hourly?: HourlySchedule
+  interval?: Interval
+  monthly?: TimeOfMonth[]
+  weekly?: TimeOfWeek[]
+  yearly?: TimeOfYear[]
 }

--- a/specification/specs/x_pack/watcher/schedule/ScheduleTriggerEvent.ts
+++ b/specification/specs/x_pack/watcher/schedule/ScheduleTriggerEvent.ts
@@ -19,5 +19,5 @@
 
 class ScheduleTriggerEvent {
   scheduled_time: Union<DateString, string>
-  triggered_time: Union<DateString, string>
+  triggered_time?: Union<DateString, string>
 }


### PR DESCRIPTION
endpoints added:
* response for `watcher.ack_watch` 
* response for `watcher.activate_watch` 
* response for `watcher.deactivate_watch` 
* response for `watcher.get_watch` 

Improved validation for `watcher.execute_watch`, close but not cigar!