### PR TITLE
Validate ML DataCounts and Datafeed type

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -6747,7 +6747,7 @@
         "name": "GetJobStatsResponse",
         "namespace": "x_pack.machine_learning.get_job_stats"
       },
-      "since": "5.4.0",
+      "since": "5.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -40904,7 +40904,7 @@
         },
         {
           "name": "earliest_record_timestamp",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -40974,14 +40974,14 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
         },
         {
           "name": "last_data_time",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -40992,7 +40992,7 @@
         },
         {
           "name": "latest_empty_bucket_timestamp",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -41003,7 +41003,7 @@
         },
         {
           "name": "latest_record_timestamp",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -41014,7 +41014,18 @@
         },
         {
           "name": "latest_sparse_bucket_timestamp",
-          "required": true,
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "latest_bucket_timestamp",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -73754,7 +73765,7 @@
       "properties": [
         {
           "name": "memory_bytes",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -73765,7 +73776,7 @@
         },
         {
           "name": "processing_time_ms",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -73776,7 +73787,7 @@
         },
         {
           "name": "records",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -73787,7 +73798,7 @@
         },
         {
           "name": "status",
-          "required": true,
+          "required": false,
           "type": {
             "key": {
               "kind": "instance_of",
@@ -73813,6 +73824,17 @@
             "kind": "instance_of",
             "type": {
               "name": "long",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "forecasted_jobs",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
               "namespace": "internal"
             }
           }
@@ -73905,7 +73927,7 @@
       "properties": [
         {
           "name": "assignment_explanation",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -73960,7 +73982,7 @@
         },
         {
           "name": "node",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -73971,7 +73993,7 @@
         },
         {
           "name": "open_time",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -78952,6 +78974,50 @@
           }
         },
         {
+          "name": "model_bytes_exceeded",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "model_bytes_memory_limit",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "peak_model_bytes",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "assignment_memory_basis",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "result_type",
           "required": true,
           "type": {
@@ -79068,6 +79134,17 @@
             "kind": "instance_of",
             "type": {
               "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "timestamp",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
               "namespace": "internal"
             }
           }
@@ -121003,7 +121080,7 @@
       "properties": [
         {
           "name": "average_bucket_processing_time_ms",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -121025,7 +121102,7 @@
         },
         {
           "name": "exponential_average_bucket_processing_time_ms",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -121051,13 +121128,13 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
         },
         {
-          "name": "maximum_bucket_processing_time_ms",
+          "name": "total_bucket_processing_time_ms",
           "required": true,
           "type": {
             "kind": "instance_of",
@@ -121068,8 +121145,19 @@
           }
         },
         {
+          "name": "maximum_bucket_processing_time_ms",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "minimum_bucket_processing_time_ms",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -6650,7 +6650,7 @@
         "name": "GetDatafeedsResponse",
         "namespace": "x_pack.machine_learning.get_datafeeds"
       },
-      "since": "5.4.0",
+      "since": "5.5.0",
       "stability": "stable",
       "urls": [
         {
@@ -41716,7 +41716,7 @@
         },
         {
           "name": "chunking_config",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -41731,7 +41731,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
+              "name": "Id",
               "namespace": "internal"
             }
           }
@@ -41751,13 +41751,10 @@
           "name": "indices",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Indices",
+              "namespace": "internal"
             }
           }
         },
@@ -41870,6 +41867,17 @@
             "type": {
               "name": "RuntimeFields",
               "namespace": "mapping.runtime_fields"
+            }
+          }
+        },
+        {
+          "name": "indices_options",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DatafeedIndicesOptions",
+              "namespace": "x_pack.machine_learning.update_data_feed"
             }
           }
         }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3900,10 +3900,10 @@ export interface DataTiersUsage extends XPackUsage {
 export interface Datafeed {
   aggregations?: Record<string, AggregationContainer>
   aggs?: Record<string, AggregationContainer>
-  chunking_config: ChunkingConfig
-  datafeed_id: string
+  chunking_config?: ChunkingConfig
+  datafeed_id: Id
   frequency?: Timestamp
-  indices: Array<string>
+  indices: Indices
   indexes?: Array<string>
   job_id: Id
   max_empty_searches?: integer
@@ -3913,6 +3913,7 @@ export interface Datafeed {
   scroll_size?: integer
   delayed_data_check_config: DelayedDataCheckConfig
   runtime_mappings?: RuntimeFields
+  indices_options?: DatafeedIndicesOptions
 }
 
 export interface DatafeedCount {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3814,17 +3814,18 @@ export interface DailySchedule {
 
 export interface DataCounts {
   bucket_count: long
-  earliest_record_timestamp: long
+  earliest_record_timestamp?: long
   empty_bucket_count: long
   input_bytes: long
   input_field_count: long
   input_record_count: long
   invalid_date_count: long
-  job_id: string
-  last_data_time: long
-  latest_empty_bucket_timestamp: long
-  latest_record_timestamp: long
-  latest_sparse_bucket_timestamp: long
+  job_id: Id
+  last_data_time?: long
+  latest_empty_bucket_timestamp?: long
+  latest_record_timestamp?: long
+  latest_sparse_bucket_timestamp?: long
+  latest_bucket_timestamp?: long
   missing_field_count: long
   out_of_order_timestamp_count: long
   processed_field_count: long
@@ -7514,11 +7515,12 @@ export interface Job {
 }
 
 export interface JobForecastStatistics {
-  memory_bytes: JobStatistics
-  processing_time_ms: JobStatistics
-  records: JobStatistics
-  status: Record<string, long>
+  memory_bytes?: JobStatistics
+  processing_time_ms?: JobStatistics
+  records?: JobStatistics
+  status?: Record<string, long>
   total: long
+  forecasted_jobs: integer
 }
 
 export type JobState = 'closing' | 'closed' | 'opened' | 'failed' | 'opening'
@@ -7531,13 +7533,13 @@ export interface JobStatistics {
 }
 
 export interface JobStats {
-  assignment_explanation: string
+  assignment_explanation?: string
   data_counts: DataCounts
   forecasts_stats: JobForecastStatistics
   job_id: string
   model_size_stats: ModelSizeStats
-  node: DiscoveryNode
-  open_time: DateString
+  node?: DiscoveryNode
+  open_time?: DateString
   state: JobState
   timing_stats: TimingStats
   deleting?: boolean
@@ -8116,6 +8118,10 @@ export interface ModelSizeStats {
   log_time: Time
   memory_status: MemoryStatus
   model_bytes: long
+  model_bytes_exceeded?: long
+  model_bytes_memory_limit?: long
+  peak_model_bytes?: long
+  assignment_memory_basis?: string
   result_type: string
   total_by_field_count: long
   total_over_field_count: long
@@ -8127,6 +8133,7 @@ export interface ModelSizeStats {
   frequent_category_count: integer
   rare_category_count: integer
   total_category_count: integer
+  timestamp?: long
 }
 
 export interface ModelSnapshot {
@@ -12744,13 +12751,14 @@ export type TimeSpan = string
 export type Timestamp = string
 
 export interface TimingStats {
-  average_bucket_processing_time_ms: double
+  average_bucket_processing_time_ms?: double
   bucket_count: long
-  exponential_average_bucket_processing_time_ms: double
+  exponential_average_bucket_processing_time_ms?: double
   exponential_average_bucket_processing_time_per_hour_ms: double
-  job_id: string
-  maximum_bucket_processing_time_ms: double
-  minimum_bucket_processing_time_ms: double
+  job_id: Id
+  total_bucket_processing_time_ms: double
+  maximum_bucket_processing_time_ms?: double
+  minimum_bucket_processing_time_ms?: double
 }
 
 export interface Token {

--- a/specification/specs/x_pack/machine_learning/datafeed/Datafeed.ts
+++ b/specification/specs/x_pack/machine_learning/datafeed/Datafeed.ts
@@ -20,11 +20,10 @@
 class Datafeed {
   aggregations?: Dictionary<string, AggregationContainer>
   aggs?: Dictionary<string, AggregationContainer>
-  chunking_config: ChunkingConfig
-  datafeed_id: string
+  chunking_config?: ChunkingConfig
+  datafeed_id: Id
   frequency?: Timestamp
-  /** @prop_serializer IndicesFormatter */
-  indices: string[]
+  indices: Indices
   indexes?: string[]
   job_id: Id
   max_empty_searches?: integer
@@ -34,6 +33,7 @@ class Datafeed {
   scroll_size?: integer
   delayed_data_check_config: DelayedDataCheckConfig
   runtime_mappings?: RuntimeFields
+  indices_options?: DatafeedIndicesOptions
 }
 
 class DelayedDataCheckConfig {

--- a/specification/specs/x_pack/machine_learning/get_datafeeds/GetDatafeedsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_datafeeds/GetDatafeedsRequest.ts
@@ -19,7 +19,7 @@
 
 /**
  * @rest_spec_name ml.get_datafeeds
- * @since 5.4.0
+ * @since 5.5.0
  * @stability TODO
  */
 interface GetDatafeedsRequest extends RequestBase {

--- a/specification/specs/x_pack/machine_learning/get_job_stats/GetJobStatsRequest.ts
+++ b/specification/specs/x_pack/machine_learning/get_job_stats/GetJobStatsRequest.ts
@@ -19,7 +19,7 @@
 
 /**
  * @rest_spec_name ml.get_job_stats
- * @since 5.4.0
+ * @since 5.5.0
  * @stability TODO
  */
 interface GetJobStatsRequest extends RequestBase {

--- a/specification/specs/x_pack/machine_learning/job/config/JobForecastStatistics.ts
+++ b/specification/specs/x_pack/machine_learning/job/config/JobForecastStatistics.ts
@@ -18,9 +18,10 @@
  */
 
 class JobForecastStatistics {
-  memory_bytes: JobStatistics
-  processing_time_ms: JobStatistics
-  records: JobStatistics
-  status: Dictionary<string, long>
+  memory_bytes?: JobStatistics
+  processing_time_ms?: JobStatistics
+  records?: JobStatistics
+  status?: Dictionary<string, long>
   total: long
+  forecasted_jobs: integer
 }

--- a/specification/specs/x_pack/machine_learning/job/config/JobStats.ts
+++ b/specification/specs/x_pack/machine_learning/job/config/JobStats.ts
@@ -18,13 +18,13 @@
  */
 
 class JobStats {
-  assignment_explanation: string
+  assignment_explanation?: string
   data_counts: DataCounts
   forecasts_stats: JobForecastStatistics
   job_id: string
   model_size_stats: ModelSizeStats
-  node: DiscoveryNode
-  open_time: DateString
+  node?: DiscoveryNode
+  open_time?: DateString
   state: JobState
   timing_stats: TimingStats
   deleting?: boolean

--- a/specification/specs/x_pack/machine_learning/job/config/TimingStats.ts
+++ b/specification/specs/x_pack/machine_learning/job/config/TimingStats.ts
@@ -18,11 +18,12 @@
  */
 
 class TimingStats {
-  average_bucket_processing_time_ms: double
+  average_bucket_processing_time_ms?: double
   bucket_count: long
-  exponential_average_bucket_processing_time_ms: double
+  exponential_average_bucket_processing_time_ms?: double
   exponential_average_bucket_processing_time_per_hour_ms: double
-  job_id: string
-  maximum_bucket_processing_time_ms: double
-  minimum_bucket_processing_time_ms: double
+  job_id: Id
+  total_bucket_processing_time_ms: double
+  maximum_bucket_processing_time_ms?: double
+  minimum_bucket_processing_time_ms?: double
 }

--- a/specification/specs/x_pack/machine_learning/job/process/DataCounts.ts
+++ b/specification/specs/x_pack/machine_learning/job/process/DataCounts.ts
@@ -19,22 +19,18 @@
 
 class DataCounts {
   bucket_count: long
-  /** @prop_serializer NullableDateTimeOffsetEpochMillisecondsFormatter */
-  earliest_record_timestamp: long
+  earliest_record_timestamp?: long
   empty_bucket_count: long
   input_bytes: long
   input_field_count: long
   input_record_count: long
   invalid_date_count: long
-  job_id: string
-  /** @prop_serializer DateTimeOffsetEpochMillisecondsFormatter */
-  last_data_time: long
-  /** @prop_serializer DateTimeOffsetEpochMillisecondsFormatter */
-  latest_empty_bucket_timestamp: long
-  /** @prop_serializer DateTimeOffsetEpochMillisecondsFormatter */
-  latest_record_timestamp: long
-  /** @prop_serializer DateTimeOffsetEpochMillisecondsFormatter */
-  latest_sparse_bucket_timestamp: long
+  job_id: Id
+  last_data_time?: long
+  latest_empty_bucket_timestamp?: long
+  latest_record_timestamp?: long
+  latest_sparse_bucket_timestamp?: long
+  latest_bucket_timestamp?: long
   missing_field_count: long
   out_of_order_timestamp_count: long
   processed_field_count: long

--- a/specification/specs/x_pack/machine_learning/job/process/ModelSizeStats.ts
+++ b/specification/specs/x_pack/machine_learning/job/process/ModelSizeStats.ts
@@ -23,6 +23,10 @@ class ModelSizeStats {
   log_time: Time
   memory_status: MemoryStatus
   model_bytes: long
+  model_bytes_exceeded?: long
+  model_bytes_memory_limit?: long
+  peak_model_bytes?: long
+  assignment_memory_basis?: string
   result_type: string
   total_by_field_count: long
   total_over_field_count: long
@@ -34,4 +38,5 @@ class ModelSizeStats {
   frequent_category_count: integer
   rare_category_count: integer
   total_category_count: integer
+  timestamp?: long
 }


### PR DESCRIPTION
addressed feedback from https://github.com/elastic/elastic-client-generator/issues/252

Added missing properties and validated endpoints:
* `ml.get_datafeeds`
* `ml.get_job_stats`