### PR TITLE
Replace `version` with dedicated Type

### DIFF
--- a/output/dangling-types/dangling.csv
+++ b/output/dangling-types/dangling.csv
@@ -6,6 +6,7 @@ TypeNames,common.ts
 LongId,common.ts
 IndexMetrics,common.ts
 VersionNumbers,common.ts
+VersionStrings,common.ts
 CustomResponseBuilderBase,common/CustomResponseBuilderBase.ts
 ElasticsearchUrlFormatter,common/ElasticsearchUrlFormatter.ts
 HttpMethod,common/HttpMethod.ts

--- a/output/dangling-types/dangling.csv
+++ b/output/dangling-types/dangling.csv
@@ -5,6 +5,7 @@ ActionIds,common.ts
 TypeNames,common.ts
 LongId,common.ts
 IndexMetrics,common.ts
+VersionNumbers,common.ts
 CustomResponseBuilderBase,common/CustomResponseBuilderBase.ts
 ElasticsearchUrlFormatter,common/ElasticsearchUrlFormatter.ts
 HttpMethod,common/HttpMethod.ts

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -11889,7 +11889,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -17778,7 +17778,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Name",
               "namespace": "internal"
             }
           }
@@ -17789,7 +17789,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -19229,7 +19229,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -19678,7 +19678,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -36778,7 +36778,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -36789,7 +36789,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -36800,7 +36800,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -36811,7 +36811,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -36822,7 +36822,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -37184,7 +37184,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -37281,7 +37281,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -40306,7 +40306,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -45577,7 +45577,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -46225,7 +46225,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -46236,7 +46236,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -47750,7 +47750,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -55327,7 +55327,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -55360,7 +55360,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -55382,7 +55382,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -62143,7 +62143,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -62218,7 +62218,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "IndexName",
               "namespace": "internal"
             }
           }
@@ -62257,7 +62257,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -62312,7 +62312,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -62323,7 +62323,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -64112,7 +64112,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -66527,7 +66527,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -67701,7 +67701,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -68283,7 +68283,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -73828,7 +73828,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -73950,7 +73950,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -77692,7 +77692,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -78170,7 +78170,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -78286,7 +78286,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -79279,7 +79279,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -79479,7 +79479,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -85125,7 +85125,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -85737,7 +85737,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -88810,7 +88810,7 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "integer",
+                "name": "VersionNumber",
                 "namespace": "internal"
               }
             }
@@ -89707,7 +89707,7 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "long",
+                "name": "VersionNumber",
                 "namespace": "internal"
               }
             }
@@ -90990,7 +90990,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -91029,7 +91029,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -91062,7 +91062,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -106359,7 +106359,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -107295,7 +107295,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -107306,7 +107306,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Name",
               "namespace": "internal"
             }
           }
@@ -110019,7 +110019,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -111509,7 +111509,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -111816,7 +111816,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -116353,7 +116353,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -117051,7 +117051,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -117166,7 +117166,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -117197,7 +117197,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -117208,7 +117208,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "IndexName",
               "namespace": "internal"
             }
           }
@@ -117251,7 +117251,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -125278,6 +125278,20 @@
       ]
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "VersionNumber",
+        "namespace": "internal"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "long",
+          "namespace": "internal"
+        }
+      }
+    },
+    {
       "inherits": [
         {
           "type": {
@@ -125879,7 +125893,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -126962,7 +126976,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -126973,7 +126987,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "IndexName",
               "namespace": "internal"
             }
           }
@@ -127028,7 +127042,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -127039,7 +127053,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -20746,7 +20746,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -20760,7 +20760,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -20789,7 +20789,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -20804,7 +20804,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "IndexName",
               "namespace": "internal"
             }
           }
@@ -20819,7 +20819,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "IndexName",
               "namespace": "internal"
             }
           }
@@ -20921,7 +20921,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -20936,7 +20936,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Name",
               "namespace": "internal"
             }
           }
@@ -20951,7 +20951,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -25075,7 +25075,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -25145,7 +25145,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -25173,7 +25173,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -25503,7 +25503,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Name",
               "namespace": "internal"
             }
           }
@@ -26702,7 +26702,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Name",
               "namespace": "internal"
             }
           }
@@ -26730,7 +26730,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -27641,7 +27641,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -29216,7 +29216,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -29244,7 +29244,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -29272,7 +29272,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Type",
               "namespace": "internal"
             }
           }
@@ -29341,7 +29341,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "NodeId",
               "namespace": "internal"
             }
           }
@@ -29397,7 +29397,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -29548,7 +29548,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Name",
               "namespace": "internal"
             }
           }
@@ -29591,7 +29591,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -30062,7 +30062,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -30149,7 +30149,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -30425,7 +30425,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -30541,7 +30541,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -31549,7 +31549,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -35150,7 +35150,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -35183,7 +35183,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -48271,7 +48271,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -48282,7 +48282,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -48293,7 +48293,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -69634,7 +69634,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -71980,7 +71980,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -79999,7 +79999,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -80893,7 +80893,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -81425,7 +81425,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -81436,7 +81436,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Name",
               "namespace": "internal"
             }
           }
@@ -81458,7 +81458,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -81640,7 +81640,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Name",
               "namespace": "internal"
             }
           }
@@ -81673,7 +81673,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -85924,7 +85924,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -85960,7 +85960,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -85982,7 +85982,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -104451,7 +104451,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -109665,7 +109665,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -109676,7 +109676,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "VersionNumber",
               "namespace": "internal"
             }
           }
@@ -119097,7 +119097,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -119217,7 +119217,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -124099,7 +124099,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "VersionString",
               "namespace": "internal"
             }
           }
@@ -125315,6 +125315,20 @@
           }
         }
       ]
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "VersionString",
+        "namespace": "internal"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "string",
+          "namespace": "internal"
+        }
+      }
     },
     {
       "kind": "enum",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2775,7 +2775,7 @@ export type CharFilter = HtmlStripCharFilter | MappingCharFilter | PatternReplac
 
 export interface CharFilterBase {
   type: string
-  version?: string
+  version?: VersionString
 }
 
 export interface CharFilterDetail {
@@ -3190,10 +3190,10 @@ export interface ClusterJvmVersion {
   bundled_jdk: boolean
   count: integer
   using_bundled_jdk: boolean
-  version: string
+  version: VersionString
   vm_name: string
   vm_vendor: string
-  vm_version: string
+  vm_version: VersionString
 }
 
 export interface ClusterNetworkTypes {
@@ -4649,9 +4649,9 @@ export interface ElasticsearchVersionInfo {
   build_hash: string
   build_snapshot: boolean
   build_type: string
-  lucene_version: string
-  minimum_index_compatibility_version: string
-  minimum_wire_compatibility_version: string
+  lucene_version: VersionString
+  minimum_index_compatibility_version: VersionString
+  minimum_wire_compatibility_version: VersionString
   number: string
 }
 
@@ -7043,7 +7043,7 @@ export interface IndicesVersionsStats {
   index_count: integer
   primary_shard_count: integer
   total_primary_bytes: long
-  version: string
+  version: VersionString
 }
 
 export interface InferenceAggregation extends PipelineAggregationBase {
@@ -7326,7 +7326,7 @@ export interface Job {
   groups?: Array<string>
   model_plot_config?: ModelPlotConfig
   custom_settings?: CustomSettings
-  job_version?: string
+  job_version?: VersionString
   deleting?: boolean
   daily_model_snapshot_retention_after_days?: long
 }
@@ -8228,7 +8228,7 @@ export type Names = string | Array<string>
 
 export interface NativeCodeInformation {
   build_hash: string
-  version: string
+  version: VersionString
 }
 
 export interface NestedAggregation extends BucketAggregationBase {
@@ -8326,7 +8326,7 @@ export interface NodeInfo {
   total_indexing_buffer: long
   transport: NodeInfoTransport
   transport_address: string
-  version: string
+  version: VersionString
 }
 
 export interface NodeInfoHttp {
@@ -8392,10 +8392,10 @@ export interface NodeJvmInfo {
   memory_pools: Array<string>
   pid: integer
   start_time_in_millis: long
-  version: string
-  vm_name: string
+  version: VersionString
+  vm_name: Name
   vm_vendor: string
-  vm_version: string
+  vm_version: VersionString
 }
 
 export interface NodeJvmStats {
@@ -8415,10 +8415,10 @@ export interface NodeOperatingSystemInfo {
   cpu: NodeInfoOSCPU
   mem: NodeInfoMemory
   name: string
-  pretty_name: string
+  pretty_name: Name
   refresh_interval_in_millis: integer
   swap: NodeInfoMemory
-  version: string
+  version: VersionString
 }
 
 export interface NodePackagingType {
@@ -8915,12 +8915,12 @@ export interface PipelineSimulation {
 export interface PluginStats {
   classname: string
   description: string
-  elasticsearch_version: string
+  elasticsearch_version: VersionString
   extended_plugins: Array<string>
   has_native_controller: boolean
-  java_version: string
+  java_version: VersionString
   name: string
-  version: string
+  version: VersionString
   licensed: boolean
   type: string
 }
@@ -10905,7 +10905,7 @@ export interface Segment {
   search: boolean
   size_in_bytes: double
   num_docs: long
-  version: string
+  version: VersionString
 }
 
 export interface SegmentsRequest extends RequestBase {
@@ -11497,8 +11497,8 @@ export interface SnapshotInfo {
   start_time_in_millis?: EpochMillis
   state?: string
   uuid: Uuid
-  version?: string
-  version_id?: integer
+  version?: VersionString
+  version_id?: VersionNumber
   feature_states?: Array<SnapshotInfoFeatureState>
 }
 
@@ -12515,14 +12515,14 @@ export type TokenFilter = AsciiFoldingTokenFilter | CommonGramsTokenFilter | Con
 
 export interface TokenFilterBase {
   type: string
-  version?: string
+  version?: VersionString
 }
 
 export type Tokenizer = CharGroupTokenizer | EdgeNGramTokenizer | KeywordTokenizer | LetterTokenizer | LowercaseTokenizer | NGramTokenizer | NoriTokenizer | PathHierarchyTokenizer | StandardTokenizer | UaxEmailUrlTokenizer | WhitespaceTokenizer
 
 export interface TokenizerBase {
   type: string
-  version?: string
+  version?: VersionString
 }
 
 export interface TopHit {
@@ -13045,7 +13045,7 @@ export interface UpdateTransformResponse extends ResponseBase {
   pivot: TransformPivot
   source: TransformSource
   sync: TransformSyncContainer
-  version: string
+  version: VersionString
 }
 
 export interface UppercaseProcessor extends ProcessorBase {
@@ -13190,6 +13190,8 @@ export type VersionNumber = long
 export interface VersionProperty extends DocValuesPropertyBase {
   type: 'version'
 }
+
+export type VersionString = string
 
 export type VersionType = 'internal' | 'external' | 'external_gte' | 'force'
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -84,7 +84,7 @@ export interface ActivationState {
 export interface ActivationStatus {
   actions: Record<IndexName, ActionStatus>
   state: ActivationState
-  version: integer
+  version: VersionNumber
 }
 
 export interface AdaptiveSelectionStats {
@@ -694,8 +694,8 @@ export interface AutoFollowPattern {
 }
 
 export interface AutoFollowedCluster {
-  cluster_name: string
-  last_seen_metadata_version: long
+  cluster_name: Name
+  last_seen_metadata_version: VersionNumber
   time_since_last_check_millis: DateString
 }
 
@@ -866,7 +866,7 @@ export interface BulkOperation {
   _index: IndexName
   retry_on_conflict: integer
   routing: Routing
-  version: long
+  version: VersionNumber
   version_type: VersionType
 }
 
@@ -910,7 +910,7 @@ export interface BulkResponseItemBase {
   _seq_no?: long
   _shards?: ShardStatistics
   _type?: string
-  _version?: long
+  _version?: VersionNumber
   forced_refresh?: boolean
   get?: InlineGet<Record<string, any>>
 }
@@ -3387,11 +3387,11 @@ export interface ClusterStateBlockIndex {
   retryable: boolean
   levels: Array<string>
   aliases?: Array<IndexAlias>
-  aliases_version?: integer
-  version?: integer
-  mapping_version?: integer
-  settings_version?: integer
-  routing_num_shards?: integer
+  aliases_version?: VersionNumber
+  version?: VersionNumber
+  mapping_version?: VersionNumber
+  settings_version?: VersionNumber
+  routing_num_shards?: VersionNumber
   state?: string
 }
 
@@ -3431,7 +3431,7 @@ export interface ClusterStateRequest extends RequestBase {
   ignore_unavailable?: boolean
   local?: boolean
   master_timeout?: Time
-  wait_for_metadata_version?: long
+  wait_for_metadata_version?: VersionNumber
   wait_for_timeout?: Time
 }
 
@@ -3441,7 +3441,7 @@ export interface ClusterStateResponse extends ResponseBase {
   master_node?: string
   state?: Array<string>
   state_uuid?: Uuid
-  version?: integer
+  version?: VersionNumber
   blocks?: ClusterStateBlocks
   metadata?: ClusterStateMetadata
 }
@@ -3761,7 +3761,7 @@ export interface CreateRequest<TDocument = unknown> extends RequestBase {
   refresh?: Refresh
   routing?: Routing
   timeout?: Time
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
   wait_for_active_shards?: WaitForActiveShards
   body: TDocument
@@ -4351,7 +4351,7 @@ export interface DeleteRequest extends RequestBase {
   refresh?: Refresh
   routing?: Routing
   timeout?: Time
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
   wait_for_active_shards?: WaitForActiveShards
 }
@@ -4433,8 +4433,8 @@ export interface DeleteWatchRequest extends RequestBase {
 
 export interface DeleteWatchResponse extends ResponseBase {
   found: boolean
-  _id: string
-  _version: integer
+  _id: Id
+  _version: VersionNumber
 }
 
 export type DelimitedPayloadEncoding = 'int' | 'float' | 'identity'
@@ -4588,7 +4588,7 @@ export interface DocumentExistsRequest extends RequestBase {
   source_excludes?: Fields
   source_includes?: Fields
   stored_fields?: Fields
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
 }
 
@@ -5444,12 +5444,12 @@ export interface FollowIndexShardStats {
   failed_read_requests: long
   failed_write_requests: long
   fatal_exception?: ErrorCause
-  follower_aliases_version: long
+  follower_aliases_version: VersionNumber
   follower_global_checkpoint: long
   follower_index: string
-  follower_mapping_version: long
+  follower_mapping_version: VersionNumber
   follower_max_seq_no: long
-  follower_settings_version: long
+  follower_settings_version: VersionNumber
   last_requested_seq_no: long
   leader_global_checkpoint: long
   leader_index: string
@@ -6214,22 +6214,22 @@ export interface GetRequest extends RequestBase {
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
   _source?: boolean | string | Array<string>
 }
 
 export interface GetResponse<TDocument = unknown> extends ResponseBase {
-  _index: string
+  _index: IndexName
   fields?: Record<string, any>
   found: boolean
-  _id: string
+  _id: Id
   _primary_term?: long
   _routing?: string
   _seq_no?: long
   _source?: TDocument
-  _type: string
-  _version?: long
+  _type: Type
+  _version?: VersionNumber
 }
 
 export interface GetRoleMappingRequest extends RequestBase {
@@ -6429,7 +6429,7 @@ export interface GetWatchResponse extends ResponseBase {
   watch?: Watch
   _primary_term?: integer
   _seq_no?: integer
-  _version?: integer
+  _version?: VersionNumber
 }
 
 export interface GlobalAggregation extends BucketAggregationBase {
@@ -6694,7 +6694,7 @@ export interface Hit<TDocument = unknown> {
   _source?: TDocument
   _seq_no?: long
   _primary_term?: long
-  _version?: long
+  _version?: VersionNumber
   sort?: SortResults
 }
 
@@ -6841,7 +6841,7 @@ export interface IndexActionResultIndexResponse {
   id: Id
   index: IndexName
   result: Result
-  version: integer
+  version: VersionNumber
   type?: Type
 }
 
@@ -6904,7 +6904,7 @@ export interface IndexRequest<TDocument = unknown> extends RequestBase {
   refresh?: Refresh
   routing?: Routing
   timeout?: Time
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
   wait_for_active_shards?: WaitForActiveShards
   require_alias?: boolean
@@ -7539,7 +7539,7 @@ export interface LifecycleExplain {
 
 export interface LifecycleExplainPhaseExecution {
   policy: Name
-  version: integer
+  version: VersionNumber
   modified_date_in_millis: EpochMillis
 }
 
@@ -7557,7 +7557,7 @@ export type LifecycleOperationMode = 'RUNNING' | 'STOPPING' | 'STOPPED'
 export interface LifecyclePolicy {
   modified_date: DateString
   policy: Policy
-  version: integer
+  version: VersionNumber
 }
 
 export type Like = string | LikeDocument
@@ -7975,7 +7975,7 @@ export interface MoreLikeThisQuery extends QueryBase {
   routing?: Routing
   stop_words?: StopWords
   unlike?: Like | Array<Like>
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
 }
 
@@ -8028,7 +8028,7 @@ export interface MultiGetHit<TDocument = unknown> {
   _seq_no?: long
   _source?: TDocument
   _type?: Type
-  _version?: long
+  _version?: VersionNumber
 }
 
 export interface MultiGetOperation {
@@ -8039,7 +8039,7 @@ export interface MultiGetOperation {
   _source?: boolean | Fields | SourceFilter
   stored_fields?: Fields
   _type?: Type
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
 }
 
@@ -8141,7 +8141,7 @@ export interface MultiTermVectorOperation {
   positions: boolean
   routing: Routing
   term_statistics: boolean
-  version: long
+  version: VersionNumber
   version_type: VersionType
 }
 
@@ -8157,7 +8157,7 @@ export interface MultiTermVectorsRequest extends RequestBase {
   realtime?: boolean
   routing?: Routing
   term_statistics?: boolean
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
   body?: {
     docs?: Array<MultiTermVectorOperation>
@@ -8820,7 +8820,7 @@ export interface PercolateQuery extends QueryBase {
   index?: IndexName
   preference?: string
   routing?: Routing
-  version?: long
+  version?: VersionNumber
 }
 
 export interface PercolatorProperty extends PropertyBase {
@@ -8891,7 +8891,7 @@ export interface Pipeline {
   description?: string
   on_failure?: Array<ProcessorContainer>
   processors?: Array<ProcessorContainer>
-  version?: long
+  version?: VersionNumber
 }
 
 export interface PipelineAggregationBase extends Aggregation {
@@ -9234,7 +9234,7 @@ export interface PutIndexTemplateRequest extends RequestBase {
     mappings?: TypeMapping
     order?: integer
     settings?: Record<string, any>
-    version?: integer
+    version?: VersionNumber
   }
 }
 
@@ -9322,7 +9322,7 @@ export interface PutPipelineRequest extends RequestBase {
     description?: string
     on_failure?: Array<ProcessorContainer>
     processors?: Array<ProcessorContainer>
-    version?: long
+    version?: VersionNumber
   }
 }
 
@@ -9451,7 +9451,7 @@ export interface PutWatchRequest extends RequestBase {
   active?: boolean
   if_primary_term?: long
   if_sequence_number?: long
-  version?: long
+  version?: VersionNumber
   body?: {
     actions?: Record<string, Action>
     condition?: ConditionContainer
@@ -9465,10 +9465,10 @@ export interface PutWatchRequest extends RequestBase {
 
 export interface PutWatchResponse extends ResponseBase {
   created: boolean
-  _id: string
+  _id: Id
   _primary_term: long
   _seq_no: long
-  _version: integer
+  _version: VersionNumber
 }
 
 export type Quantifier = 'some' | 'all'
@@ -11132,7 +11132,7 @@ export interface ShardRequestCache {
 
 export interface ShardRetentionLeases {
   primary_term: long
-  version: long
+  version: VersionNumber
   leases: Array<ShardLease>
 }
 
@@ -11237,8 +11237,8 @@ export interface ShardStore {
   allocation_id: Id
   attributes: Record<string, any>
   id: Id
-  legacy_version: long
-  name: string
+  legacy_version: VersionNumber
+  name: Name
   store_exception: ShardStoreException
   transport_address: string
 }
@@ -11542,7 +11542,7 @@ export interface SnapshotLifecyclePolicyMetadata {
   next_execution?: DateString
   next_execution_millis: EpochMillis
   policy: SnapshotLifecyclePolicy
-  version: integer
+  version: VersionNumber
   stats: SnapshotLifecycleStats
 }
 
@@ -11697,7 +11697,7 @@ export interface SourceExistsRequest extends RequestBase {
   source_enabled?: boolean
   source_excludes?: Fields
   source_includes?: Fields
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
 }
 
@@ -11729,7 +11729,7 @@ export interface SourceRequest extends RequestBase {
   source_enabled?: boolean
   _source_excludes?: Fields
   _source_includes?: Fields
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
 }
 
@@ -12242,7 +12242,7 @@ export interface TemplateMapping {
   mappings: TypeMapping
   order: integer
   settings: Record<string, any>
-  version?: integer
+  version?: VersionNumber
 }
 
 export interface TermQuery extends QueryBase {
@@ -12312,7 +12312,7 @@ export interface TermVectorsRequest<TDocument = unknown> extends RequestBase {
   realtime?: boolean
   routing?: Routing
   term_statistics?: boolean
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
   body?: {
     doc?: TDocument
@@ -12328,16 +12328,16 @@ export interface TermVectorsResponse extends ResponseBase {
   term_vectors?: Record<Field, TermVector>
   took: long
   _type?: Type
-  _version: long
+  _version: VersionNumber
 }
 
 export interface TermVectorsResult {
   found: boolean
-  id: string
-  index: string
+  id: Id
+  index: IndexName
   term_vectors: Record<Field, TermVector>
   took: long
-  version: long
+  version: VersionNumber
 }
 
 export interface TermsAggregate<TKey = unknown> extends MultiBucketAggregate<TKey> {
@@ -13185,6 +13185,8 @@ export interface VerifyRepositoryResponse extends ResponseBase {
   nodes: Record<string, CompactNodeInfo>
 }
 
+export type VersionNumber = long
+
 export interface VersionProperty extends DocValuesPropertyBase {
   type: 'version'
 }
@@ -13248,7 +13250,7 @@ export interface WatchStatus {
   last_checked?: DateString
   last_met_condition?: DateString
   state: ActivationState
-  version: integer
+  version: VersionNumber
   execution_state?: string
 }
 
@@ -13372,14 +13374,14 @@ export interface WordDelimiterTokenFilter extends TokenFilterBase {
 }
 
 export interface WriteResponseBase extends ResponseBase {
-  _id: string
-  _index: string
+  _id: Id
+  _index: IndexName
   _primary_term: long
   result: Result
   _seq_no: long
   _shards: ShardStatistics
-  _type?: string
-  _version: long
+  _type?: Type
+  _version: VersionNumber
   forced_refresh?: boolean
   error?: ErrorCause
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1051,20 +1051,20 @@ export interface CatCountRequest extends CatRequestBase {
 export type CatCountResponse = CatCountRecord[]
 
 export interface CatDataFrameAnalyticsRecord {
-  id?: string
-  type?: string
-  t?: string
+  id?: Id
+  type?: Type
+  t?: Type
   create_time?: string
   ct?: string
   createTime?: string
-  version?: string
-  v?: string
-  source_index?: string
-  si?: string
-  sourceIndex?: string
-  dest_index?: string
-  di?: string
-  destIndex?: string
+  version?: VersionString
+  v?: VersionString
+  source_index?: IndexName
+  si?: IndexName
+  sourceIndex?: IndexName
+  dest_index?: IndexName
+  di?: IndexName
+  destIndex?: IndexName
   description?: string
   d?: string
   model_memory_limit?: string
@@ -1080,15 +1080,15 @@ export interface CatDataFrameAnalyticsRecord {
   assignment_explanation?: string
   ae?: string
   assignmentExplanation?: string
-  'node.id'?: string
-  ni?: string
-  nodeId?: string
-  'node.name'?: string
-  nn?: string
-  nodeName?: string
-  'node.ephemeral_id'?: string
-  ne?: string
-  nodeEphemeralId?: string
+  'node.id'?: Id
+  ni?: Id
+  nodeId?: Id
+  'node.name'?: Name
+  nn?: Name
+  nodeName?: Name
+  'node.ephemeral_id'?: Id
+  ne?: Id
+  nodeEphemeralId?: Id
   'node.address'?: string
   na?: string
   nodeAddress?: string
@@ -1747,8 +1747,8 @@ export interface CatNodeAttributesRequest extends CatRequestBase {
 export type CatNodeAttributesResponse = CatNodeAttributesRecord[]
 
 export interface CatNodesRecord {
-  id?: string
-  nodeId?: string
+  id?: Id
+  nodeId?: Id
   pid?: string
   p?: string
   ip?: string
@@ -1757,12 +1757,12 @@ export interface CatNodesRecord {
   po?: string
   http_address?: string
   http?: string
-  version?: string
-  v?: string
+  version?: VersionString
+  v?: VersionString
   flavor?: string
   f?: string
-  type?: string
-  t?: string
+  type?: Type
+  t?: Type
   build?: string
   b?: string
   jdk?: string
@@ -1821,8 +1821,8 @@ export interface CatNodesRecord {
   nodeRole?: string
   master?: string
   m?: string
-  name?: string
-  n?: string
+  name?: Name
+  n?: Name
   'completion.size'?: string
   cs?: string
   completionSize?: string
@@ -2041,12 +2041,12 @@ export type CatPendingTasksResponse = CatPendingTasksRecord[]
 
 export interface CatPluginsRecord {
   id?: NodeId
-  name?: string
-  n?: string
+  name?: Name
+  n?: Name
   component?: string
   c?: string
-  version?: string
-  v?: string
+  version?: VersionString
+  v?: VersionString
   description?: string
   d?: string
   type?: Type
@@ -2178,8 +2178,8 @@ export interface CatSegmentsRecord {
   searchable?: string
   is?: string
   isSearchable?: string
-  version?: string
-  v?: string
+  version?: VersionString
+  v?: VersionString
   compound?: string
   ico?: string
   isCompound?: string
@@ -2455,15 +2455,15 @@ export interface CatSnapshotsRequest extends CatRequestBase {
 export type CatSnapshotsResponse = CatSnapshotsRecord[]
 
 export interface CatTasksRecord {
-  id?: string
+  id?: Id
   action?: string
   ac?: string
-  task_id?: string
-  ti?: string
+  task_id?: Id
+  ti?: Id
   parent_task_id?: string
   pti?: string
-  type?: string
-  ty?: string
+  type?: Type
+  ty?: Type
   start_time?: string
   start?: string
   timestamp?: string
@@ -2473,16 +2473,16 @@ export interface CatTasksRecord {
   running_time_ns?: string
   running_time?: string
   time?: string
-  node_id?: string
-  ni?: string
+  node_id?: NodeId
+  ni?: NodeId
   ip?: string
   i?: string
   port?: string
   po?: string
   node?: string
   n?: string
-  version?: string
-  v?: string
+  version?: VersionString
+  v?: VersionString
   x_opaque_id?: string
   x?: string
   description?: string
@@ -2499,15 +2499,15 @@ export interface CatTasksRequest extends CatRequestBase {
 export type CatTasksResponse = CatTasksRecord[]
 
 export interface CatTemplatesRecord {
-  name?: string
-  n?: string
+  name?: Name
+  n?: Name
   index_patterns?: string
   t?: string
   order?: string
   o?: string
   p?: string
-  version?: string
-  v?: string
+  version?: VersionString
+  v?: VersionString
   composed_of?: string
   c?: string
 }
@@ -2569,7 +2569,7 @@ export interface CatThreadPoolRequest extends CatRequestBase {
 export type CatThreadPoolResponse = CatThreadPoolRecord[]
 
 export interface CatTrainedModelsRecord {
-  id?: string
+  id?: Id
   created_by?: string
   c?: string
   createdBy?: string
@@ -2583,8 +2583,8 @@ export interface CatTrainedModelsRecord {
   l?: string
   create_time?: DateString
   ct?: DateString
-  version?: string
-  v?: string
+  version?: VersionString
+  v?: VersionString
   description?: string
   d?: string
   'ingest.pipelines'?: string
@@ -2627,7 +2627,7 @@ export interface CatTrainedModelsRequest extends CatRequestBase {
 export type CatTrainedModelsResponse = CatTrainedModelsRecord[]
 
 export interface CatTransformsRecord {
-  id?: string
+  id?: Id
   state?: string
   s?: string
   checkpoint?: string
@@ -2646,8 +2646,8 @@ export interface CatTransformsRecord {
   create_time?: string
   ct?: string
   createTime?: string
-  version?: string
-  v?: string
+  version?: VersionString
+  v?: VersionString
   source_index?: string
   si?: string
   sourceIndex?: string

--- a/specification/specs/analysis/analyzers/AnalyzerBase.ts
+++ b/specification/specs/analysis/analyzers/AnalyzerBase.ts
@@ -19,5 +19,5 @@
 
 class AnalyzerBase {
   type: string
-  version: string
+  version: VersionString
 }

--- a/specification/specs/analysis/char_filters/CharFilterBase.ts
+++ b/specification/specs/analysis/char_filters/CharFilterBase.ts
@@ -19,7 +19,7 @@
 
 class CharFilterBase {
   type: string
-  version?: string
+  version?: VersionString
 }
 
 type CharFilter =

--- a/specification/specs/analysis/token_filters/TokenFilterBase.ts
+++ b/specification/specs/analysis/token_filters/TokenFilterBase.ts
@@ -19,7 +19,7 @@
 
 class TokenFilterBase {
   type: string
-  version?: string
+  version?: VersionString
 }
 
 type TokenFilter =

--- a/specification/specs/analysis/tokenizers/TokenizerBase.ts
+++ b/specification/specs/analysis/tokenizers/TokenizerBase.ts
@@ -19,7 +19,7 @@
 
 class TokenizerBase {
   type: string
-  version?: string
+  version?: VersionString
 }
 
 type Tokenizer =

--- a/specification/specs/cat/cat_data_frame_analytics/CatDataFrameAnalyticsRecord.ts
+++ b/specification/specs/cat/cat_data_frame_analytics/CatDataFrameAnalyticsRecord.ts
@@ -21,12 +21,12 @@ class CatDataFrameAnalyticsRecord {
   /**
    * the id
    */
-  'id'?: string
+  'id'?: Id
   /**
    * analysis type
    * @aliases t
    */
-  'type'?: string
+  'type'?: Type
   /**
    * job creation time
    * @aliases ct, createTime
@@ -36,17 +36,17 @@ class CatDataFrameAnalyticsRecord {
    * the version of Elasticsearch when the analytics was created
    * @aliases v
    */
-  'version'?: string
+  'version'?: VersionString
   /**
    * source index
    * @aliases si, sourceIndex
    */
-  'source_index'?: string
+  'source_index'?: IndexName
   /**
    * destination index
    * @aliases di, destIndex
    */
-  'dest_index'?: string
+  'dest_index'?: IndexName
   /**
    * description
    * @aliases d
@@ -81,17 +81,17 @@ class CatDataFrameAnalyticsRecord {
    * id of the assigned node
    * @aliases ni, nodeId
    */
-  'node.id'?: string
+  'node.id'?: Id
   /**
    * name of the assigned node
    * @aliases nn, nodeName
    */
-  'node.name'?: string
+  'node.name'?: Name
   /**
    * ephemeral id of the assigned node
    * @aliases ne, nodeEphemeralId
    */
-  'node.ephemeral_id'?: string
+  'node.ephemeral_id'?: Id
   /**
    * network address of the assigned node
    * @aliases na, nodeAddress

--- a/specification/specs/cat/cat_nodes/CatNodesRecord.ts
+++ b/specification/specs/cat/cat_nodes/CatNodesRecord.ts
@@ -22,7 +22,7 @@ class CatNodesRecord {
    * unique node id
    * @aliases nodeId
    */
-  'id'?: string
+  'id'?: Id
   /**
    * process id
    * @aliases p
@@ -48,7 +48,7 @@ class CatNodesRecord {
    * es version
    * @aliases v
    */
-  'version'?: string
+  'version'?: VersionString
   /**
    * es distribution flavor
    * @aliases f
@@ -58,7 +58,7 @@ class CatNodesRecord {
    * es distribution type
    * @aliases t
    */
-  'type'?: string
+  'type'?: Type
   /**
    * es build hash
    * @aliases b
@@ -162,16 +162,18 @@ class CatNodesRecord {
    * @aliases r,role,nodeRole
    */
   'node.role'?: string
+
   /**
    * *:current master
    * @aliases m
    */
   'master'?: string
+
   /**
    * node name
    * @aliases n
    */
-  'name'?: string
+  'name'?: Name
 
   /**
    * size of completion
@@ -184,6 +186,7 @@ class CatNodesRecord {
    * @aliases fm,fielddataMemory
    */
   'fielddata.memory_size'?: string
+
   /**
    * fielddata evictions
    * @aliases fe,fielddataEvictions
@@ -195,16 +198,19 @@ class CatNodesRecord {
    * @aliases qcm,queryCacheMemory
    */
   'query_cache.memory_size'?: string
+
   /**
    * query cache evictions
    * @aliases qce,queryCacheEvictions
    */
   'query_cache.evictions'?: string
+
   /**
    * query cache hit counts
    * @aliases qchc,queryCacheHitCount
    */
   'query_cache.hit_count'?: string
+
   /**
    * query cache miss counts
    * @aliases qcmc,queryCacheMissCount
@@ -216,16 +222,19 @@ class CatNodesRecord {
    * @aliases rcm,requestCacheMemory
    */
   'request_cache.memory_size'?: string
+
   /**
    * request cache evictions
    * @aliases rce,requestCacheEvictions
    */
   'request_cache.evictions'?: string
+
   /**
    * request cache hit counts
    * @aliases rchc,requestCacheHitCount
    */
   'request_cache.hit_count'?: string
+
   /**
    * request cache miss counts
    * @aliases rcmc,requestCacheMissCount
@@ -237,6 +246,7 @@ class CatNodesRecord {
    * @aliases ft,flushTotal
    */
   'flush.total'?: string
+
   /**
    * time spent in flush
    * @aliases ftt,flushTotalTime
@@ -248,31 +258,37 @@ class CatNodesRecord {
    * @aliases gc,getCurrent
    */
   'get.current'?: string
+
   /**
    * time spent in get
    * @aliases gti,getTime
    */
   'get.time'?: string
+
   /**
    * number of get ops
    * @aliases gto,getTotal
    */
   'get.total'?: string
+
   /**
    * time spent in successful gets
    * @aliases geti,getExistsTime
    */
   'get.exists_time'?: string
+
   /**
    * number of successful gets
    * @aliases geto,getExistsTotal
    */
   'get.exists_total'?: string
+
   /**
    * time spent in failed gets
    * @aliases gmti,getMissingTime
    */
   'get.missing_time'?: string
+
   /**
    * number of failed gets
    * @aliases gmto,getMissingTotal
@@ -284,31 +300,37 @@ class CatNodesRecord {
    * @aliases idc,indexingDeleteCurrent
    */
   'indexing.delete_current'?: string
+
   /**
    * time spent in deletions
    * @aliases idti,indexingDeleteTime
    */
   'indexing.delete_time'?: string
+
   /**
    * number of delete ops
    * @aliases idto,indexingDeleteTotal
    */
   'indexing.delete_total'?: string
+
   /**
    * number of current indexing ops
    * @aliases iic,indexingIndexCurrent
    */
   'indexing.index_current'?: string
+
   /**
    * time spent in indexing
    * @aliases iiti,indexingIndexTime
    */
   'indexing.index_time'?: string
+
   /**
    * number of indexing ops
    * @aliases iito,indexingIndexTotal
    */
   'indexing.index_total'?: string
+
   /**
    * number of failed indexing ops
    * @aliases iif,indexingIndexFailed
@@ -320,21 +342,25 @@ class CatNodesRecord {
    * @aliases mc,mergesCurrent
    */
   'merges.current'?: string
+
   /**
    * number of current merging docs
    * @aliases mcd,mergesCurrentDocs
    */
   'merges.current_docs'?: string
+
   /**
    * size of current merges
    * @aliases mcs,mergesCurrentSize
    */
   'merges.current_size'?: string
+
   /**
    * number of completed merge ops
    * @aliases mt,mergesTotal
    */
   'merges.total'?: string
+
   /**
    * docs merged
    * @aliases mtd,mergesTotalDocs

--- a/specification/specs/cat/cat_plugins/CatPluginsRecord.ts
+++ b/specification/specs/cat/cat_plugins/CatPluginsRecord.ts
@@ -26,7 +26,7 @@ class CatPluginsRecord {
    * node name
    * @aliases n
    */
-  'name'?: string
+  'name'?: Name
   /**
    * component
    * @aliases c
@@ -36,7 +36,7 @@ class CatPluginsRecord {
    * component version
    * @aliases v
    */
-  'version'?: string
+  'version'?: VersionString
   /**
    * plugin details
    * @aliases d

--- a/specification/specs/cat/cat_segments/CatSegmentsRecord.ts
+++ b/specification/specs/cat/cat_segments/CatSegmentsRecord.ts
@@ -85,7 +85,7 @@ class CatSegmentsRecord {
    * version
    * @aliases v
    */
-  'version'?: string
+  'version'?: VersionString
   /**
    * is segment compound
    * @aliases ico,isCompound

--- a/specification/specs/cat/cat_tasks/CatTasksRecord.ts
+++ b/specification/specs/cat/cat_tasks/CatTasksRecord.ts
@@ -21,7 +21,7 @@ class CatTasksRecord {
   /**
    * id of the task with the node
    */
-  'id'?: string
+  'id'?: Id
   /**
    * task action
    * @aliases ac
@@ -31,7 +31,7 @@ class CatTasksRecord {
    * unique task id
    * @aliases ti
    */
-  'task_id'?: string
+  'task_id'?: Id
   /**
    * parent task id
    * @aliases pti
@@ -41,7 +41,7 @@ class CatTasksRecord {
    * task type
    * @aliases ty
    */
-  'type'?: string
+  'type'?: Type
   /**
    * start time in ms
    * @aliases start
@@ -61,13 +61,11 @@ class CatTasksRecord {
    * @aliases time
    */
   'running_time'?: string
-
-  // Node info
   /**
    * unique node id
    * @aliases ni
    */
-  'node_id'?: string
+  'node_id'?: NodeId
   /**
    * ip address
    * @aliases i
@@ -87,7 +85,7 @@ class CatTasksRecord {
    * es version
    * @aliases v
    */
-  'version'?: string
+  'version'?: VersionString
   /**
    * X-Opaque-ID header
    * @aliases x

--- a/specification/specs/cat/cat_templates/CatTemplatesRecord.ts
+++ b/specification/specs/cat/cat_templates/CatTemplatesRecord.ts
@@ -22,7 +22,7 @@ class CatTemplatesRecord {
    * template name
    * @aliases n
    */
-  'name'?: string
+  'name'?: Name
   /**
    * template index patterns
    * @aliases t
@@ -37,7 +37,7 @@ class CatTemplatesRecord {
    * version
    * @aliases v
    */
-  'version'?: string
+  'version'?: VersionString
   /**
    * component templates comprising index template
    * @aliases c

--- a/specification/specs/cat/cat_trained_models/CatTrainedModelsRecord.ts
+++ b/specification/specs/cat/cat_trained_models/CatTrainedModelsRecord.ts
@@ -21,8 +21,7 @@ class CatTrainedModelsRecord {
   /**
    * the trained model id
    */
-  'id'?: string
-
+  'id'?: Id
   /**
    * who created the model
    * @aliases c, createdBy
@@ -52,14 +51,12 @@ class CatTrainedModelsRecord {
    * The version of Elasticsearch when the model was created
    * @aliases v
    */
-  'version'?: string
+  'version'?: VersionString
   /**
    * The model description
    * @aliases d
    */
   'description'?: string
-
-  // Trained Model Stats
   /**
    * The number of pipelines referencing the model
    * @aliases ip, ingestPipelines

--- a/specification/specs/cat/cat_transforms/CatTransformsRecord.ts
+++ b/specification/specs/cat/cat_transforms/CatTransformsRecord.ts
@@ -21,7 +21,7 @@ class CatTransformsRecord {
   /**
    * the id
    */
-  'id'?: string
+  'id'?: Id
   /**
    * transform state
    * @aliases s
@@ -61,7 +61,7 @@ class CatTransformsRecord {
    * the version of Elasticsearch when the transform was created
    * @aliases v
    */
-  'version'?: string
+  'version'?: VersionString
   /**
    * source index
    * @aliases si, sourceIndex

--- a/specification/specs/cluster/cluster_state/ClusterStateBlocks.ts
+++ b/specification/specs/cluster/cluster_state/ClusterStateBlocks.ts
@@ -26,10 +26,10 @@ class ClusterStateBlockIndex {
   retryable: boolean
   levels: string[]
   aliases?: Array<IndexAlias>
-  aliases_version?: integer
-  version?: integer
-  mapping_version?: integer
-  settings_version?: integer
-  routing_num_shards?: integer
+  aliases_version?: VersionNumber
+  version?: VersionNumber
+  mapping_version?: VersionNumber
+  settings_version?: VersionNumber
+  routing_num_shards?: VersionNumber
   state?: string // TODO: create enum of values
 }

--- a/specification/specs/cluster/cluster_state/ClusterStateRequest.ts
+++ b/specification/specs/cluster/cluster_state/ClusterStateRequest.ts
@@ -34,7 +34,7 @@ interface ClusterStateRequest extends RequestBase {
     ignore_unavailable?: boolean
     local?: boolean
     master_timeout?: Time
-    wait_for_metadata_version?: long
+    wait_for_metadata_version?: VersionNumber
     wait_for_timeout?: Time
   }
   body?: {}

--- a/specification/specs/cluster/cluster_state/ClusterStateResponse.ts
+++ b/specification/specs/cluster/cluster_state/ClusterStateResponse.ts
@@ -23,7 +23,7 @@ class ClusterStateResponse extends ResponseBase {
   master_node?: string
   state?: string[]
   state_uuid?: Uuid
-  version?: integer
+  version?: VersionNumber
   blocks?: ClusterStateBlocks
   metadata?: ClusterStateMetadata
 }

--- a/specification/specs/cluster/cluster_stats/ClusterIndicesStats.ts
+++ b/specification/specs/cluster/cluster_stats/ClusterIndicesStats.ts
@@ -74,5 +74,5 @@ class IndicesVersionsStats {
   index_count: integer
   primary_shard_count: integer
   total_primary_bytes: long
-  version: string
+  version: VersionString
 }

--- a/specification/specs/cluster/cluster_stats/ClusterJvmVersion.ts
+++ b/specification/specs/cluster/cluster_stats/ClusterJvmVersion.ts
@@ -21,8 +21,8 @@ class ClusterJvmVersion {
   bundled_jdk: boolean
   count: integer
   using_bundled_jdk: boolean
-  version: string
+  version: VersionString
   vm_name: string
   vm_vendor: string
-  vm_version: string
+  vm_version: VersionString
 }

--- a/specification/specs/cluster/nodes_info/NodeInfo.ts
+++ b/specification/specs/cluster/nodes_info/NodeInfo.ts
@@ -38,5 +38,5 @@ class NodeInfo {
   total_indexing_buffer: long
   transport: NodeInfoTransport
   transport_address: string
-  version: string
+  version: VersionString
 }

--- a/specification/specs/cluster/nodes_info/NodeJvmInfo.ts
+++ b/specification/specs/cluster/nodes_info/NodeJvmInfo.ts
@@ -23,8 +23,8 @@ class NodeJvmInfo {
   memory_pools: string[]
   pid: integer
   start_time_in_millis: long
-  version: string
-  vm_name: string
+  version: VersionString
+  vm_name: Name
   vm_vendor: string
-  vm_version: string
+  vm_version: VersionString
 }

--- a/specification/specs/cluster/nodes_info/NodeOperatingSystemInfo.ts
+++ b/specification/specs/cluster/nodes_info/NodeOperatingSystemInfo.ts
@@ -23,8 +23,8 @@ class NodeOperatingSystemInfo {
   cpu: NodeInfoOSCPU
   mem: NodeInfoMemory
   name: string
-  pretty_name: string
+  pretty_name: Name
   refresh_interval_in_millis: integer
   swap: NodeInfoMemory
-  version: string
+  version: VersionString
 }

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -136,6 +136,9 @@ type ByteSize = long | string
 
 type Percentage = string | float
 
+type VersionNumber = long
+type VersionNumbers = VersionNumber[]
+
 // TODO: replace all uuid's with this type
 type Uuid = string
 

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -136,8 +136,11 @@ type ByteSize = long | string
 
 type Percentage = string | float
 
+// Versionining Numbers & Strings
 type VersionNumber = long
 type VersionNumbers = VersionNumber[]
+type VersionString = string
+type VersionStrings = VersionString[]
 
 // TODO: replace all uuid's with this type
 type Uuid = string

--- a/specification/specs/common_abstractions/response/ElasticsearchVersionInfo.ts
+++ b/specification/specs/common_abstractions/response/ElasticsearchVersionInfo.ts
@@ -23,8 +23,8 @@ class ElasticsearchVersionInfo {
   build_hash: string
   build_snapshot: boolean
   build_type: string
-  lucene_version: string
-  minimum_index_compatibility_version: string
-  minimum_wire_compatibility_version: string
+  lucene_version: VersionString
+  minimum_index_compatibility_version: VersionString
+  minimum_wire_compatibility_version: VersionString
   number: string
 }

--- a/specification/specs/common_options/stats/PluginStats.ts
+++ b/specification/specs/common_options/stats/PluginStats.ts
@@ -20,12 +20,12 @@
 class PluginStats {
   classname: string
   description: string
-  elasticsearch_version: string
+  elasticsearch_version: VersionString
   extended_plugins: string[]
   has_native_controller: boolean
-  java_version: string
+  java_version: VersionString
   name: string
-  version: string
+  version: VersionString
   licensed: boolean
   type: string
 }

--- a/specification/specs/document/multiple/bulk/bulk_operation/BulkOperation.ts
+++ b/specification/specs/document/multiple/bulk/bulk_operation/BulkOperation.ts
@@ -22,7 +22,7 @@ class BulkOperation {
   _index: IndexName
   retry_on_conflict: integer
   routing: Routing
-  version: long
+  version: VersionNumber
   version_type: VersionType
 }
 

--- a/specification/specs/document/multiple/bulk/bulk_response_item/BulkResponseItemBase.ts
+++ b/specification/specs/document/multiple/bulk/bulk_response_item/BulkResponseItemBase.ts
@@ -30,7 +30,7 @@ class BulkResponseItemBase {
   _seq_no?: long
   _shards?: ShardStatistics
   _type?: string
-  _version?: long
+  _version?: VersionNumber
   forced_refresh?: boolean
   get?: InlineGet<Dictionary<string, UserDefinedValue>>
 }

--- a/specification/specs/document/multiple/multi_get/MultiGetRequest.ts
+++ b/specification/specs/document/multiple/multi_get/MultiGetRequest.ts
@@ -53,6 +53,6 @@ class MultiGetOperation {
   _source?: boolean | Fields | SourceFilter
   stored_fields?: Fields
   _type?: Type
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
 }

--- a/specification/specs/document/multiple/multi_get/MultiGetResponse.ts
+++ b/specification/specs/document/multiple/multi_get/MultiGetResponse.ts
@@ -33,5 +33,5 @@ class MultiGetHit<TDocument> {
   _seq_no?: long
   _source?: TDocument
   _type?: Type
-  _version?: long
+  _version?: VersionNumber
 }

--- a/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorOperation.ts
+++ b/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorOperation.ts
@@ -18,7 +18,6 @@
  */
 
 class MultiTermVectorOperation {
-  /** @prop_serializer SourceFormatter`1 */
   doc: any
   fields: Fields
   field_statistics: boolean
@@ -30,6 +29,6 @@ class MultiTermVectorOperation {
   positions: boolean
   routing: Routing
   term_statistics: boolean
-  version: long
+  version: VersionNumber
   version_type: VersionType
 }

--- a/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorsRequest.ts
+++ b/specification/specs/document/multiple/multi_term_vectors/MultiTermVectorsRequest.ts
@@ -37,7 +37,7 @@ interface MultiTermVectorsRequest extends RequestBase {
     realtime?: boolean
     routing?: Routing
     term_statistics?: boolean
-    version?: long
+    version?: VersionNumber
     version_type?: VersionType
   }
   body?: {

--- a/specification/specs/document/single/WriteResponseBase.ts
+++ b/specification/specs/document/single/WriteResponseBase.ts
@@ -18,14 +18,14 @@
  */
 
 class WriteResponseBase extends ResponseBase {
-  _id: string
-  _index: string
+  _id: Id
+  _index: IndexName
   _primary_term: long
   result: Result
   _seq_no: long
   _shards: ShardStatistics
-  _type?: string
-  _version: long
+  _type?: Type
+  _version: VersionNumber
   forced_refresh?: boolean
   error?: ErrorCause
 }

--- a/specification/specs/document/single/create/CreateRequest.ts
+++ b/specification/specs/document/single/create/CreateRequest.ts
@@ -34,7 +34,7 @@ interface CreateRequest<TDocument> extends RequestBase {
     refresh?: Refresh
     routing?: Routing
     timeout?: Time
-    version?: long
+    version?: VersionNumber
     version_type?: VersionType
     wait_for_active_shards?: WaitForActiveShards
   }

--- a/specification/specs/document/single/delete/DeleteRequest.ts
+++ b/specification/specs/document/single/delete/DeleteRequest.ts
@@ -34,7 +34,7 @@ interface DeleteRequest extends RequestBase {
     refresh?: Refresh
     routing?: Routing
     timeout?: Time
-    version?: long
+    version?: VersionNumber
     version_type?: VersionType
     wait_for_active_shards?: WaitForActiveShards
   }

--- a/specification/specs/document/single/exists/DocumentExistsRequest.ts
+++ b/specification/specs/document/single/exists/DocumentExistsRequest.ts
@@ -37,7 +37,7 @@ interface DocumentExistsRequest extends RequestBase {
     source_excludes?: Fields
     source_includes?: Fields
     stored_fields?: Fields
-    version?: long
+    version?: VersionNumber
     version_type?: VersionType
   }
   body?: {}

--- a/specification/specs/document/single/get/GetRequest.ts
+++ b/specification/specs/document/single/get/GetRequest.ts
@@ -37,7 +37,7 @@ interface GetRequest extends RequestBase {
     _source_excludes?: Fields
     _source_includes?: Fields
     stored_fields?: Fields
-    version?: long
+    version?: VersionNumber
     version_type?: VersionType
     _source?: boolean | string | string[]
   }

--- a/specification/specs/document/single/get/GetResponse.ts
+++ b/specification/specs/document/single/get/GetResponse.ts
@@ -18,15 +18,14 @@
  */
 
 class GetResponse<TDocument> extends ResponseBase {
-  _index: string
+  _index: IndexName
   fields?: Dictionary<string, UserDefinedValue>
   found: boolean
-  _id: string
+  _id: Id
   _primary_term?: long
   _routing?: string
   _seq_no?: long
-  /** @prop_serializer SourceFormatter`1 */
   _source?: TDocument
-  _type: string
-  _version?: long
+  _type: Type
+  _version?: VersionNumber
 }

--- a/specification/specs/document/single/index/IndexRequest.ts
+++ b/specification/specs/document/single/index/IndexRequest.ts
@@ -37,7 +37,7 @@ interface IndexRequest<TDocument> extends RequestBase {
     refresh?: Refresh
     routing?: Routing
     timeout?: Time
-    version?: long
+    version?: VersionNumber
     version_type?: VersionType
     wait_for_active_shards?: WaitForActiveShards
     require_alias?: boolean

--- a/specification/specs/document/single/source/SourceRequest.ts
+++ b/specification/specs/document/single/source/SourceRequest.ts
@@ -36,7 +36,7 @@ interface SourceRequest extends RequestBase {
     source_enabled?: boolean
     _source_excludes?: Fields
     _source_includes?: Fields
-    version?: long
+    version?: VersionNumber
     version_type?: VersionType
   }
   body?: {}

--- a/specification/specs/document/single/source_exists/SourceExistsRequest.ts
+++ b/specification/specs/document/single/source_exists/SourceExistsRequest.ts
@@ -36,7 +36,7 @@ interface SourceExistsRequest extends RequestBase {
     source_enabled?: boolean
     source_excludes?: Fields
     source_includes?: Fields
-    version?: long
+    version?: VersionNumber
     version_type?: VersionType
   }
   body?: {}

--- a/specification/specs/document/single/term_vectors/TermVectorsRequest.ts
+++ b/specification/specs/document/single/term_vectors/TermVectorsRequest.ts
@@ -38,7 +38,7 @@ interface TermVectorsRequest<TDocument> extends RequestBase {
     realtime?: boolean
     routing?: Routing
     term_statistics?: boolean
-    version?: long
+    version?: VersionNumber
     version_type?: VersionType
   }
   body?: {

--- a/specification/specs/document/single/term_vectors/TermVectorsResponse.ts
+++ b/specification/specs/document/single/term_vectors/TermVectorsResponse.ts
@@ -24,5 +24,5 @@ class TermVectorsResponse extends ResponseBase {
   term_vectors?: Dictionary<Field, TermVector>
   took: long
   _type?: Type
-  _version: long
+  _version: VersionNumber
 }

--- a/specification/specs/document/single/term_vectors/TermVectorsResult.ts
+++ b/specification/specs/document/single/term_vectors/TermVectorsResult.ts
@@ -19,9 +19,9 @@
 
 class TermVectorsResult {
   found: boolean
-  id: string
-  index: string
+  id: Id
+  index: IndexName
   term_vectors: Dictionary<Field, TermVector>
   took: long
-  version: long
+  version: VersionNumber
 }

--- a/specification/specs/indices/index_settings/index_templates/get_index_template/TemplateMapping.ts
+++ b/specification/specs/indices/index_settings/index_templates/get_index_template/TemplateMapping.ts
@@ -23,5 +23,5 @@ class TemplateMapping {
   mappings: TypeMapping
   order: integer
   settings: Dictionary<string, UserDefinedValue>
-  version?: integer
+  version?: VersionNumber
 }

--- a/specification/specs/indices/index_settings/index_templates/put_index_template/PutIndexTemplateRequest.ts
+++ b/specification/specs/indices/index_settings/index_templates/put_index_template/PutIndexTemplateRequest.ts
@@ -39,6 +39,6 @@ interface PutIndexTemplateRequest extends RequestBase {
     mappings?: TypeMapping
     order?: integer
     settings?: Dictionary<string, UserDefinedValue>
-    version?: integer
+    version?: VersionNumber
   }
 }

--- a/specification/specs/indices/monitoring/indices_segments/Segment.ts
+++ b/specification/specs/indices/monitoring/indices_segments/Segment.ts
@@ -27,5 +27,5 @@ class Segment {
   search: boolean
   size_in_bytes: double
   num_docs: long
-  version: string
+  version: VersionString
 }

--- a/specification/specs/indices/monitoring/indices_shard_stores/ShardStore.ts
+++ b/specification/specs/indices/monitoring/indices_shard_stores/ShardStore.ts
@@ -22,8 +22,8 @@ class ShardStore {
   allocation_id: Id
   attributes: Dictionary<string, UserDefinedValue>
   id: Id
-  legacy_version: long
-  name: string
+  legacy_version: VersionNumber
+  name: Name
   store_exception: ShardStoreException
   transport_address: string
 }

--- a/specification/specs/indices/monitoring/indices_stats/ShardRetentionLeases.ts
+++ b/specification/specs/indices/monitoring/indices_stats/ShardRetentionLeases.ts
@@ -19,6 +19,6 @@
 
 class ShardRetentionLeases {
   primary_term: long
-  version: long
+  version: VersionNumber
   leases: ShardLease[]
 }

--- a/specification/specs/ingest/Pipeline.ts
+++ b/specification/specs/ingest/Pipeline.ts
@@ -21,5 +21,5 @@ class Pipeline {
   description?: string
   on_failure?: ProcessorContainer[]
   processors?: ProcessorContainer[]
-  version?: long
+  version?: VersionNumber
 }

--- a/specification/specs/ingest/put_pipeline/PutPipelineRequest.ts
+++ b/specification/specs/ingest/put_pipeline/PutPipelineRequest.ts
@@ -34,6 +34,6 @@ interface PutPipelineRequest extends RequestBase {
     description?: string
     on_failure?: ProcessorContainer[]
     processors?: ProcessorContainer[]
-    version?: long
+    version?: VersionNumber
   }
 }

--- a/specification/specs/modules/snapshot_and_restore/snapshot/SnapshotInfo.ts
+++ b/specification/specs/modules/snapshot_and_restore/snapshot/SnapshotInfo.ts
@@ -33,7 +33,7 @@ class SnapshotInfo {
   start_time_in_millis?: EpochMillis
   state?: string
   uuid: Uuid
-  version?: string
-  version_id?: integer
+  version?: VersionString
+  version_id?: VersionNumber
   feature_states?: SnapshotInfoFeatureState[]
 }

--- a/specification/specs/query_dsl/specialized/more_like_this/MoreLikeThisQuery.ts
+++ b/specification/specs/query_dsl/specialized/more_like_this/MoreLikeThisQuery.ts
@@ -34,6 +34,6 @@ class MoreLikeThisQuery extends QueryBase {
   routing?: Routing
   stop_words?: StopWords
   unlike?: Like | Like[]
-  version?: long
+  version?: VersionNumber
   version_type?: VersionType
 }

--- a/specification/specs/query_dsl/specialized/percolate/PercolateQuery.ts
+++ b/specification/specs/query_dsl/specialized/percolate/PercolateQuery.ts
@@ -27,5 +27,5 @@ class PercolateQuery extends QueryBase {
   index?: IndexName
   preference?: string
   routing?: Routing
-  version?: long
+  version?: VersionNumber
 }

--- a/specification/specs/search/search/hits/Hit.ts
+++ b/specification/specs/search/search/hits/Hit.ts
@@ -39,6 +39,6 @@ class Hit<TDocument> {
   _source?: TDocument
   _seq_no?: long
   _primary_term?: long
-  _version?: long
+  _version?: VersionNumber
   sort?: SortResults
 }

--- a/specification/specs/search/search/hits/HitMetadata.ts
+++ b/specification/specs/search/search/hits/HitMetadata.ts
@@ -26,5 +26,5 @@ class HitMetadata<TDocument> {
   /** @prop_serializer SourceFormatter`1 */
   _source: TDocument
   _type: string
-  _version: long
+  _version: VersionNumber
 }

--- a/specification/specs/x_pack/cross_cluster_replication/follow/follow_index_stats/FollowIndexShardStats.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/follow/follow_index_stats/FollowIndexShardStats.ts
@@ -22,12 +22,12 @@ class FollowIndexShardStats {
   failed_read_requests: long
   failed_write_requests: long
   fatal_exception?: ErrorCause
-  follower_aliases_version: long
+  follower_aliases_version: VersionNumber
   follower_global_checkpoint: long
   follower_index: string
-  follower_mapping_version: long
+  follower_mapping_version: VersionNumber
   follower_max_seq_no: long
-  follower_settings_version: long
+  follower_settings_version: VersionNumber
   last_requested_seq_no: long
   leader_global_checkpoint: long
   leader_index: string

--- a/specification/specs/x_pack/cross_cluster_replication/stats/AutoFollowedCluster.ts
+++ b/specification/specs/x_pack/cross_cluster_replication/stats/AutoFollowedCluster.ts
@@ -18,8 +18,7 @@
  */
 
 class AutoFollowedCluster {
-  cluster_name: string
-  last_seen_metadata_version: long
-  /** @prop_serializer DateTimeOffsetEpochMillisecondsFormatter */
+  cluster_name: Name
+  last_seen_metadata_version: VersionNumber
   time_since_last_check_millis: DateString
 }

--- a/specification/specs/x_pack/ilm/explain_lifecycle/LifecycleExplain.ts
+++ b/specification/specs/x_pack/ilm/explain_lifecycle/LifecycleExplain.ts
@@ -38,6 +38,6 @@ class LifecycleExplain {
 
 class LifecycleExplainPhaseExecution {
   policy: Name
-  version: integer
+  version: VersionNumber
   modified_date_in_millis: EpochMillis
 }

--- a/specification/specs/x_pack/ilm/get_lifecycle/LifecyclePolicy.ts
+++ b/specification/specs/x_pack/ilm/get_lifecycle/LifecyclePolicy.ts
@@ -18,8 +18,7 @@
  */
 
 class LifecyclePolicy {
-  /** @prop_serializer DateTimeOffsetEpochMillisecondsFormatter */
   modified_date: DateString
   policy: Policy
-  version: integer
+  version: VersionNumber
 }

--- a/specification/specs/x_pack/info/x_pack_info/NativeCodeInformation.ts
+++ b/specification/specs/x_pack/info/x_pack_info/NativeCodeInformation.ts
@@ -19,5 +19,5 @@
 
 class NativeCodeInformation {
   build_hash: string
-  version: string
+  version: VersionString
 }

--- a/specification/specs/x_pack/info/x_pack_usage/Job.ts
+++ b/specification/specs/x_pack/info/x_pack_usage/Job.ts
@@ -42,7 +42,7 @@ class Job {
   groups?: string[]
   model_plot_config?: ModelPlotConfig
   custom_settings?: CustomSettings
-  job_version?: string
+  job_version?: VersionString
   deleting?: boolean
   daily_model_snapshot_retention_after_days?: long
 }

--- a/specification/specs/x_pack/slm/SnapshotLifecyclePolicyMetadata.ts
+++ b/specification/specs/x_pack/slm/SnapshotLifecyclePolicyMetadata.ts
@@ -26,7 +26,7 @@ class SnapshotLifecyclePolicyMetadata {
   next_execution?: DateString
   next_execution_millis: EpochMillis
   policy: SnapshotLifecyclePolicy
-  version: integer
+  version: VersionNumber
   stats: SnapshotLifecycleStats
 }
 

--- a/specification/specs/x_pack/transform/update_transform/UpdateTransformResponse.ts
+++ b/specification/specs/x_pack/transform/update_transform/UpdateTransformResponse.ts
@@ -27,5 +27,5 @@ class UpdateTransformResponse extends ResponseBase {
   pivot: TransformPivot
   source: TransformSource
   sync: TransformSyncContainer
-  version: string
+  version: VersionString
 }

--- a/specification/specs/x_pack/watcher/acknowledge_watch/WatchStatus.ts
+++ b/specification/specs/x_pack/watcher/acknowledge_watch/WatchStatus.ts
@@ -22,6 +22,6 @@ class WatchStatus {
   last_checked?: DateString
   last_met_condition?: DateString
   state: ActivationState
-  version: integer
+  version: VersionNumber
   execution_state?: string // TODO find execution states in enum in server codebase
 }

--- a/specification/specs/x_pack/watcher/activate_watch/ActivationStatus.ts
+++ b/specification/specs/x_pack/watcher/activate_watch/ActivationStatus.ts
@@ -20,5 +20,5 @@
 class ActivationStatus {
   actions: Dictionary<IndexName, ActionStatus>
   state: ActivationState
-  version: integer
+  version: VersionNumber
 }

--- a/specification/specs/x_pack/watcher/delete_watch/DeleteWatchResponse.ts
+++ b/specification/specs/x_pack/watcher/delete_watch/DeleteWatchResponse.ts
@@ -19,6 +19,6 @@
 
 class DeleteWatchResponse extends ResponseBase {
   found: boolean
-  _id: string
-  _version: integer
+  _id: Id
+  _version: VersionNumber
 }

--- a/specification/specs/x_pack/watcher/execution/index/IndexActionResultIndexResponse.ts
+++ b/specification/specs/x_pack/watcher/execution/index/IndexActionResultIndexResponse.ts
@@ -22,6 +22,6 @@ class IndexActionResultIndexResponse {
   id: Id
   index: IndexName
   result: Result
-  version: integer
+  version: VersionNumber
   type?: Type
 }

--- a/specification/specs/x_pack/watcher/get_watch/GetWatchResponse.ts
+++ b/specification/specs/x_pack/watcher/get_watch/GetWatchResponse.ts
@@ -24,5 +24,5 @@ class GetWatchResponse extends ResponseBase {
   watch?: Watch
   _primary_term?: integer
   _seq_no?: integer
-  _version?: integer
+  _version?: VersionNumber
 }

--- a/specification/specs/x_pack/watcher/put_watch/PutWatchRequest.ts
+++ b/specification/specs/x_pack/watcher/put_watch/PutWatchRequest.ts
@@ -30,7 +30,7 @@ interface PutWatchRequest extends RequestBase {
     active?: boolean
     if_primary_term?: long
     if_sequence_number?: long
-    version?: long
+    version?: VersionNumber
   }
   body?: {
     actions?: Dictionary<string, Action>

--- a/specification/specs/x_pack/watcher/put_watch/PutWatchResponse.ts
+++ b/specification/specs/x_pack/watcher/put_watch/PutWatchResponse.ts
@@ -19,8 +19,8 @@
 
 class PutWatchResponse extends ResponseBase {
   created: boolean
-  _id: string
+  _id: Id
   _primary_term: long
   _seq_no: long
-  _version: integer
+  _version: VersionNumber
 }


### PR DESCRIPTION
introduced the types in common.ts:
```
type VersionNumber = long
type VersionNumbers = VersionNumber[]
type VersionString = string
type VersionStrings = VersionString[]
```

and replaced all occurrences of:
* `*version*?{0,1}: [integer, long]` with `VersionNumber`
* `*version*?{0,1}: string` with `VersionString`
Aliases such as `v` included.