### PR TITLE
Add Indices.data streams Endpoints

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -4467,9 +4467,16 @@
       "description": "Promotes a data stream from a replicated data stream managed by CCR to a regular data stream",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
       "name": "indices.promote_data_stream",
-      "request": null,
+      "request": {
+        "name": "IndicesPromoteDataStreamRequest",
+        "namespace": "x_pack.data_streams.promote_data_stream"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "IndicesPromoteDataStreamResponse",
+        "namespace": "x_pack.data_streams.promote_data_stream"
+      },
+      "since": "7.9.0",
       "stability": "stable",
       "urls": [
         {
@@ -69106,6 +69113,94 @@
             "kind": "instance_of",
             "type": {
               "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "IndicesPromoteDataStreamRequest",
+        "namespace": "x_pack.data_streams.promote_data_stream"
+      },
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "IndicesPromoteDataStreamResponse",
+        "namespace": "x_pack.data_streams.promote_data_stream"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
               "namespace": "internal"
             }
           }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -4150,9 +4150,16 @@
       "description": "Returns data streams.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
       "name": "indices.get_data_stream",
-      "request": null,
+      "request": {
+        "name": "IndicesGetDataStreamRequest",
+        "namespace": "x_pack.data_streams.get_data_stream"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "IndicesGetDataStreamResponse",
+        "namespace": "x_pack.data_streams.get_data_stream"
+      },
+      "since": "7.9.0",
       "stability": "stable",
       "urls": [
         {
@@ -4420,9 +4427,16 @@
       "description": "Migrates an alias to a data stream",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
       "name": "indices.migrate_to_data_stream",
-      "request": null,
+      "request": {
+        "name": "IndicesMigrateToDataStreamRequest",
+        "namespace": "x_pack.data_streams.migrate_to_data_stream"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "IndicesMigrateToDataStreamResponse",
+        "namespace": "x_pack.data_streams.migrate_to_data_stream"
+      },
+      "since": "7.9.0",
       "stability": "stable",
       "urls": [
         {
@@ -68974,6 +68988,128 @@
       "properties": []
     },
     {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "IndicesGetDataStreamRequest",
+        "namespace": "x_pack.data_streams.get_data_stream"
+      },
+      "path": [
+        {
+          "description": "A comma-separated list of data streams to get; use `*` to get all data streams",
+          "name": "name",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "expand_wildcards",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ExpandWildcardOptions",
+              "namespace": "common"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "IndicesGetDataStreamResponse",
+        "namespace": "x_pack.data_streams.get_data_stream"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "IndicesMigrateToDataStreamRequest",
+        "namespace": "x_pack.data_streams.migrate_to_data_stream"
+      },
+      "path": [
+        {
+          "description": "The name of the alias to migrate",
+          "name": "name",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": []
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "AcknowledgedResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "IndicesMigrateToDataStreamResponse",
+        "namespace": "x_pack.data_streams.migrate_to_data_stream"
+      },
+      "properties": []
+    },
+    {
       "kind": "interface",
       "name": {
         "name": "IndicesOptions",
@@ -69098,22 +69234,6 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "stub_c",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "internal"
-              }
-            }
-          }
-        ]
-      },
       "inherits": [
         {
           "type": {
@@ -69129,30 +69249,19 @@
       },
       "path": [
         {
-          "name": "stub_a",
+          "description": "The name of the data stream",
+          "name": "name",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "IndexName",
               "namespace": "internal"
             }
           }
         }
       ],
-      "query": [
-        {
-          "name": "stub_b",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
+      "query": []
     },
     {
       "inherits": [

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -40966,6 +40966,20 @@
       ]
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "DataStreamName",
+        "namespace": "internal"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "string",
+          "namespace": "internal"
+        }
+      }
+    },
+    {
       "inherits": [
         {
           "type": {
@@ -68914,22 +68928,6 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "stub_c",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "internal"
-              }
-            }
-          }
-        ]
-      },
       "inherits": [
         {
           "type": {
@@ -68945,36 +68943,25 @@
       },
       "path": [
         {
-          "name": "stub_a",
+          "description": "A comma-separated list of data streams to delete; use `*` to delete all data streams",
+          "name": "name",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "DataStreamName",
               "namespace": "internal"
             }
           }
         }
       ],
-      "query": [
-        {
-          "name": "stub_b",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
+      "query": []
     },
     {
       "inherits": [
         {
           "type": {
-            "name": "ResponseBase",
+            "name": "AcknowledgedResponseBase",
             "namespace": "common_abstractions.response"
           }
         }
@@ -68984,19 +68971,7 @@
         "name": "IndicesDeleteDataStreamResponse",
         "namespace": "x_pack.data_streams.delete_data_stream"
       },
-      "properties": [
-        {
-          "name": "stub",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
+      "properties": []
     },
     {
       "kind": "interface",

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1314,16 +1314,9 @@
       "description": "Creates a new named collection of auto-follow patterns against a specified remote cluster. Newly created indices on the remote cluster matching any of the specified patterns will be automatically configured as follower indices.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html",
       "name": "ccr.put_auto_follow_pattern",
-      "request": {
-        "name": "CreateAutoFollowPatternRequest",
-        "namespace": "x_pack.cross_cluster_replication.auto_follow.create_auto_follow_pattern"
-      },
+      "request": null,
       "requestBodyRequired": true,
-      "response": {
-        "name": "CreateAutoFollowPatternResponse",
-        "namespace": "x_pack.cross_cluster_replication.auto_follow.create_auto_follow_pattern"
-      },
-      "since": "6.5.0",
+      "response": null,
       "stability": "stable",
       "urls": [
         {
@@ -3619,9 +3612,16 @@
       "description": "Creates a data stream",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
       "name": "indices.create_data_stream",
-      "request": null,
+      "request": {
+        "name": "IndicesCreateDataStreamRequest",
+        "namespace": "x_pack.data_streams.create_data_stream"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "IndicesCreateDataStreamResponse",
+        "namespace": "x_pack.data_streams.create_data_stream"
+      },
+      "since": "7.9.0",
       "stability": "stable",
       "urls": [
         {
@@ -3639,9 +3639,16 @@
       "description": "Provides statistics on operations happening in a data stream.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
       "name": "indices.data_streams_stats",
-      "request": null,
+      "request": {
+        "name": "IndicesDataStreamsStatsRequest",
+        "namespace": "x_pack.data_streams.data_streams_stats"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "IndicesDataStreamsStatsResponse",
+        "namespace": "x_pack.data_streams.data_streams_stats"
+      },
+      "since": "7.9.0",
       "stability": "stable",
       "urls": [
         {
@@ -3725,9 +3732,16 @@
       "description": "Deletes a data stream.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
       "name": "indices.delete_data_stream",
-      "request": null,
+      "request": {
+        "name": "IndicesDeleteDataStreamRequest",
+        "namespace": "x_pack.data_streams.delete_data_stream"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "IndicesDeleteDataStreamResponse",
+        "namespace": "x_pack.data_streams.delete_data_stream"
+      },
+      "since": "7.9.0",
       "stability": "stable",
       "urls": [
         {
@@ -39383,206 +39397,6 @@
         "kind": "properties",
         "properties": [
           {
-            "name": "follow_index_pattern",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "leader_index_patterns",
-            "required": false,
-            "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            }
-          },
-          {
-            "name": "max_outstanding_read_requests",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "long",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "max_outstanding_write_requests",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "max_poll_timeout",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Time",
-                "namespace": "common_options.time_unit"
-              }
-            }
-          },
-          {
-            "name": "max_read_request_operation_count",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "max_read_request_size",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "max_retry_delay",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Time",
-                "namespace": "common_options.time_unit"
-              }
-            }
-          },
-          {
-            "name": "max_write_buffer_count",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "max_write_buffer_size",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "max_write_request_operation_count",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "max_write_request_size",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "remote_cluster",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          }
-        ]
-      },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "common_abstractions.request"
-          }
-        }
-      ],
-      "kind": "request",
-      "name": {
-        "name": "CreateAutoFollowPatternRequest",
-        "namespace": "x_pack.cross_cluster_replication.auto_follow.create_auto_follow_pattern"
-      },
-      "path": [
-        {
-          "description": "The name of the auto follow pattern.",
-          "name": "name",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Name",
-              "namespace": "internal"
-            }
-          }
-        }
-      ],
-      "query": []
-    },
-    {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "common_abstractions.response"
-          }
-        }
-      ],
-      "kind": "interface",
-      "name": {
-        "name": "CreateAutoFollowPatternResponse",
-        "namespace": "x_pack.cross_cluster_replication.auto_follow.create_auto_follow_pattern"
-      },
-      "properties": []
-    },
-    {
-      "attachedBehaviors": [
-        "CommonQueryParameters"
-      ],
-      "body": {
-        "kind": "properties",
-        "properties": [
-          {
             "name": "leader_index",
             "required": false,
             "type": {
@@ -68912,6 +68726,270 @@
         ],
         "kind": "union_of"
       }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "IndicesCreateDataStreamRequest",
+        "namespace": "x_pack.data_streams.create_data_stream"
+      },
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "IndicesCreateDataStreamResponse",
+        "namespace": "x_pack.data_streams.create_data_stream"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "IndicesDataStreamsStatsRequest",
+        "namespace": "x_pack.data_streams.data_streams_stats"
+      },
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "IndicesDataStreamsStatsResponse",
+        "namespace": "x_pack.data_streams.data_streams_stats"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "IndicesDeleteDataStreamRequest",
+        "namespace": "x_pack.data_streams.delete_data_stream"
+      },
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "IndicesDeleteDataStreamResponse",
+        "namespace": "x_pack.data_streams.delete_data_stream"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "kind": "interface",

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -68854,22 +68854,6 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "stub_c",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "internal"
-              }
-            }
-          }
-        ]
-      },
       "inherits": [
         {
           "type": {
@@ -68885,12 +68869,13 @@
       },
       "path": [
         {
-          "name": "stub_a",
-          "required": true,
+          "description": "A comma-separated list of data stream names; use `_all` or empty string to perform the operation on all data streams",
+          "name": "name",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "IndexName",
               "namespace": "internal"
             }
           }
@@ -68898,12 +68883,23 @@
       ],
       "query": [
         {
-          "name": "stub_b",
-          "required": true,
+          "name": "expand_wildcards",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "ExpandWildcardOptions",
+              "namespace": "common"
+            }
+          }
+        },
+        {
+          "name": "human",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
               "namespace": "internal"
             }
           }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -112,14 +112,6 @@
         "Missing response"
       ]
     },
-    "indices.get_data_stream": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
     "indices.get_index_template": {
       "request": [
         "Missing request"
@@ -129,14 +121,6 @@
       ]
     },
     "indices.get_upgrade": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
-    "indices.migrate_to_data_stream": {
       "request": [
         "Missing request"
       ],

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1,5 +1,13 @@
 {
   "endpointErrors": {
+    "ccr.put_auto_follow_pattern": {
+      "request": [
+        "Missing request"
+      ],
+      "response": [
+        "Missing response"
+      ]
+    },
     "data_frame_transform_deprecated.delete_transform": {
       "request": [
         "Missing request"
@@ -81,30 +89,6 @@
       ]
     },
     "indices.add_block": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
-    "indices.create_data_stream": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
-    "indices.data_streams_stats": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
-    "indices.delete_data_stream": {
       "request": [
         "Missing request"
       ],

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -144,14 +144,6 @@
         "Missing response"
       ]
     },
-    "indices.promote_data_stream": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
     "indices.put_index_template": {
       "request": [
         "Missing request"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6995,6 +6995,18 @@ export interface IndicesPrivileges {
   allow_restricted_indices?: boolean
 }
 
+export interface IndicesPromoteDataStreamRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body?: {
+    stub_c: integer
+  }
+}
+
+export interface IndicesPromoteDataStreamResponse extends ResponseBase {
+  stub: integer
+}
+
 export interface IndicesResponseBase extends AcknowledgedResponseBase {
   _shards?: ShardStatistics
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6978,6 +6978,22 @@ export interface IndicesDeleteDataStreamRequest extends RequestBase {
 export interface IndicesDeleteDataStreamResponse extends AcknowledgedResponseBase {
 }
 
+export interface IndicesGetDataStreamRequest extends RequestBase {
+  name?: IndexName
+  expand_wildcards?: ExpandWildcardOptions
+}
+
+export interface IndicesGetDataStreamResponse extends ResponseBase {
+  stub: integer
+}
+
+export interface IndicesMigrateToDataStreamRequest extends RequestBase {
+  name: IndexName
+}
+
+export interface IndicesMigrateToDataStreamResponse extends AcknowledgedResponseBase {
+}
+
 export interface IndicesOptions {
   allow_no_indices: boolean
   expand_wildcards: ExpandWildcards
@@ -6993,11 +7009,7 @@ export interface IndicesPrivileges {
 }
 
 export interface IndicesPromoteDataStreamRequest extends RequestBase {
-  stub_a: integer
-  stub_b: integer
-  body?: {
-    stub_c: integer
-  }
+  name: IndexName
 }
 
 export interface IndicesPromoteDataStreamResponse extends ResponseBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6960,11 +6960,9 @@ export interface IndicesCreateDataStreamResponse extends ResponseBase {
 }
 
 export interface IndicesDataStreamsStatsRequest extends RequestBase {
-  stub_a: integer
-  stub_b: integer
-  body?: {
-    stub_c: integer
-  }
+  name?: IndexName
+  expand_wildcards?: ExpandWildcardOptions
+  human?: boolean
 }
 
 export interface IndicesDataStreamsStatsResponse extends ResponseBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3837,6 +3837,8 @@ export interface DataPathStats {
   type: string
 }
 
+export type DataStreamName = string
+
 export interface DataStreamsUsage extends XPackUsage {
   data_streams: long
   indices_count: long
@@ -6970,15 +6972,10 @@ export interface IndicesDataStreamsStatsResponse extends ResponseBase {
 }
 
 export interface IndicesDeleteDataStreamRequest extends RequestBase {
-  stub_a: integer
-  stub_b: integer
-  body?: {
-    stub_c: integer
-  }
+  name: DataStreamName
 }
 
-export interface IndicesDeleteDataStreamResponse extends ResponseBase {
-  stub: integer
+export interface IndicesDeleteDataStreamResponse extends AcknowledgedResponseBase {
 }
 
 export interface IndicesOptions {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3664,28 +3664,6 @@ export interface CreateApiKeyResponse extends ResponseBase {
   name: string
 }
 
-export interface CreateAutoFollowPatternRequest extends RequestBase {
-  name: Name
-  body: {
-    follow_index_pattern?: string
-    leader_index_patterns?: Array<string>
-    max_outstanding_read_requests?: long
-    max_outstanding_write_requests?: integer
-    max_poll_timeout?: Time
-    max_read_request_operation_count?: integer
-    max_read_request_size?: string
-    max_retry_delay?: Time
-    max_write_buffer_count?: integer
-    max_write_buffer_size?: string
-    max_write_request_operation_count?: integer
-    max_write_request_size?: string
-    remote_cluster?: string
-  }
-}
-
-export interface CreateAutoFollowPatternResponse extends AcknowledgedResponseBase {
-}
-
 export interface CreateFollowIndexRequest extends RequestBase {
   index: IndexName
   wait_for_active_shards?: integer
@@ -6966,6 +6944,42 @@ export interface IndexingStats {
 }
 
 export type Indices = string | Array<string>
+
+export interface IndicesCreateDataStreamRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body?: {
+    stub_c: integer
+  }
+}
+
+export interface IndicesCreateDataStreamResponse extends ResponseBase {
+  stub: integer
+}
+
+export interface IndicesDataStreamsStatsRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body?: {
+    stub_c: integer
+  }
+}
+
+export interface IndicesDataStreamsStatsResponse extends ResponseBase {
+  stub: integer
+}
+
+export interface IndicesDeleteDataStreamRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body?: {
+    stub_c: integer
+  }
+}
+
+export interface IndicesDeleteDataStreamResponse extends ResponseBase {
+  stub: integer
+}
 
 export interface IndicesOptions {
   allow_no_indices: boolean

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -132,6 +132,8 @@ type Metrics = string | string[]
 type Name = string
 type Names = string | string[]
 
+type DataStreamName = string
+
 type ByteSize = long | string
 
 type Percentage = string | float

--- a/specification/specs/x_pack/data_streams/create_data_stream/IndicesCreateDataStreamRequest.ts
+++ b/specification/specs/x_pack/data_streams/create_data_stream/IndicesCreateDataStreamRequest.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name indices.create_data_stream
+ * @since 7.9.0
+ * @stability TODO
+ */
+interface IndicesCreateDataStreamRequest extends RequestBase {
+  path_parts?: {
+    stub_a: integer
+  }
+  query_parameters?: {
+    stub_b: integer
+  }
+  body?: {
+    stub_c: integer
+  }
+}

--- a/specification/specs/x_pack/data_streams/create_data_stream/IndicesCreateDataStreamResponse.ts
+++ b/specification/specs/x_pack/data_streams/create_data_stream/IndicesCreateDataStreamResponse.ts
@@ -17,4 +17,6 @@
  * under the License.
  */
 
-class CreateAutoFollowPatternResponse extends AcknowledgedResponseBase {}
+class IndicesCreateDataStreamResponse extends ResponseBase {
+  stub: integer
+}

--- a/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -24,12 +24,11 @@
  */
 interface IndicesDataStreamsStatsRequest extends RequestBase {
   path_parts?: {
-    stub_a: integer
+    name?: IndexName
   }
   query_parameters?: {
-    stub_b: integer
+    expand_wildcards?: ExpandWildcardOptions // default: open
+    human?: boolean                          // default: false
   }
-  body?: {
-    stub_c: integer
-  }
+  body?: {}
 }

--- a/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name indices.data_streams_stats
+ * @since 7.9.0
+ * @stability TODO
+ */
+interface IndicesDataStreamsStatsRequest extends RequestBase {
+  path_parts?: {
+    stub_a: integer
+  }
+  query_parameters?: {
+    stub_b: integer
+  }
+  body?: {
+    stub_c: integer
+  }
+}

--- a/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -28,7 +28,7 @@ interface IndicesDataStreamsStatsRequest extends RequestBase {
   }
   query_parameters?: {
     expand_wildcards?: ExpandWildcardOptions // default: open
-    human?: boolean                          // default: false
+    human?: boolean // default: false
   }
   body?: {}
 }

--- a/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsResponse.ts
+++ b/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsResponse.ts
@@ -19,4 +19,5 @@
 
 class IndicesDataStreamsStatsResponse extends ResponseBase {
   stub: integer
+  // https://www.elastic.co/guide/en/elasticsearch/reference/7.12/data-stream-stats-api.html#data-stream-stats-api-response-body
 }

--- a/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsResponse.ts
+++ b/specification/specs/x_pack/data_streams/data_streams_stats/IndicesDataStreamsStatsResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class IndicesDataStreamsStatsResponse extends ResponseBase {
+  stub: integer
+}

--- a/specification/specs/x_pack/data_streams/delete_data_stream/IndicesDeleteDataStreamRequest.ts
+++ b/specification/specs/x_pack/data_streams/delete_data_stream/IndicesDeleteDataStreamRequest.ts
@@ -24,12 +24,8 @@
  */
 interface IndicesDeleteDataStreamRequest extends RequestBase {
   path_parts?: {
-    stub_a: integer
+    name: DataStreamName
   }
-  query_parameters?: {
-    stub_b: integer
-  }
-  body?: {
-    stub_c: integer
-  }
+  query_parameters?: {}
+  body?: {}
 }

--- a/specification/specs/x_pack/data_streams/delete_data_stream/IndicesDeleteDataStreamRequest.ts
+++ b/specification/specs/x_pack/data_streams/delete_data_stream/IndicesDeleteDataStreamRequest.ts
@@ -18,28 +18,18 @@
  */
 
 /**
- * @rest_spec_name ccr.put_auto_follow_pattern
- * @since 6.5.0
+ * @rest_spec_name indices.delete_data_stream
+ * @since 7.9.0
  * @stability TODO
  */
-interface CreateAutoFollowPatternRequest extends RequestBase {
+interface IndicesDeleteDataStreamRequest extends RequestBase {
   path_parts?: {
-    name: Name
+    stub_a: integer
   }
-  query_parameters?: {}
+  query_parameters?: {
+    stub_b: integer
+  }
   body?: {
-    follow_index_pattern?: string
-    leader_index_patterns?: string[]
-    max_outstanding_read_requests?: long
-    max_outstanding_write_requests?: integer
-    max_poll_timeout?: Time
-    max_read_request_operation_count?: integer
-    max_read_request_size?: string
-    max_retry_delay?: Time
-    max_write_buffer_count?: integer
-    max_write_buffer_size?: string
-    max_write_request_operation_count?: integer
-    max_write_request_size?: string
-    remote_cluster?: string
+    stub_c: integer
   }
 }

--- a/specification/specs/x_pack/data_streams/delete_data_stream/IndicesDeleteDataStreamResponse.ts
+++ b/specification/specs/x_pack/data_streams/delete_data_stream/IndicesDeleteDataStreamResponse.ts
@@ -17,6 +17,4 @@
  * under the License.
  */
 
-class IndicesDeleteDataStreamResponse extends ResponseBase {
-  stub: integer
-}
+class IndicesDeleteDataStreamResponse extends AcknowledgedResponseBase {}

--- a/specification/specs/x_pack/data_streams/delete_data_stream/IndicesDeleteDataStreamResponse.ts
+++ b/specification/specs/x_pack/data_streams/delete_data_stream/IndicesDeleteDataStreamResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class IndicesDeleteDataStreamResponse extends ResponseBase {
+  stub: integer
+}

--- a/specification/specs/x_pack/data_streams/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/specs/x_pack/data_streams/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name indices.get_data_stream
+ * @since 7.9.0
+ * @stability TODO
+ */
+interface IndicesGetDataStreamRequest extends RequestBase {
+  path_parts?: {
+    name?: Name
+  }
+  query_parameters?: {
+    expand_wildcards?: ExpandWildcardOptions
+  }
+  body?: {}
+}

--- a/specification/specs/x_pack/data_streams/get_data_stream/IndicesGetDataStreamResponse.ts
+++ b/specification/specs/x_pack/data_streams/get_data_stream/IndicesGetDataStreamResponse.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class IndicesGetDataStreamResponse extends ResponseBase {
+  stub: integer
+  // https://www.elastic.co/guide/en/elasticsearch/reference/7.12/indices-get-data-stream.html#get-data-stream-api-response-body
+}

--- a/specification/specs/x_pack/data_streams/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
+++ b/specification/specs/x_pack/data_streams/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
@@ -18,16 +18,14 @@
  */
 
 /**
- * @rest_spec_name indices.get_data_stream
+ * @rest_spec_name indices.migrate_to_data_stream
  * @since 7.9.0
  * @stability TODO
  */
-interface IndicesGetDataStreamRequest extends RequestBase {
+interface IndicesMigrateToDataStreamRequest extends RequestBase {
   path_parts?: {
-    name?: IndexName
+    name: IndexName
   }
-  query_parameters?: {
-    expand_wildcards?: ExpandWildcardOptions
-  }
+  query_parameters?: {}
   body?: {}
 }

--- a/specification/specs/x_pack/data_streams/migrate_to_data_stream/IndicesMigrateToDataStreamResponse.ts
+++ b/specification/specs/x_pack/data_streams/migrate_to_data_stream/IndicesMigrateToDataStreamResponse.ts
@@ -17,17 +17,6 @@
  * under the License.
  */
 
-/**
- * @rest_spec_name indices.get_data_stream
- * @since 7.9.0
- * @stability TODO
- */
-interface IndicesGetDataStreamRequest extends RequestBase {
-  path_parts?: {
-    name?: IndexName
-  }
-  query_parameters?: {
-    expand_wildcards?: ExpandWildcardOptions
-  }
-  body?: {}
+class IndicesMigrateToDataStreamResponse extends ResponseBase {
+  stub: integer
 }

--- a/specification/specs/x_pack/data_streams/migrate_to_data_stream/IndicesMigrateToDataStreamResponse.ts
+++ b/specification/specs/x_pack/data_streams/migrate_to_data_stream/IndicesMigrateToDataStreamResponse.ts
@@ -17,6 +17,4 @@
  * under the License.
  */
 
-class IndicesMigrateToDataStreamResponse extends ResponseBase {
-  stub: integer
-}
+class IndicesMigrateToDataStreamResponse extends AcknowledgedResponseBase {}

--- a/specification/specs/x_pack/data_streams/promote_data_stream/IndicesPromoteDataStreamRequest.ts
+++ b/specification/specs/x_pack/data_streams/promote_data_stream/IndicesPromoteDataStreamRequest.ts
@@ -24,12 +24,8 @@
  */
 interface IndicesPromoteDataStreamRequest extends RequestBase {
   path_parts?: {
-    stub_a: integer
+    name: IndexName
   }
-  query_parameters?: {
-    stub_b: integer
-  }
-  body?: {
-    stub_c: integer
-  }
+  query_parameters?: {}
+  body?: {}
 }

--- a/specification/specs/x_pack/data_streams/promote_data_stream/IndicesPromoteDataStreamRequest.ts
+++ b/specification/specs/x_pack/data_streams/promote_data_stream/IndicesPromoteDataStreamRequest.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name indices.promote_data_stream
+ * @since 7.9.0
+ * @stability TODO
+ */
+interface IndicesPromoteDataStreamRequest extends RequestBase {
+  path_parts?: {
+    stub_a: integer
+  }
+  query_parameters?: {
+    stub_b: integer
+  }
+  body?: {
+    stub_c: integer
+  }
+}

--- a/specification/specs/x_pack/data_streams/promote_data_stream/IndicesPromoteDataStreamResponse.ts
+++ b/specification/specs/x_pack/data_streams/promote_data_stream/IndicesPromoteDataStreamResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class IndicesPromoteDataStreamResponse extends ResponseBase {
+  stub: integer
+}


### PR DESCRIPTION
request & responses for:
* indices.create_data_stream
* indices.data_streams_stats
* indices.delete_data_stream
* indices.promoted_data_stream
* indices.get_data_stream
* indices.migrate_to_data_stream

`indices.delete_data_stream` is validated, the others are stubbed