### PR TITLE
Stubbed Req & Resp for get_script_* APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -2981,9 +2981,16 @@
       "description": "Returns all script contexts.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html",
       "name": "get_script_context",
-      "request": null,
+      "request": {
+        "name": "GetScriptContextRequest",
+        "namespace": "modules.scripting.get_script_context"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "GetScriptContextResponse",
+        "namespace": "modules.scripting.get_script_context"
+      },
+      "since": "0.0.0",
       "stability": "experimental",
       "urls": [
         {
@@ -3001,9 +3008,16 @@
       "description": "Returns available script types, languages and contexts",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
       "name": "get_script_languages",
-      "request": null,
+      "request": {
+        "name": "GetScriptLanguagesRequest",
+        "namespace": "modules.scripting.get_script_languages"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "GetScriptLanguagesResponse",
+        "namespace": "modules.scripting.get_script_languages"
+      },
+      "since": "0.0.0",
       "stability": "experimental",
       "urls": [
         {
@@ -62847,6 +62861,182 @@
                 "name": "RollupJobInformation",
                 "namespace": "x_pack.roll_up.get_rollup_job"
               }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "GetScriptContextRequest",
+        "namespace": "modules.scripting.get_script_context"
+      },
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "GetScriptContextResponse",
+        "namespace": "modules.scripting.get_script_context"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "stub_c",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
+      "inherits": [
+        {
+          "type": {
+            "name": "RequestBase",
+            "namespace": "common_abstractions.request"
+          }
+        }
+      ],
+      "kind": "request",
+      "name": {
+        "name": "GetScriptLanguagesRequest",
+        "namespace": "modules.scripting.get_script_languages"
+      },
+      "path": [
+        {
+          "name": "stub_a",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "stub_b",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": [
+        {
+          "type": {
+            "name": "ResponseBase",
+            "namespace": "common_abstractions.response"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "GetScriptLanguagesResponse",
+        "namespace": "modules.scripting.get_script_languages"
+      },
+      "properties": [
+        {
+          "name": "stub",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
             }
           }
         }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -64,22 +64,6 @@
         "Missing response"
       ]
     },
-    "get_script_context": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
-    "get_script_languages": {
-      "request": [
-        "Missing request"
-      ],
-      "response": [
-        "Missing response"
-      ]
-    },
     "indices.delete_index_template": {
       "request": [
         "Missing request"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6289,6 +6289,30 @@ export interface GetRollupJobResponse extends ResponseBase {
   jobs: Array<RollupJobInformation>
 }
 
+export interface GetScriptContextRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body?: {
+    stub_c: integer
+  }
+}
+
+export interface GetScriptContextResponse extends ResponseBase {
+  stub: integer
+}
+
+export interface GetScriptLanguagesRequest extends RequestBase {
+  stub_a: integer
+  stub_b: integer
+  body?: {
+    stub_c: integer
+  }
+}
+
+export interface GetScriptLanguagesResponse extends ResponseBase {
+  stub: integer
+}
+
 export interface GetScriptRequest extends RequestBase {
   id: Id
   master_timeout?: Time

--- a/specification/specs/modules/scripting/get_script_context/GetScriptContextRequest.ts
+++ b/specification/specs/modules/scripting/get_script_context/GetScriptContextRequest.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name get_script_context
+ * @since 0.0.0
+ * @stability TODO
+ */
+interface GetScriptContextRequest extends RequestBase {
+  path_parts?: {
+    stub_a: integer
+  }
+  query_parameters?: {
+    stub_b: integer
+  }
+  body?: {
+    stub_c: integer
+  }
+}

--- a/specification/specs/modules/scripting/get_script_context/GetScriptContextResponse.ts
+++ b/specification/specs/modules/scripting/get_script_context/GetScriptContextResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GetScriptContextResponse extends ResponseBase {
+  stub: integer
+}

--- a/specification/specs/modules/scripting/get_script_languages/GetScriptLanguagesRequest.ts
+++ b/specification/specs/modules/scripting/get_script_languages/GetScriptLanguagesRequest.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @rest_spec_name get_script_languages
+ * @since 0.0.0
+ * @stability TODO
+ */
+interface GetScriptLanguagesRequest extends RequestBase {
+  path_parts?: {
+    stub_a: integer
+  }
+  query_parameters?: {
+    stub_b: integer
+  }
+  body?: {
+    stub_c: integer
+  }
+}

--- a/specification/specs/modules/scripting/get_script_languages/GetScriptLanguagesResponse.ts
+++ b/specification/specs/modules/scripting/get_script_languages/GetScriptLanguagesResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GetScriptLanguagesResponse extends ResponseBase {
+  stub: integer
+}


### PR DESCRIPTION
added the request & response stubs for the endpoints:
* `get_script_context`
* `get_script_languages`