### PR TITLE
Remove filter_path from EQL Search

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -49052,17 +49052,6 @@
               "namespace": "common_options.time_unit"
             }
           }
-        },
-        {
-          "name": "filter_path",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
         }
       ]
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4747,7 +4747,6 @@ export interface EqlSearchRequest extends RequestBase {
   keep_alive?: Time
   keep_on_completion?: boolean
   wait_for_completion_timeout?: Time
-  filter_path?: string
   body: {
     query: string
     case_sensitive?: boolean

--- a/specification/specs/x_pack/eql/search/EqlSearchRequest.ts
+++ b/specification/specs/x_pack/eql/search/EqlSearchRequest.ts
@@ -33,7 +33,6 @@ interface EqlSearchRequest extends RequestBase {
     keep_alive?: Time
     keep_on_completion?: boolean
     wait_for_completion_timeout?: Time
-    filter_path?: string
   }
   body?: {
     query: string


### PR DESCRIPTION
`filter_path` is specified in the `CommonQueryParameters` behaviour already. 