### PR TITLE
Add missing searchable snapshot Endpoints

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -8738,9 +8738,16 @@
       "description": "Clear the cache of searchable snapshots.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-apis.html",
       "name": "searchable_snapshots.clear_cache",
-      "request": null,
+      "request": {
+        "name": "SearchableSnapshotsClearCacheRequest",
+        "namespace": "x_pack.searchable_snapshots.clear_cache"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "SearchableSnapshotsClearCacheResponse",
+        "namespace": "x_pack.searchable_snapshots.clear_cache"
+      },
+      "since": "7.10.0",
       "stability": "experimental",
       "urls": [
         {
@@ -8767,9 +8774,16 @@
       "description": "Mount a snapshot as a searchable index.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-mount-snapshot.html",
       "name": "searchable_snapshots.mount",
-      "request": null,
+      "request": {
+        "name": "SearchableSnapshotsMountRequest",
+        "namespace": "x_pack.searchable_snapshots.mount"
+      },
       "requestBodyRequired": true,
-      "response": null,
+      "response": {
+        "name": "SearchableSnapshotsMountResponse",
+        "namespace": "x_pack.searchable_snapshots.mount"
+      },
+      "since": "7.10.0",
       "stability": "experimental",
       "urls": [
         {
@@ -8787,9 +8801,16 @@
       "description": "DEPRECATED: This API is replaced by the Repositories Metering API.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-apis.html",
       "name": "searchable_snapshots.repository_stats",
-      "request": null,
+      "request": {
+        "name": "SearchableSnapshotsRepositoryStatsRequest",
+        "namespace": "x_pack.searchable_snapshots.repository_stats"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "SearchableSnapshotsRepositoryStatsResponse",
+        "namespace": "x_pack.searchable_snapshots.repository_stats"
+      },
+      "since": "7.10.0",
       "stability": "experimental",
       "urls": [
         {
@@ -102496,6 +102517,150 @@
         "name": "SearchType",
         "namespace": "common"
       }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "SearchableSnapshotsClearCacheRequest",
+        "namespace": "x_pack.searchable_snapshots.clear_cache"
+      },
+      "path": [],
+      "query": []
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "SearchableSnapshotsClearCacheResponse",
+        "namespace": "x_pack.searchable_snapshots.clear_cache"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "SearchableSnapshotsMountRequest",
+        "namespace": "x_pack.searchable_snapshots.mount"
+      },
+      "path": [],
+      "query": []
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "SearchableSnapshotsMountResponse",
+        "namespace": "x_pack.searchable_snapshots.mount"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "SearchableSnapshotsRepositoryStatsRequest",
+        "namespace": "x_pack.searchable_snapshots.repository_stats"
+      },
+      "path": [],
+      "query": []
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "SearchableSnapshotsRepositoryStatsResponse",
+        "namespace": "x_pack.searchable_snapshots.repository_stats"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "attachedBehaviors": [

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -102522,6 +102522,22 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
       "inherits": [
         {
           "type": {
@@ -102535,8 +102551,32 @@
         "name": "SearchableSnapshotsClearCacheRequest",
         "namespace": "x_pack.searchable_snapshots.clear_cache"
       },
-      "path": [],
-      "query": []
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "inherits": [
@@ -102570,6 +102610,22 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
       "inherits": [
         {
           "type": {
@@ -102583,8 +102639,32 @@
         "name": "SearchableSnapshotsMountRequest",
         "namespace": "x_pack.searchable_snapshots.mount"
       },
-      "path": [],
-      "query": []
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "inherits": [
@@ -102618,6 +102698,22 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
       "inherits": [
         {
           "type": {
@@ -102631,8 +102727,32 @@
         "name": "SearchableSnapshotsRepositoryStatsRequest",
         "namespace": "x_pack.searchable_snapshots.repository_stats"
       },
-      "path": [],
-      "query": []
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "inherits": [
@@ -102666,6 +102786,22 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
       "inherits": [
         {
           "type": {
@@ -102679,8 +102815,32 @@
         "name": "SearchableSnapshotsStatsRequest",
         "namespace": "x_pack.searchable_snapshots.stats"
       },
-      "path": [],
-      "query": []
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "inherits": [

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -8807,9 +8807,16 @@
       "description": "Retrieve various statistics about searchable snapshots.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-apis.html",
       "name": "searchable_snapshots.stats",
-      "request": null,
+      "request": {
+        "name": "SearchableSnapshotsStatsRequest",
+        "namespace": "x_pack.searchable_snapshots.stats"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "SearchableSnapshotsStatsResponse",
+        "namespace": "x_pack.searchable_snapshots.stats"
+      },
+      "since": "7.10.0",
       "stability": "experimental",
       "urls": [
         {
@@ -102489,6 +102496,54 @@
         "name": "SearchType",
         "namespace": "common"
       }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "SearchableSnapshotsStatsRequest",
+        "namespace": "x_pack.searchable_snapshots.stats"
+      },
+      "path": [],
+      "query": []
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "SearchableSnapshotsStatsResponse",
+        "namespace": "x_pack.searchable_snapshots.stats"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "inherits": [

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -102614,13 +102614,55 @@
         "kind": "properties",
         "properties": [
           {
-            "name": "stub_c",
+            "name": "index",
             "required": true,
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "integer",
+                "name": "IndexName",
                 "namespace": "internal"
+              }
+            }
+          },
+          {
+            "name": "renamed_index",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "IndexName",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "name": "index_settings",
+            "required": false,
+            "type": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              },
+              "kind": "dictionary_of",
+              "value": {
+                "kind": "user_defined_value"
+              }
+            }
+          },
+          {
+            "name": "ignore_index_settings",
+            "required": false,
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
               }
             }
           }
@@ -102641,12 +102683,25 @@
       },
       "path": [
         {
-          "name": "stub_a",
+          "description": "The name of the repository containing the snapshot of the index to mount",
+          "name": "repository",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "Name",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "The name of the snapshot of the index to mount",
+          "name": "snapshot",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Name",
               "namespace": "internal"
             }
           }
@@ -102654,12 +102709,34 @@
       ],
       "query": [
         {
-          "name": "stub_b",
-          "required": true,
+          "name": "master_timeout",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "Time",
+              "namespace": "common_options.time_unit"
+            }
+          }
+        },
+        {
+          "name": "wait_for_completion",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "storage",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
               "namespace": "internal"
             }
           }
@@ -102682,13 +102759,55 @@
       },
       "properties": [
         {
-          "name": "stub",
+          "name": "snapshot",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "SearchableSnapshotsMountSnapshot",
+              "namespace": "x_pack.searchable_snapshots.mount"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "SearchableSnapshotsMountSnapshot",
+        "namespace": "x_pack.searchable_snapshots.mount"
+      },
+      "properties": [
+        {
+          "name": "snapshot",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Name",
               "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "indices",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Indices",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "shards",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ShardStatistics",
+              "namespace": "common_options.hit"
             }
           }
         }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -370,30 +370,6 @@
         "Missing response"
       ]
     },
-    "searchable_snapshots.clear_cache": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
-    "searchable_snapshots.mount": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
-    "searchable_snapshots.repository_stats": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
     "security.clear_cached_privileges": {
       "request": [
         "Missing request"

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -394,14 +394,6 @@
         "Missing response"
       ]
     },
-    "searchable_snapshots.stats": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
     "security.clear_cached_privileges": {
       "request": [
         "Missing request"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10695,15 +10695,27 @@ export interface SearchableSnapshotsClearCacheResponse extends ResponseBase {
 }
 
 export interface SearchableSnapshotsMountRequest extends RequestBase {
-  stub_a: integer
-  stub_b: integer
+  repository: Name
+  snapshot: Name
+  master_timeout?: Time
+  wait_for_completion?: boolean
+  storage?: string
   body: {
-    stub_c: integer
+    index: IndexName
+    renamed_index?: IndexName
+    index_settings?: Record<string, any>
+    ignore_index_settings?: Array<string>
   }
 }
 
 export interface SearchableSnapshotsMountResponse extends ResponseBase {
-  stub: integer
+  snapshot: SearchableSnapshotsMountSnapshot
+}
+
+export interface SearchableSnapshotsMountSnapshot {
+  snapshot: Name
+  indices: Indices
+  shards: ShardStatistics
 }
 
 export interface SearchableSnapshotsRepositoryStatsRequest extends RequestBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10682,6 +10682,27 @@ export interface SearchTransform {
 
 export type SearchType = 'query_then_fetch' | 'dfs_query_then_fetch'
 
+export interface SearchableSnapshotsClearCacheRequest extends RequestBase {
+}
+
+export interface SearchableSnapshotsClearCacheResponse extends ResponseBase {
+  stub: integer
+}
+
+export interface SearchableSnapshotsMountRequest extends RequestBase {
+}
+
+export interface SearchableSnapshotsMountResponse extends ResponseBase {
+  stub: integer
+}
+
+export interface SearchableSnapshotsRepositoryStatsRequest extends RequestBase {
+}
+
+export interface SearchableSnapshotsRepositoryStatsResponse extends ResponseBase {
+  stub: integer
+}
+
 export interface SearchableSnapshotsStatsRequest extends RequestBase {
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10683,6 +10683,11 @@ export interface SearchTransform {
 export type SearchType = 'query_then_fetch' | 'dfs_query_then_fetch'
 
 export interface SearchableSnapshotsClearCacheRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body?: {
+    stub_c: integer
+  }
 }
 
 export interface SearchableSnapshotsClearCacheResponse extends ResponseBase {
@@ -10690,6 +10695,11 @@ export interface SearchableSnapshotsClearCacheResponse extends ResponseBase {
 }
 
 export interface SearchableSnapshotsMountRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body: {
+    stub_c: integer
+  }
 }
 
 export interface SearchableSnapshotsMountResponse extends ResponseBase {
@@ -10697,6 +10707,11 @@ export interface SearchableSnapshotsMountResponse extends ResponseBase {
 }
 
 export interface SearchableSnapshotsRepositoryStatsRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body?: {
+    stub_c: integer
+  }
 }
 
 export interface SearchableSnapshotsRepositoryStatsResponse extends ResponseBase {
@@ -10704,6 +10719,11 @@ export interface SearchableSnapshotsRepositoryStatsResponse extends ResponseBase
 }
 
 export interface SearchableSnapshotsStatsRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body?: {
+    stub_c: integer
+  }
 }
 
 export interface SearchableSnapshotsStatsResponse extends ResponseBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10682,6 +10682,13 @@ export interface SearchTransform {
 
 export type SearchType = 'query_then_fetch' | 'dfs_query_then_fetch'
 
+export interface SearchableSnapshotsStatsRequest extends RequestBase {
+}
+
+export interface SearchableSnapshotsStatsResponse extends ResponseBase {
+  stub: integer
+}
+
 export interface SearchableSnapshotsUsage extends XPackUsage {
   indices_count: integer
 }

--- a/specification/specs/x_pack/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name searchable_snapshots.clear_cache
+ * @since 7.10.0
+ * @stability TODO
+ */
+interface SearchableSnapshotsClearCacheRequest extends RequestBase {
+  path_parts?: {}
+  query_parameters?: {}
+  body?: {}
+}

--- a/specification/specs/x_pack/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
@@ -23,7 +23,13 @@
  * @stability TODO
  */
 interface SearchableSnapshotsClearCacheRequest extends RequestBase {
-  path_parts?: {}
-  query_parameters?: {}
-  body?: {}
+  path_parts?: {
+    stub_a: integer
+  }
+  query_parameters?: {
+    stub_b: integer
+  }
+  body?: {
+    stub_c: integer
+  }
 }

--- a/specification/specs/x_pack/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheResponse.ts
+++ b/specification/specs/x_pack/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class SearchableSnapshotsClearCacheResponse extends ResponseBase {
+  stub: integer
+}

--- a/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name searchable_snapshots.mount
+ * @since 7.10.0
+ * @stability TODO
+ */
+interface SearchableSnapshotsMountRequest extends RequestBase {
+  path_parts?: {}
+  query_parameters?: {}
+  body?: {}
+}

--- a/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
@@ -24,12 +24,18 @@
  */
 interface SearchableSnapshotsMountRequest extends RequestBase {
   path_parts?: {
-    stub_a: integer
+    repository: Name
+    snapshot: Name
   }
   query_parameters?: {
-    stub_b: integer
+    master_timeout?: Time         // default: 30s
+    wait_for_completion?: boolean // default: false
+    storage?: string              // default: full_copy
   }
   body?: {
-    stub_c: integer
+    index: IndexName
+    renamed_index?: IndexName
+    index_settings?: Dictionary<string, UserDefinedValue>
+    ignore_index_settings?: string[]
   }
 }

--- a/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
@@ -28,9 +28,9 @@ interface SearchableSnapshotsMountRequest extends RequestBase {
     snapshot: Name
   }
   query_parameters?: {
-    master_timeout?: Time         // default: 30s
+    master_timeout?: Time // default: 30s
     wait_for_completion?: boolean // default: false
-    storage?: string              // default: full_copy
+    storage?: string // default: full_copy
   }
   body?: {
     index: IndexName

--- a/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
@@ -23,7 +23,13 @@
  * @stability TODO
  */
 interface SearchableSnapshotsMountRequest extends RequestBase {
-  path_parts?: {}
-  query_parameters?: {}
-  body?: {}
+  path_parts?: {
+    stub_a: integer
+  }
+  query_parameters?: {
+    stub_b: integer
+  }
+  body?: {
+    stub_c: integer
+  }
 }

--- a/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountResponse.ts
+++ b/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class SearchableSnapshotsMountResponse extends ResponseBase {
+  stub: integer
+}

--- a/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountResponse.ts
+++ b/specification/specs/x_pack/searchable_snapshots/mount/SearchableSnapshotsMountResponse.ts
@@ -18,5 +18,11 @@
  */
 
 class SearchableSnapshotsMountResponse extends ResponseBase {
-  stub: integer
+  snapshot: SearchableSnapshotsMountSnapshot
+}
+
+class SearchableSnapshotsMountSnapshot {
+  snapshot: Name
+  indices: Indices
+  shards: ShardStatistics
 }

--- a/specification/specs/x_pack/searchable_snapshots/repository_stats/SearchableSnapshotsRepositoryStatsRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/repository_stats/SearchableSnapshotsRepositoryStatsRequest.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name searchable_snapshots.repository_stats
+ * @since 7.10.0
+ * @stability TODO
+ */
+interface SearchableSnapshotsRepositoryStatsRequest extends RequestBase {
+  path_parts?: {}
+  query_parameters?: {}
+  body?: {}
+}

--- a/specification/specs/x_pack/searchable_snapshots/repository_stats/SearchableSnapshotsRepositoryStatsRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/repository_stats/SearchableSnapshotsRepositoryStatsRequest.ts
@@ -23,7 +23,13 @@
  * @stability TODO
  */
 interface SearchableSnapshotsRepositoryStatsRequest extends RequestBase {
-  path_parts?: {}
-  query_parameters?: {}
-  body?: {}
+  path_parts?: {
+    stub_a: integer
+  }
+  query_parameters?: {
+    stub_b: integer
+  }
+  body?: {
+    stub_c: integer
+  }
 }

--- a/specification/specs/x_pack/searchable_snapshots/repository_stats/SearchableSnapshotsRepositoryStatsResponse.ts
+++ b/specification/specs/x_pack/searchable_snapshots/repository_stats/SearchableSnapshotsRepositoryStatsResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class SearchableSnapshotsRepositoryStatsResponse extends ResponseBase {
+  stub: integer
+}

--- a/specification/specs/x_pack/searchable_snapshots/stats/SearchableSnapshotsStatsRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/stats/SearchableSnapshotsStatsRequest.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name searchable_snapshots.stats
+ * @since 7.10.0
+ * @stability TODO
+ */
+interface SearchableSnapshotsStatsRequest extends RequestBase {
+  path_parts?: {}
+  query_parameters?: {}
+  body?: {}
+}

--- a/specification/specs/x_pack/searchable_snapshots/stats/SearchableSnapshotsStatsRequest.ts
+++ b/specification/specs/x_pack/searchable_snapshots/stats/SearchableSnapshotsStatsRequest.ts
@@ -23,7 +23,13 @@
  * @stability TODO
  */
 interface SearchableSnapshotsStatsRequest extends RequestBase {
-  path_parts?: {}
-  query_parameters?: {}
-  body?: {}
+  path_parts?: {
+    stub_a: integer
+  }
+  query_parameters?: {
+    stub_b: integer
+  }
+  body?: {
+    stub_c: integer
+  }
 }

--- a/specification/specs/x_pack/searchable_snapshots/stats/SearchableSnapshotsStatsResponse.ts
+++ b/specification/specs/x_pack/searchable_snapshots/stats/SearchableSnapshotsStatsResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class SearchableSnapshotsStatsResponse extends ResponseBase {
+  stub: integer
+}


### PR DESCRIPTION
added request & response for:
* searchable_snapshots.clear_cache
* searchable_snapshots.mount
* searchable_snapshots.repository_stats
* searchable_snapshots.stats

the endpoints don't validate (yet) just the classes added ..