### PR TITLE
Address Indices.get settings Response

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -72170,6 +72170,7 @@
           ],
           "name": "number_of_shards",
           "required": false,
+          "serverDefault": "1",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72184,6 +72185,7 @@
           ],
           "name": "number_of_replicas",
           "required": false,
+          "serverDefault": "0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72212,6 +72214,7 @@
           ],
           "name": "check_on_startup",
           "required": false,
+          "serverDefault": "false",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72226,6 +72229,7 @@
           ],
           "name": "codec",
           "required": false,
+          "serverDefault": "LZ4",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72240,6 +72244,7 @@
           ],
           "name": "routing_partition_size",
           "required": false,
+          "serverDefault": "1",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72254,6 +72259,7 @@
           ],
           "name": "soft_deletes.retention_lease.period",
           "required": false,
+          "serverDefault": "12h",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72268,6 +72274,7 @@
           ],
           "name": "load_fixed_bitset_filters_eagerly",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72282,6 +72289,7 @@
           ],
           "name": "hidden",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72296,6 +72304,7 @@
           ],
           "name": "auto_expand_replicas",
           "required": false,
+          "serverDefault": "false",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72310,6 +72319,7 @@
           ],
           "name": "search.idle.after",
           "required": false,
+          "serverDefault": "30s",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72324,6 +72334,7 @@
           ],
           "name": "refresh_interval",
           "required": false,
+          "serverDefault": "1s",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72338,6 +72349,7 @@
           ],
           "name": "max_result_window",
           "required": false,
+          "serverDefault": "10000",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72352,6 +72364,7 @@
           ],
           "name": "max_inner_result_window",
           "required": false,
+          "serverDefault": "100",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72366,6 +72379,7 @@
           ],
           "name": "max_rescore_window",
           "required": false,
+          "serverDefault": "10000",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72380,6 +72394,7 @@
           ],
           "name": "max_docvalue_fields_search",
           "required": false,
+          "serverDefault": "100",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72394,6 +72409,7 @@
           ],
           "name": "max_script_fields",
           "required": false,
+          "serverDefault": "32",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72408,6 +72424,7 @@
           ],
           "name": "max_ngram_diff",
           "required": false,
+          "serverDefault": "1",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72422,6 +72439,7 @@
           ],
           "name": "max_shingle_diff",
           "required": false,
+          "serverDefault": "3",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72464,6 +72482,7 @@
           ],
           "name": "analyze.max_token_count",
           "required": false,
+          "serverDefault": "10000",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72478,6 +72497,7 @@
           ],
           "name": "highlight.max_analyzed_offset",
           "required": false,
+          "serverDefault": "1000000",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72492,6 +72512,7 @@
           ],
           "name": "max_terms_count",
           "required": false,
+          "serverDefault": "65536",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72506,6 +72527,7 @@
           ],
           "name": "max_regex_length",
           "required": false,
+          "serverDefault": "1000",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72534,6 +72556,7 @@
           ],
           "name": "gc_deletes",
           "required": false,
+          "serverDefault": "60s",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72548,6 +72571,7 @@
           ],
           "name": "default_pipeline",
           "required": false,
+          "serverDefault": "_none",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72562,6 +72586,7 @@
           ],
           "name": "final_pipeline",
           "required": false,
+          "serverDefault": "_none",
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -38538,7 +38538,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "ClusterStateBlockIndexSettingRouting",
+              "name": "IndexRouting",
               "namespace": "cluster"
             }
           }
@@ -38752,56 +38752,6 @@
             "type": {
               "name": "Name",
               "namespace": "internal"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ClusterStateBlockIndexSettingRouting",
-        "namespace": "cluster"
-      },
-      "properties": [
-        {
-          "name": "allocation",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ClusterStateBlockIndexSettingRoutingAllocation",
-              "namespace": "cluster"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ClusterStateBlockIndexSettingRoutingAllocation",
-        "namespace": "cluster"
-      },
-      "properties": [
-        {
-          "name": "include",
-          "required": true,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
             }
           }
         }
@@ -71977,6 +71927,184 @@
     {
       "kind": "interface",
       "name": {
+        "name": "IndexRouting",
+        "namespace": "cluster"
+      },
+      "properties": [
+        {
+          "name": "allocation",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexRoutingAllocation",
+              "namespace": "cluster"
+            }
+          }
+        },
+        {
+          "name": "rebalance",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexRoutingRebalance",
+              "namespace": "cluster"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "IndexRoutingAllocation",
+        "namespace": "cluster"
+      },
+      "properties": [
+        {
+          "description": "server_default all",
+          "name": "enable",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexRoutingAllocationOptions",
+              "namespace": "cluster"
+            }
+          }
+        },
+        {
+          "name": "include",
+          "required": true,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "initial_recovery",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "all"
+        },
+        {
+          "name": "primaries"
+        },
+        {
+          "name": "new_primaries"
+        },
+        {
+          "name": "none"
+        }
+      ],
+      "name": {
+        "name": "IndexRoutingAllocationOptions",
+        "namespace": "cluster"
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "IndexRoutingRebalance",
+        "namespace": "cluster"
+      },
+      "properties": [
+        {
+          "description": "server_default all",
+          "name": "enable",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexRoutingRebalanceOptions",
+              "namespace": "cluster"
+            }
+          }
+        },
+        {
+          "name": "include",
+          "required": true,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "all"
+        },
+        {
+          "name": "primaries"
+        },
+        {
+          "name": "replicas"
+        },
+        {
+          "name": "none"
+        }
+      ],
+      "name": {
+        "name": "IndexRoutingRebalanceOptions",
+        "namespace": "cluster"
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "IndexSegment",
         "namespace": "indices.monitoring.indices_segments"
       },
@@ -72082,79 +72210,6 @@
           }
         }
       ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "IndexSettingRouting",
-        "namespace": "cluster"
-      },
-      "properties": [
-        {
-          "name": "allocation.enable",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "IndexSettingRoutingAllocation",
-              "namespace": "cluster"
-            }
-          }
-        },
-        {
-          "name": "rebalance.enable",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "IndexSettingRoutingRebalance",
-              "namespace": "cluster"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "all"
-        },
-        {
-          "name": "primaries"
-        },
-        {
-          "name": "new_primaries"
-        },
-        {
-          "name": "none"
-        }
-      ],
-      "name": {
-        "name": "IndexSettingRoutingAllocation",
-        "namespace": "cluster"
-      }
-    },
-    {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "all"
-        },
-        {
-          "name": "primaries"
-        },
-        {
-          "name": "replicas"
-        },
-        {
-          "name": "none"
-        }
-      ],
-      "name": {
-        "name": "IndexSettingRoutingRebalance",
-        "namespace": "cluster"
-      }
     },
     {
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-modules.html#index-modules-settings",
@@ -72545,7 +72600,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "IndexSettingRouting",
+              "name": "IndexRouting",
               "namespace": "cluster"
             }
           }
@@ -72606,7 +72661,7 @@
       "properties": [
         {
           "name": "aliases",
-          "required": true,
+          "required": false,
           "type": {
             "key": {
               "kind": "instance_of",
@@ -72627,7 +72682,7 @@
         },
         {
           "name": "mappings",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -72638,6 +72693,26 @@
         },
         {
           "name": "settings",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexStateSettings",
+              "namespace": "index_modules.index_settings"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "IndexStateSettings",
+        "namespace": "index_modules.index_settings"
+      },
+      "properties": [
+        {
+          "name": "index",
           "required": true,
           "type": {
             "kind": "instance_of",

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -4513,7 +4513,7 @@
         "name": "GetIndexSettingsResponse",
         "namespace": "indices.index_settings.get_index_settings"
       },
-      "since": "0.0.0",
+      "since": "1.3.0",
       "stability": "stable",
       "urls": [
         {
@@ -63731,6 +63731,7 @@
         {
           "name": "allow_no_indices",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -63742,6 +63743,7 @@
         {
           "name": "expand_wildcards",
           "required": false,
+          "serverDefault": "all",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -63751,8 +63753,10 @@
           }
         },
         {
+          "description": "If true, returns settings in flat format.",
           "name": "flat_settings",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -63762,8 +63766,10 @@
           }
         },
         {
+          "description": "If true, missing or closed indices are not included in the response.",
           "name": "ignore_unavailable",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -63773,8 +63779,10 @@
           }
         },
         {
+          "description": "If true, return all default settings in the response.",
           "name": "include_defaults",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -63784,8 +63792,10 @@
           }
         },
         {
+          "description": "If true, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the master node.",
           "name": "local",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -63795,8 +63805,10 @@
           }
         },
         {
+          "description": "Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.",
           "name": "master_timeout",
           "required": false,
+          "serverDefault": "30s",
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3438,7 +3438,7 @@ export interface ClusterStateBlockIndexMapping {
 }
 
 export interface ClusterStateBlockIndexSetting {
-  routing?: ClusterStateBlockIndexSettingRouting
+  routing?: IndexRouting
   refresh_interval?: Time
   number_of_shards: integer | string
   number_of_replicas: integer | string
@@ -3455,14 +3455,6 @@ export interface ClusterStateBlockIndexSetting {
 
 export interface ClusterStateBlockIndexSettingLifecycle {
   name: Name
-}
-
-export interface ClusterStateBlockIndexSettingRouting {
-  allocation: ClusterStateBlockIndexSettingRoutingAllocation
-}
-
-export interface ClusterStateBlockIndexSettingRoutingAllocation {
-  include: Record<string, string>
 }
 
 export interface ClusterStateBlockIndexSettingVersion {
@@ -7174,6 +7166,26 @@ export interface IndexRequest<TDocument = unknown> extends RequestBase {
 export interface IndexResponse extends WriteResponseBase {
 }
 
+export interface IndexRouting {
+  allocation?: IndexRoutingAllocation
+  rebalance?: IndexRoutingRebalance
+}
+
+export interface IndexRoutingAllocation {
+  enable?: IndexRoutingAllocationOptions
+  include: Record<string, string>
+  initial_recovery?: Record<string, string>
+}
+
+export type IndexRoutingAllocationOptions = 'all' | 'primaries' | 'new_primaries' | 'none'
+
+export interface IndexRoutingRebalance {
+  enable: IndexRoutingRebalanceOptions
+  include: Record<string, string>
+}
+
+export type IndexRoutingRebalanceOptions = 'all' | 'primaries' | 'replicas' | 'none'
+
 export interface IndexSegment {
   shards: Record<string, ShardsSegment | Array<ShardsSegment>>
 }
@@ -7185,15 +7197,6 @@ export interface IndexSettingBlocks {
   write?: boolean
   metadata?: boolean
 }
-
-export interface IndexSettingRouting {
-  'allocation.enable'?: IndexSettingRoutingAllocation
-  'rebalance.enable'?: IndexSettingRoutingRebalance
-}
-
-export type IndexSettingRoutingAllocation = 'all' | 'primaries' | 'new_primaries' | 'none'
-
-export type IndexSettingRoutingRebalance = 'all' | 'primaries' | 'replicas' | 'none'
 
 export interface IndexSettings {
   number_of_shards?: integer
@@ -7246,8 +7249,8 @@ export interface IndexSettings {
   'index.max_terms_count'?: integer
   max_regex_length?: integer
   'index.max_regex_length'?: integer
-  routing?: IndexSettingRouting
-  'index.routing'?: IndexSettingRouting
+  routing?: IndexRouting
+  'index.routing'?: IndexRouting
   gc_deletes?: Time
   'index.gc_deletes'?: Time
   default_pipeline?: PipelineName
@@ -7257,9 +7260,13 @@ export interface IndexSettings {
 }
 
 export interface IndexState {
-  aliases: Record<IndexName, Alias>
-  mappings: TypeMapping
-  settings: IndexSettings
+  aliases?: Record<IndexName, Alias>
+  mappings?: TypeMapping
+  settings: IndexStateSettings
+}
+
+export interface IndexStateSettings {
+  index: IndexSettings
 }
 
 export interface IndexStats {

--- a/specification/specs/cluster/ClusterStateBlocks.ts
+++ b/specification/specs/cluster/ClusterStateBlocks.ts
@@ -42,7 +42,7 @@ class ClusterStateBlockIndex {
 }
 
 class ClusterStateBlockIndexSetting {
-  routing?: ClusterStateBlockIndexSettingRouting
+  routing?: IndexRouting
   refresh_interval?: Time
   number_of_shards: integer | string // TODO: not sure this correct
   number_of_replicas: integer | string // TODO: not sure this correct
@@ -55,14 +55,6 @@ class ClusterStateBlockIndexSetting {
   uuid?: Uuid
   version?: ClusterStateBlockIndexSettingVersion
   lifecycle?: ClusterStateBlockIndexSettingLifecycle
-}
-
-class ClusterStateBlockIndexSettingRouting {
-  allocation: ClusterStateBlockIndexSettingRoutingAllocation
-}
-
-class ClusterStateBlockIndexSettingRoutingAllocation {
-  include: Dictionary<string, string>
 }
 
 class ClusterStateBlockIndexSettingVersion {

--- a/specification/specs/cluster/IndexRouting.ts
+++ b/specification/specs/cluster/IndexRouting.ts
@@ -17,12 +17,34 @@
  * under the License.
  */
 
-class IndexState {
-  aliases?: Dictionary<IndexName, Alias>
-  mappings?: TypeMapping
-  settings: IndexStateSettings
+class IndexRouting {
+  allocation?: IndexRoutingAllocation
+  rebalance?: IndexRoutingRebalance
 }
 
-class IndexStateSettings {
-  index: IndexSettings
+class IndexRoutingAllocation {
+  /** server_default all */
+  enable?: IndexRoutingAllocationOptions
+  include: Dictionary<string, string>
+  initial_recovery?: Dictionary<string, string>
+}
+
+class IndexRoutingRebalance {
+  /** server_default all */
+  enable: IndexRoutingRebalanceOptions
+  include: Dictionary<string, string>
+}
+
+enum IndexRoutingAllocationOptions {
+  all = 0,
+  primaries = 1,
+  new_primaries = 2,
+  none = 3
+}
+
+enum IndexRoutingRebalanceOptions {
+  all = 0,
+  primaries = 1,
+  replicas = 2,
+  none = 3
 }

--- a/specification/specs/cluster/IndexSettings.ts
+++ b/specification/specs/cluster/IndexSettings.ts
@@ -23,80 +23,98 @@
 class IndexSettings {
   /**
    * @aliases index.number_of_shards
+   * @server_default 1
    */
-  number_of_shards?: integer // default 1
+  number_of_shards?: integer
   /**
    * @aliases index.number_of_replicas
+   * @server_default 0
    */
-  number_of_replicas?: integer // default 0
+  number_of_replicas?: integer
   /**
    * @aliases index.number_of_routing_shards
    */
   number_of_routing_shards?: integer
   /**
    * @aliases index.check_on_startup
+   * @server_default false
    */
-  check_on_startup?: IndexCheckOnStartup // default false
+  check_on_startup?: IndexCheckOnStartup
   /**
    * @aliases index.codec
+   * @server_default LZ4
    */
-  codec?: string // default LZ4
+  codec?: string
   /**
    * @aliases index.routing_partition_size
+   * @server_default 1
    */
-  routing_partition_size?: integer // default 1
+  routing_partition_size?: integer
   /**
    * @aliases index.soft_deletes.retention_lease.period
+   * @server_default 12h
    */
-  'soft_deletes.retention_lease.period'?: Time // default 12h
+  'soft_deletes.retention_lease.period'?: Time
   /**
    * @aliases index.load_fixed_bitset_filters_eagerly
+   * @server_default true
    */
-  load_fixed_bitset_filters_eagerly?: boolean // default true
+  load_fixed_bitset_filters_eagerly?: boolean
   /**
    * @aliases index.hidden
+   * @server_default false
    */
-  hidden?: boolean // default false
+  hidden?: boolean
   /**
    * @aliases index.auto_expand_replicas
+   * @server_default false
    */
-  auto_expand_replicas?: string // default false
+  auto_expand_replicas?: string
   /**
    * @aliases index.search.idle.after
+   * @server_default 30s
    */
-  'search.idle.after'?: Time // default 30s
+  'search.idle.after'?: Time
   /**
    * @aliases index.refresh_interval
+   * @server_default 1s
    */
-  refresh_interval?: Time // default 1s
+  refresh_interval?: Time
   /**
    * @aliases index.max_result_window
+   * @server_default 10000
    */
-  max_result_window?: integer // default 10000
+  max_result_window?: integer
   /**
    * @aliases index.max_inner_result_window
+   * @server_default 100
    */
-  max_inner_result_window?: integer // default 100
+  max_inner_result_window?: integer
   /**
    * @aliases index.max_rescore_window
+   * @server_default 10000
    */
-  max_rescore_window?: integer // default 10000
+  max_rescore_window?: integer
   /**
    * @aliases index.max_docvalue_fields_search
+   * @server_default 100
    */
-  max_docvalue_fields_search?: integer // default 100
+  max_docvalue_fields_search?: integer
   /**
    * @aliases index.max_script_fields
+   * @server_default 32
    */
-  max_script_fields?: integer // default 32
+  max_script_fields?: integer
   /**
    * @aliases index.max_ngram_diff
+   * @server_default 1
    */
-  max_ngram_diff?: integer // default 1
+  max_ngram_diff?: integer
   /**
    * @aliases index.max_shingle_diff
+   * @server_default 3
    */
-  max_shingle_diff?: integer // default 3
+  max_shingle_diff?: integer
   /**
    * @aliases index.bocks
    */
@@ -107,36 +125,43 @@ class IndexSettings {
   max_refresh_listeners?: integer
   /**
    * @aliases index.analyze.max_token_count
+   * @server_default 10000
    */
-  'analyze.max_token_count'?: integer // default 10000
+  'analyze.max_token_count'?: integer
   /**
    * @aliases index.highlight.max_analyzed_offset
+   * @server_default 1000000
    */
-  'highlight.max_analyzed_offset'?: integer // default 1000000
+  'highlight.max_analyzed_offset'?: integer
   /**
    * @aliases index.max_terms_count
+   * @server_default 65536
    */
-  max_terms_count?: integer // default 65536
+  max_terms_count?: integer
   /**
    * @aliases index.max_regex_length
+   * @server_default 1000
    */
-  max_regex_length?: integer // default 1000
+  max_regex_length?: integer
   /**
    * @aliases index.routing
    */
   routing?: IndexSettingRouting
   /**
    * @aliases index.gc_deletes
+   * @server_default 60s
    */
-  gc_deletes?: Time // default 60s
+  gc_deletes?: Time
   /**
    * @aliases index.default_pipeline
+   * @server_default _none
    */
-  default_pipeline?: PipelineName // default _none
+  default_pipeline?: PipelineName
   /**
    * @aliases index.final_pipeline
+   * @server_default _none
    */
-  final_pipeline?: PipelineName // default _none
+  final_pipeline?: PipelineName
 }
 
 class IndexSettingBlocks {

--- a/specification/specs/cluster/IndexSettings.ts
+++ b/specification/specs/cluster/IndexSettings.ts
@@ -146,7 +146,7 @@ class IndexSettings {
   /**
    * @aliases index.routing
    */
-  routing?: IndexSettingRouting
+  routing?: IndexRouting
   /**
    * @aliases index.gc_deletes
    * @server_default 60s
@@ -176,23 +176,4 @@ enum IndexCheckOnStartup {
   false = 0,
   checksum = 1,
   true = 2
-}
-
-class IndexSettingRouting {
-  'allocation.enable'?: IndexSettingRoutingAllocation // default: all
-  'rebalance.enable'?: IndexSettingRoutingRebalance // default: all
-}
-
-enum IndexSettingRoutingAllocation {
-  all = 0,
-  primaries = 1,
-  new_primaries = 2,
-  none = 3
-}
-
-enum IndexSettingRoutingRebalance {
-  all = 0,
-  primaries = 1,
-  replicas = 2,
-  none = 3
 }

--- a/specification/specs/indices/index_settings/get_index_settings/GetIndexSettingsRequest.ts
+++ b/specification/specs/indices/index_settings/get_index_settings/GetIndexSettingsRequest.ts
@@ -19,22 +19,54 @@
 
 /**
  * @rest_spec_name indices.get_settings
- * @since 0.0.0
+ * @since 1.3.0
  * @stability TODO
  */
 interface GetIndexSettingsRequest extends RequestBase {
   path_parts?: {
+    /**
+     * Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard expressions (*) are supported.
+     * To target all data streams and indices in a cluster, omit this parameter or use _all or *.
+     */
     index?: Indices
+    /**
+     * Comma-separated list or wildcard expression of setting names used to limit the request.
+     */
     name?: Names
   }
   query_parameters?: {
+    /**
+     * @server_default true
+     */
     allow_no_indices?: boolean
+    /**
+     * @server_default all
+     */
     expand_wildcards?: ExpandWildcards
+    /**
+     * If true, returns settings in flat format.
+     * @server_default false
+     */
     flat_settings?: boolean
+    /**
+     * If true, missing or closed indices are not included in the response.
+     * @server_default false
+     */
     ignore_unavailable?: boolean
+    /**
+     * If true, return all default settings in the response.
+     * @server_default false
+     */
     include_defaults?: boolean
+    /**
+     * If true, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the master node.
+     * @server_default false
+     */
     local?: boolean
+    /**
+     * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
     master_timeout?: Time
   }
-  body?: {}
 }


### PR DESCRIPTION
Mostly cosmetics with annotations and descriptions.

The primary cause of failing tests is based on upstream tests using string instead of int, e.g.
```
"hidden": "true",
"number_of_shards": "1",
"number_of_replicas": "1",
```

should be 
```
"hidden": true,
"number_of_shards": 1,
"number_of_replicas": 1,
```

Those required changed in the integration tests will addressed next.

this PR can be merged as it might uncover some cross-class failures because  refactored `IndexSettings`.