### PR TITLE
Switch to aliases

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -49470,43 +49470,24 @@
           }
         },
         {
+          "aliases": [
+            "resource.id"
+          ],
           "name": "resource_id",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          }
-        },
-        {
-          "name": "resource.id",
-          "required": false,
-          "type": {
             "kind": "instance_of",
             "type": {
-              "name": "Id",
+              "name": "Ids",
               "namespace": "internal"
             }
           }
         },
         {
+          "aliases": [
+            "resource.type"
+          ],
           "name": "resource_type",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "resource.type",
           "required": false,
           "type": {
             "kind": "instance_of",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4801,8 +4801,8 @@ export interface ErrorCause {
   phase?: string
   property_name?: string
   processor_type?: string
-  resource_id?: Array<string>
-  'resource.id'?: Id
+  resource_id?: Ids
+  'resource.id'?: Ids
   resource_type?: string
   'resource.type'?: string
   script?: string

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -73,7 +73,7 @@ class ErrorCause {
    * @aliases resource.id
    */
   resource_id?: Ids
-    /**
+  /**
    * resource type
    * @aliases resource.type
    */

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -68,10 +68,16 @@ class ErrorCause {
   phase?: string
   property_name?: string
   processor_type?: string
-  resource_id?: string[]
-  'resource.id'?: Id
+  /**
+   * resource id
+   * @aliases resource.id
+   */
+  resource_id?: Ids
+    /**
+   * resource type
+   * @aliases resource.type
+   */
   resource_type?: string
-  'resource.type'?: string
   script?: string
   script_stack?: string[]
   header?: Dictionary<string, string>


### PR DESCRIPTION
Any reason not to use aliases on these? Today .NET has a custom formatter to handle the oddities of the naming here. I think the approach I've applied on Cat*Records for alias generation should avoid that custom handling.