### PR TITLE
Validated watcher.stats Response

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -124486,7 +124486,7 @@
       "properties": [
         {
           "name": "current_watches",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -124511,7 +124511,7 @@
         },
         {
           "name": "queued_watches",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13096,9 +13096,9 @@ export interface WatcherActionsUsage {
 }
 
 export interface WatcherNodeStats {
-  current_watches: Array<WatchRecordStats>
+  current_watches?: Array<WatchRecordStats>
   execution_thread_pool: ExecutionThreadPool
-  queued_watches: Array<WatchRecordQueuedStats>
+  queued_watches?: Array<WatchRecordQueuedStats>
   watch_count: long
   watcher_state: WatcherState
   node_id: Id

--- a/specification/specs/x_pack/watcher/watcher_stats/WatcherNodeStats.ts
+++ b/specification/specs/x_pack/watcher/watcher_stats/WatcherNodeStats.ts
@@ -18,9 +18,9 @@
  */
 
 class WatcherNodeStats {
-  current_watches: WatchRecordStats[]
+  current_watches?: WatchRecordStats[]
   execution_thread_pool: ExecutionThreadPool
-  queued_watches: WatchRecordQueuedStats[]
+  queued_watches?: WatchRecordQueuedStats[]
   watch_count: long
   watcher_state: WatcherState
   node_id: Id


### PR DESCRIPTION
as titled.

@delvedor, I wanted to validated the request as well but ran into a type casting issue:
```
expectAssignable<T.WatcherStatsRequest>({
  "metric": "all",
  "emit_stacktraces": "true"
})
```

and `emit_stacktraces` is of type `boolean` in `WatcherStatsRequest.ts` 🤷 