### PR TITLE
Validate eql.search Response

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -49288,7 +49288,7 @@
       "properties": [
         {
           "name": "total",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49876,32 +49876,20 @@
           "name": "hits",
           "required": true,
           "type": {
-            "items": [
+            "generics": [
               {
-                "generics": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "TEvent",
-                      "namespace": "x_pack.eql"
-                    }
-                  }
-                ],
                 "kind": "instance_of",
                 "type": {
-                  "name": "EqlHits",
+                  "name": "TEvent",
                   "namespace": "x_pack.eql"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "EmptyObject",
-                  "namespace": "internal"
                 }
               }
             ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "EqlHits",
+              "namespace": "x_pack.eql"
+            }
           }
         }
       ]

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -49876,20 +49876,32 @@
           "name": "hits",
           "required": true,
           "type": {
-            "generics": [
+            "items": [
+              {
+                "generics": [
+                  {
+                    "kind": "instance_of",
+                    "type": {
+                      "name": "TEvent",
+                      "namespace": "x_pack.eql"
+                    }
+                  }
+                ],
+                "kind": "instance_of",
+                "type": {
+                  "name": "EqlHits",
+                  "namespace": "x_pack.eql"
+                }
+              },
               {
                 "kind": "instance_of",
                 "type": {
-                  "name": "TEvent",
-                  "namespace": "x_pack.eql"
+                  "name": "EmptyObject",
+                  "namespace": "internal"
                 }
               }
             ],
-            "kind": "instance_of",
-            "type": {
-              "name": "EqlHits",
-              "namespace": "x_pack.eql"
-            }
+            "kind": "union_of"
           }
         }
       ]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4777,7 +4777,7 @@ export interface EqlGetStatusResponse extends ResponseBase {
 }
 
 export interface EqlHits<TEvent = unknown> {
-  total: TotalHits
+  total?: TotalHits
   events?: Array<EqlHitsEvent<TEvent>>
   sequences?: Array<EqlHitsSequence<TEvent>>
 }
@@ -4832,7 +4832,7 @@ export interface EqlSearchResponseBase<TEvent = unknown> extends ResponseBase {
   is_running?: boolean
   took?: integer
   timed_out?: boolean
-  hits: EqlHits<TEvent> | EmptyObject
+  hits: EqlHits<TEvent>
 }
 
 export interface EqlUsage extends XPackUsage {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4832,7 +4832,7 @@ export interface EqlSearchResponseBase<TEvent = unknown> extends ResponseBase {
   is_running?: boolean
   took?: integer
   timed_out?: boolean
-  hits: EqlHits<TEvent>
+  hits: EqlHits<TEvent> | EmptyObject
 }
 
 export interface EqlUsage extends XPackUsage {

--- a/specification/specs/x_pack/eql/EqlHits.ts
+++ b/specification/specs/x_pack/eql/EqlHits.ts
@@ -18,7 +18,7 @@
  */
 
 class EqlHits<TEvent> {
-  total: TotalHits
+  total?: TotalHits
   events?: EqlHitsEvent<TEvent>[]
   sequences?: EqlHitsSequence<TEvent>[]
 }

--- a/specification/specs/x_pack/eql/EqlSearchResponseBase.ts
+++ b/specification/specs/x_pack/eql/EqlSearchResponseBase.ts
@@ -23,5 +23,5 @@ class EqlSearchResponseBase<TEvent> extends ResponseBase {
   is_running?: boolean
   took?: integer
   timed_out?: boolean
-  hits: EqlHits<TEvent>
+  hits: EqlHits<TEvent> | EmptyObject
 }

--- a/specification/specs/x_pack/eql/EqlSearchResponseBase.ts
+++ b/specification/specs/x_pack/eql/EqlSearchResponseBase.ts
@@ -23,5 +23,5 @@ class EqlSearchResponseBase<TEvent> extends ResponseBase {
   is_running?: boolean
   took?: integer
   timed_out?: boolean
-  hits: EqlHits<TEvent> | EmptyObject
+  hits: EqlHits<TEvent>
 }


### PR DESCRIPTION
as titled.

Needed `EmptyObject` union to `hits` property to resolve the no hits found case.