### PR TITLE
Write validation errors to a json file

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -72632,6 +72632,133 @@
       ]
     },
     {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "operations",
+            "required": false,
+            "type": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              },
+              "kind": "dictionary_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "SearchTemplateRequest",
+                  "namespace": "search.search_template"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "MultiSearchTemplateRequest",
+        "namespace": "search.multi_search_template"
+      },
+      "path": [
+        {
+          "description": "A comma-separated list of index names to use as default",
+          "name": "index",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Indices",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "A comma-separated list of document types to use as default",
+          "name": "type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Types",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "ccs_minimize_roundtrips",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "max_concurrent_searches",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "search_type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SearchType",
+              "namespace": "common"
+            }
+          }
+        },
+        {
+          "name": "total_hits_as_integer",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "typed_keys",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
       "kind": "interface",
       "name": {
         "name": "MultiTermLookup",
@@ -113086,6 +113213,51 @@
             "kind": "instance_of",
             "type": {
               "name": "ulong",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "UpdateByQueryRethrottleRequest",
+        "namespace": "document.multiple.update_by_query_rethrottle"
+      },
+      "path": [
+        {
+          "description": "The task id to rethrottle",
+          "name": "task_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "requests_per_second",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
               "namespace": "internal"
             }
           }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1,0 +1,667 @@
+{
+  "endpointErrors": {
+    "autoscaling.delete_autoscaling_policy": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "autoscaling.get_autoscaling_capacity": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "autoscaling.get_autoscaling_policy": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "autoscaling.put_autoscaling_policy": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "close_point_in_time": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "cluster.delete_component_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "cluster.delete_voting_config_exclusions": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "cluster.exists_component_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "cluster.get_component_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "cluster.post_voting_config_exclusions": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "cluster.put_component_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "dangling_indices.delete_dangling_index": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "dangling_indices.import_dangling_index": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "dangling_indices.list_dangling_indices": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "data_frame_transform_deprecated.delete_transform": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "data_frame_transform_deprecated.get_transform": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "data_frame_transform_deprecated.get_transform_stats": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "data_frame_transform_deprecated.preview_transform": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "data_frame_transform_deprecated.put_transform": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "data_frame_transform_deprecated.start_transform": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "data_frame_transform_deprecated.stop_transform": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "data_frame_transform_deprecated.update_transform": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "eql.delete": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "eql.get": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "eql.get_status": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "eql.search": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "features.get_features": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "get_script_context": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "get_script_languages": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.add_block": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.create_data_stream": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.data_streams_stats": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.delete_data_stream": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.delete_index_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.exists_index_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.get_data_stream": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.get_index_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.get_upgrade": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.migrate_to_data_stream": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.promote_data_stream": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.put_index_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.resolve_index": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.simulate_index_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.simulate_template": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "indices.upgrade": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "logstash.delete_pipeline": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "logstash.get_pipeline": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "logstash.put_pipeline": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "mget": {
+      "request": [
+        "MultiGetRequest: query parameter 'source_enabled' does not exist in the json spec",
+        "MultiGetRequest: should have a body definition"
+      ],
+      "response": [
+        "Type document.multiple.multi_get.request:MultiGetResponse not found"
+      ]
+    },
+    "ml.delete_data_frame_analytics": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.delete_trained_model": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.delete_trained_model_alias": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.evaluate_data_frame": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.explain_data_frame_analytics": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.get_data_frame_analytics": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.get_data_frame_analytics_stats": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.get_jobs": {
+      "request": [
+        "GetJobsRequest: missing json spec query parameter 'allow_no_match'"
+      ],
+      "response": [
+        "type_alias definition x_pack.info.x_pack_usage:UrlConfig / union_of / instance_of - Non-leaf type cannot be used here: 'x_pack.info.x_pack_usage:BaseUrlConfig'"
+      ]
+    },
+    "ml.get_trained_models": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.get_trained_models_stats": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.preview_data_frame_analytics": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.put_data_frame_analytics": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.put_trained_model": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.put_trained_model_alias": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.start_data_frame_analytics": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.stop_data_frame_analytics": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.update_data_frame_analytics": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "ml.upgrade_job_snapshot": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "monitoring.bulk": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "msearch_template": {
+      "request": [
+        "MultiSearchTemplateRequest: query parameter 'total_hits_as_integer' does not exist in the json spec",
+        "MultiSearchTemplateRequest: missing json spec query parameter 'rest_total_hits_as_int'",
+        "MultiSearchTemplateRequest: should have a body definition",
+        "request definition search.multi_search_template:MultiSearchTemplateRequest / body / Property 'operations' / dictionary_of / instance_of - 'search.search_template:SearchTemplateRequest' is a request and must only be used in endpoints"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "open_point_in_time": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "rank_eval": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "rollup.rollup": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "search_template": {
+      "request": [
+        "SearchTemplateRequest: query parameter 'total_hits_as_integer' does not exist in the json spec",
+        "SearchTemplateRequest: missing json spec query parameter 'rest_total_hits_as_int'",
+        "SearchTemplateRequest: should have a body definition"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "searchable_snapshots.clear_cache": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "searchable_snapshots.mount": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "searchable_snapshots.repository_stats": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "searchable_snapshots.stats": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "security.clear_api_key_cache": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "security.clear_cached_privileges": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "security.grant_api_key": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "snapshot.clone": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
+    "watcher.query_watches": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    }
+  },
+  "generalErrors": []
+}

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -7390,6 +7390,19 @@ export interface MultiSearchResponse extends ResponseBase {
   responses: Array<SearchResponse<any>>
 }
 
+export interface MultiSearchTemplateRequest extends RequestBase {
+  index?: Indices
+  type?: Types
+  ccs_minimize_roundtrips?: boolean
+  max_concurrent_searches?: long
+  search_type?: SearchType
+  total_hits_as_integer?: boolean
+  typed_keys?: boolean
+  body: {
+    operations?: Record<string, SearchTemplateRequest>
+  }
+}
+
 export interface MultiTermLookup {
   field: Field
 }
@@ -11814,6 +11827,11 @@ export interface UpdateByQueryResponse extends ResponseBase {
   version_conflicts?: long
   throttled_millis?: ulong
   throttled_until_millis?: ulong
+}
+
+export interface UpdateByQueryRethrottleRequest extends RequestBase {
+  task_id: Id
+  requests_per_second?: long
 }
 
 export interface UpdateDatafeedRequest extends RequestBase {

--- a/specification/compiler/compiler.ts
+++ b/specification/compiler/compiler.ts
@@ -23,6 +23,7 @@ import stringify from 'safe-stable-stringify'
 import { Model } from './model/metamodel'
 import { compileSpecification, compileEndpoints } from './model/build-model'
 import buildJsonSpec, { JsonSpec } from './model/json-spec'
+import * as errors from './validation-errors'
 
 type StepFunction = (model: Model, restSpec: Map<string, JsonSpec>) => Promise<Model>
 
@@ -57,6 +58,12 @@ export default class Compiler {
     await writeFile(
       join(__dirname, '..', '..', 'output', 'schema', 'schema.json'),
       stringify(this.model, null, 2),
+      'utf8'
+    )
+
+    await writeFile(
+      join(__dirname, '..', '..', 'output', 'schema', 'validation-errors.json'),
+      stringify(errors.getValidationErrors(), null, 2),
       'utf8'
     )
   }

--- a/specification/compiler/index.ts
+++ b/specification/compiler/index.ts
@@ -23,6 +23,7 @@ import addInfo from './steps/add-info'
 import addDescription from './steps/add-description'
 import validateModel from './steps/validate-model'
 import addContentType from './steps/add-content-type'
+import * as errors from './validation-errors'
 
 const compiler = new Compiler()
 
@@ -35,6 +36,7 @@ compiler
   .step(validateModel)
   .write()
   .then(() => {
+    errors.logErrors()
     console.log('Done')
   })
   .catch(err => {

--- a/specification/compiler/index.ts
+++ b/specification/compiler/index.ts
@@ -23,7 +23,6 @@ import addInfo from './steps/add-info'
 import addDescription from './steps/add-description'
 import validateModel from './steps/validate-model'
 import addContentType from './steps/add-content-type'
-import * as errors from './validation-errors'
 
 const compiler = new Compiler()
 
@@ -36,7 +35,6 @@ compiler
   .step(validateModel)
   .write()
   .then(() => {
-    errors.logErrors()
     console.log('Done')
   })
   .catch(err => {

--- a/specification/compiler/steps/validate-model.ts
+++ b/specification/compiler/steps/validate-model.ts
@@ -18,7 +18,8 @@
  */
 
 import * as model from '../model/metamodel'
-import * as errors from '../validation-errors'
+import { ValidationErrors } from '../validation-errors'
+import { JsonSpec } from '../model/json-spec'
 
 enum TypeDefKind {
   type,
@@ -35,7 +36,7 @@ enum TypeDefKind {
  * - verify that request parents don't define properties (would they be path/request/body properties?)
  * - verify that unions can be distinguished in a JSON stream (otherwise they should be inheritance trees)
  */
-export default async function validateModel (apiModel: model.Model): Promise<model.Model> {
+export default async function validateModel (apiModel: model.Model, restSpec: Map<string, JsonSpec>, errors: ValidationErrors): Promise<model.Model> {
   // Fail hard if the FAIL_HARD env var is defined
   const failHard = process.env.FAIL_HARD != null
 

--- a/specification/compiler/steps/validate-rest-spec.ts
+++ b/specification/compiler/steps/validate-rest-spec.ts
@@ -18,9 +18,9 @@
  */
 
 import assert from 'assert'
-import chalk from 'chalk'
 import * as model from '../model/metamodel'
 import { JsonSpec } from '../model/json-spec'
+import * as errors from '../validation-errors'
 
 // This code can be simplified once https://github.com/tc39/proposal-set-methods is available
 
@@ -56,14 +56,14 @@ export default async function validateRestSpec (model: model.Model, jsonSpec: Ma
       // are all the parameters in the request definition present in the json spec?
       for (const name of pathProperties) {
         if (!urlParts.includes(name)) {
-          console.warn(`The ${chalk.green(endpoint.request.name)} definition has the path parameter ${chalk.green(name)} which is not present in the json spec`)
+          errors.addEndpointError(endpoint.name, 'request', `${endpoint.request.name}: path parameter '${name}' does not exist in the json spec`)
         }
       }
 
       // are all the parameters in the json spec present in the request definition?
       for (const name of urlParts) {
         if (!pathProperties.includes(name)) {
-          console.warn(`The ${chalk.green(endpoint.request.name)} definition does not include the path parameter ${chalk.green(name)} which is present in the json spec`)
+          errors.addEndpointError(endpoint.name, 'request', `${endpoint.request.name}: missing json spec path parameter '${name}'`)
         }
       }
 
@@ -73,24 +73,24 @@ export default async function validateRestSpec (model: model.Model, jsonSpec: Ma
         // are all the parameters in the request definition present in the json spec?
         for (const name of queryProperties) {
           if (!params.includes(name)) {
-            console.warn(`The ${chalk.green(endpoint.request.name)} definition has the query parameter ${chalk.green(name)} which is not present in the json spec`)
+            errors.addEndpointError(endpoint.name, 'request', `${endpoint.request.name}: query parameter '${name}' does not exist in the json spec`)
           }
         }
 
         // are all the parameters in the json spec present in the request definition?
         for (const name of params) {
           if (!queryProperties.includes(name)) {
-            console.warn(`The ${chalk.green(endpoint.request.name)} definition does not include the query parameter ${chalk.green(name)} which is present in the json spec`)
+            errors.addEndpointError(endpoint.name, 'request', `${endpoint.request.name}: missing json spec query parameter '${name}'`)
           }
         }
       }
 
       if (requestDefinition.body === Body.yesBody && spec.body == null) {
-        console.warn(`The ${chalk.green(endpoint.request.name)} definition should not include a body`)
+        errors.addEndpointError(endpoint.name, 'request', `${endpoint.request.name}: should not have a body`)
       }
 
       if (requestDefinition.body === Body.noBody && spec.body != null && spec.body.required === true) {
-        console.warn(`The ${chalk.green(endpoint.request.name)} definition should include a body`)
+        errors.addEndpointError(endpoint.name, 'request', `${endpoint.request.name}: should have a body definition`)
       }
     }
   }

--- a/specification/compiler/steps/validate-rest-spec.ts
+++ b/specification/compiler/steps/validate-rest-spec.ts
@@ -20,7 +20,7 @@
 import assert from 'assert'
 import * as model from '../model/metamodel'
 import { JsonSpec } from '../model/json-spec'
-import * as errors from '../validation-errors'
+import { ValidationErrors } from '../validation-errors'
 
 // This code can be simplified once https://github.com/tc39/proposal-set-methods is available
 
@@ -37,7 +37,7 @@ const LOG = 'ALL' // default: ALL
  * furthermore it verifies if the body is required or not.
  * If a validation fails, it will log a warning.
  */
-export default async function validateRestSpec (model: model.Model, jsonSpec: Map<string, JsonSpec>): Promise<model.Model> {
+export default async function validateRestSpec (model: model.Model, jsonSpec: Map<string, JsonSpec>, errors: ValidationErrors): Promise<model.Model> {
   for (const endpoint of model.endpoints) {
     if (endpoint.request == null) continue
     const requestDefinition = getProperties(getDefinition(endpoint.request.name))

--- a/specification/compiler/validation-errors.ts
+++ b/specification/compiler/validation-errors.ts
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** Errors for an endpoint */
+export class EndpointError {
+  request: string[]
+  response: string[]
+}
+
+/** Model errors: general errors and endpoint errors */
+export class ValidationErrors {
+  generalErrors: string[]
+  endpointErrors: Record<string, EndpointError>
+}
+
+const endpointErrors = new Map<string, EndpointError>()
+const generalErrors: string[] = []
+
+/** Add some error information relative to an endpoint's request or response */
+export function addEndpointError (endpoint: string, part: 'request' | 'response', message: string): void {
+  let error = endpointErrors.get(endpoint)
+  if (error == null) {
+    error = { request: [], response: [] }
+    endpointErrors.set(endpoint, error)
+  }
+
+  error[part].push(message)
+}
+
+/** Add a general error, unrelated to an endpoint */
+export function addGeneralError (message: string): void {
+  generalErrors.push(message)
+}
+
+export function getValidationErrors (): ValidationErrors {
+  const result = {
+    generalErrors: generalErrors,
+    endpointErrors: {}
+  }
+
+  // Filter out endpoints with no errors
+  for (const [endpoint, error] of endpointErrors) {
+    if (error.request.length !== 0 || error.response.length !== 0) {
+      result.endpointErrors[endpoint] = error
+    }
+  }
+
+  return result
+}
+
+export function logErrors (): void {
+  const logArray = function (errs: string[], prefix = ''): void {
+    for (const err of errs) {
+      console.error(`${prefix}${err}`)
+    }
+  }
+
+  logArray(generalErrors)
+  // eslint-disable-next-line @typescript-eslint/require-array-sort-compare
+  const names = Array.from(endpointErrors.keys()).sort()
+  for (const name of names) {
+    const endpointErrs = endpointErrors.get(name)
+    if (endpointErrs != null) {
+      for (const part of ['request', 'response']) {
+        logArray(endpointErrs[part], `${name} ${part}`)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR collects errors of the different compilation/validation pipeline steps and outputs them as JSON in `output/schema/validation-errors.json` (and also in the console, sorted by endpoint name).

The file is structured by endpoint/request & response with also a section for general errors (e.g. on builtin types) which aren't associated to an endpoint.

This file should be used to show model validation errors in [`clients-flight-recorder/recordings/types-validation/types-validation.md`](https://github.com/elastic/clients-flight-recorder/blob/dev/recordings/types-validation/types-validation.md) to provide a complete picture of input specifications "readiness". I'll prepare a PR in that repo once this one is merged.