### PR TITLE
watcher.stats Request

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -11223,7 +11223,7 @@
         "name": "WatcherStatsResponse",
         "namespace": "x_pack.watcher.watcher_stats"
       },
-      "since": "0.0.0",
+      "since": "5.5.0",
       "stability": "stable",
       "urls": [
         {

--- a/specification/specs/x_pack/watcher/watcher_stats/WatcherStatsRequest.ts
+++ b/specification/specs/x_pack/watcher/watcher_stats/WatcherStatsRequest.ts
@@ -19,7 +19,7 @@
 
 /**
  * @rest_spec_name watcher.stats
- * @since 0.0.0
+ * @since 5.5.0
  * @stability TODO
  */
 interface WatcherStatsRequest extends RequestBase {


### PR DESCRIPTION
The request is failing to validate based on the casting of `true` a string `"true"`. The [docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.12/watcher-api-stats.html) state that `emit_stacktraces` is of type `boolean` but the compiler presents a string:
```
expectAssignable<T.WatcherStatsRequest>({
  "metric": "all",
  "emit_stacktraces": "true"
})
``` 