### PR TITLE
Remove duplicate properties which appear on base types

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -54701,17 +54701,6 @@
           }
         },
         {
-          "name": "ignore_above",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "index",
           "required": false,
           "type": {
@@ -56923,17 +56912,6 @@
             "type": {
               "name": "StringFielddata",
               "namespace": "modules.indices.fielddata.string"
-            }
-          }
-        },
-        {
-          "name": "ignore_above",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "internal"
             }
           }
         },
@@ -72983,17 +72961,6 @@
             "kind": "instance_of",
             "type": {
               "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "ignore_above",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
               "namespace": "internal"
             }
           }
@@ -93464,17 +93431,6 @@
         },
         {
           "name": "index",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "store",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -125743,17 +125699,6 @@
             "type": {
               "name": "ExecutionPhase",
               "namespace": "x_pack.watcher.watcher_stats"
-            }
-          }
-        },
-        {
-          "name": "execution_time",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "DateString",
-              "namespace": "internal"
             }
           }
         },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5369,7 +5369,6 @@ export interface FlattenedProperty extends PropertyBase {
   depth_limit?: integer
   doc_values?: boolean
   eager_global_ordinals?: boolean
-  ignore_above?: integer
   index?: boolean
   index_options?: IndexOptions
   null_value?: string
@@ -5629,7 +5628,6 @@ export interface GenericProperty extends DocValuesPropertyBase {
   analyzer: string
   boost: double
   fielddata: StringFielddata
-  ignore_above: integer
   ignore_malformed: boolean
   index: boolean
   index_options: IndexOptions
@@ -7441,7 +7439,6 @@ export interface KeywordMarkerTokenFilter extends TokenFilterBase {
 export interface KeywordProperty extends DocValuesPropertyBase {
   boost?: double
   eager_global_ordinals?: boolean
-  ignore_above?: integer
   index?: boolean
   index_options?: IndexOptions
   normalizer?: string
@@ -9672,7 +9669,6 @@ export interface RangePropertyBase extends DocValuesPropertyBase {
   boost?: double
   coerce?: boolean
   index?: boolean
-  store?: boolean
 }
 
 export interface RangeQuery extends QueryBase {
@@ -13236,7 +13232,6 @@ export interface WatchRecordQueuedStats {
 
 export interface WatchRecordStats extends WatchRecordQueuedStats {
   execution_phase: ExecutionPhase
-  execution_time: DateString
   triggered_time: DateString
   executed_actions?: Array<string>
   watch_id: Id

--- a/specification/specs/mapping/types/complex/flattened/FlattenedProperty.ts
+++ b/specification/specs/mapping/types/complex/flattened/FlattenedProperty.ts
@@ -22,7 +22,6 @@ class FlattenedProperty extends PropertyBase {
   depth_limit?: integer
   doc_values?: boolean
   eager_global_ordinals?: boolean
-  ignore_above?: integer
   index?: boolean
   index_options?: IndexOptions
   null_value?: string

--- a/specification/specs/mapping/types/core/keyword/KeywordProperty.ts
+++ b/specification/specs/mapping/types/core/keyword/KeywordProperty.ts
@@ -20,7 +20,6 @@
 class KeywordProperty extends DocValuesPropertyBase {
   boost?: double
   eager_global_ordinals?: boolean
-  ignore_above?: integer
   index?: boolean
   index_options?: IndexOptions
   normalizer?: string

--- a/specification/specs/mapping/types/core/range/RangeProperty.ts
+++ b/specification/specs/mapping/types/core/range/RangeProperty.ts
@@ -21,7 +21,6 @@ class RangePropertyBase extends DocValuesPropertyBase {
   boost?: double
   coerce?: boolean
   index?: boolean
-  store?: boolean
 }
 
 type RangeProperty =

--- a/specification/specs/mapping/types/specialized/generic/GenericProperty.ts
+++ b/specification/specs/mapping/types/specialized/generic/GenericProperty.ts
@@ -21,7 +21,6 @@ class GenericProperty extends DocValuesPropertyBase {
   analyzer: string
   boost: double
   fielddata: StringFielddata
-  ignore_above: integer
   ignore_malformed: boolean
   index: boolean
   index_options: IndexOptions

--- a/specification/specs/x_pack/watcher/watcher_stats/WatchRecordStats.ts
+++ b/specification/specs/x_pack/watcher/watcher_stats/WatchRecordStats.ts
@@ -19,7 +19,6 @@
 
 class WatchRecordStats extends WatchRecordQueuedStats {
   execution_phase: ExecutionPhase
-  execution_time: DateString
   triggered_time: DateString
   executed_actions?: Array<string>
   watch_id: Id


### PR DESCRIPTION
The following were flagged in compiler warnings in the .NET generated code because the types included properties which duplicates properties from types they extend.