### PR TITLE
Tag polymorphic types. Part 1: containers

### DIFF
--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -274,11 +274,43 @@ For example:
 ```ts
 /** @variants container */
 class FooContainer {
-  bar: BarDefinition
-  baz: BazDefinition
-  faz: FazDefinition
+  bar?: BarDefinition
+  baz?: BazDefinition
+  faz?: FazDefinition
 }
 ```
+
+Some containers have properties associated to the container that are not part of the list of variants,
+for example `AggregationContainer` and its `aggs` and `meta` properties.
+
+An annotation allows distinguishing these properties from container variants:
+
+```ts
+/** @variant container_property */
+```
+
+For example:
+
+```
+/**
+ * @variants container
+ */
+class AggregationContainer {
+
+  // These two field are always available
+  /** @variant container_property */
+  aggs?: Dictionary<string, AggregationContainer>
+  /** @variant container_property */
+  meta?: Dictionary<string, UserDefinedValue>
+
+  // Regular container fields. Only one of them can exist at a time.
+  adjacency_matrix?: AdjacencyMatrixAggregation
+  auto_date_histogram?: AutoDateHistogramAggregation
+  avg?: AverageAggregation
+  ...
+
+```
+
 
 ### Additional information
 

--- a/output/dangling-types/dangling.csv
+++ b/output/dangling-types/dangling.csv
@@ -1,3 +1,4 @@
+TypedKeysContainer,behaviors.ts
 short,common.ts
 byte,common.ts
 ScrollIds,common.ts

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -12607,6 +12607,8 @@
       ]
     },
     {
+      "description": "A bucket aggregation returning a form of [adjacency matrix](https://en.wikipedia.org/wiki/Adjacency_matrix). The\nrequest provides a collection of named filter expressions, similar to the filters aggregation request. Each bucket\nin the response represents a non-empty cell in the matrix of intersecting filters.",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-adjacency-matrix-aggregation.html",
       "inherits": [
         {
           "type": {
@@ -12622,8 +12624,9 @@
       },
       "properties": [
         {
+          "description": "Filters used to create buckets.",
           "name": "filters",
-          "required": false,
+          "required": true,
           "type": {
             "key": {
               "kind": "instance_of",
@@ -12639,6 +12642,18 @@
                 "name": "QueryContainer",
                 "namespace": "query_dsl.abstractions.container"
               }
+            }
+          }
+        },
+        {
+          "description": "Separator used to concatenate filter names. Defaults to `&`.",
+          "name": "separator",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
           }
         }
@@ -12799,36 +12814,7 @@
         "name": "Aggregation",
         "namespace": "aggregations"
       },
-      "properties": [
-        {
-          "name": "meta",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "value": {
-              "kind": "user_defined_value"
-            }
-          }
-        },
-        {
-          "name": "name",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
+      "properties": []
     },
     {
       "kind": "interface",
@@ -12979,17 +12965,12 @@
       },
       "properties": [
         {
-          "name": "adjacency_matrix",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "AdjacencyMatrixAggregation",
-              "namespace": "aggregations.bucket.adjacency_matrix"
-            }
-          }
-        },
-        {
+          "aliases": [
+            "aggregations"
+          ],
+          "container_property": true,
+          "description": "Nested aggregations. Bucket aggregations support bucket or metric sub-aggregations.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html#run-sub-aggs",
           "name": "aggs",
           "required": false,
           "type": {
@@ -13011,7 +12992,8 @@
           }
         },
         {
-          "name": "aggregations",
+          "container_property": true,
+          "name": "meta",
           "required": false,
           "type": {
             "key": {
@@ -13023,11 +13005,18 @@
             },
             "kind": "dictionary_of",
             "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "AggregationContainer",
-                "namespace": "aggregations"
-              }
+              "kind": "user_defined_value"
+            }
+          }
+        },
+        {
+          "name": "adjacency_matrix",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "AdjacencyMatrixAggregation",
+              "namespace": "aggregations.bucket.adjacency_matrix"
             }
           }
         },
@@ -13417,23 +13406,6 @@
           }
         },
         {
-          "name": "meta",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "value": {
-              "kind": "user_defined_value"
-            }
-          }
-        },
-        {
           "name": "min",
           "required": false,
           "type": {
@@ -13807,7 +13779,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -16742,17 +16717,6 @@
               "namespace": "internal"
             }
           }
-        },
-        {
-          "name": "typed_keys",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
         }
       ],
       "query": []
@@ -18122,6 +18086,8 @@
       ]
     },
     {
+      "description": "A multi-bucket aggregation similar to `date_histogram` except instead of providing an interval to use as the width\nof each bucket, a target number of buckets is provided indicating the number of buckets needed and the interval of\nthe buckets is automatically chosen to best achieve that target. The number of buckets returned will always be less\nthan or equal to this target number.",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-autodatehistogram-aggregation.html",
       "inherits": [
         {
           "type": {
@@ -19151,29 +19117,7 @@
         "name": "BucketAggregationBase",
         "namespace": "aggregations.bucket"
       },
-      "properties": [
-        {
-          "name": "aggregations",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "AggregationContainer",
-                "namespace": "aggregations"
-              }
-            }
-          }
-        }
-      ]
+      "properties": []
     },
     {
       "kind": "interface",
@@ -19871,7 +19815,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "attachedBehaviors": [
@@ -20343,7 +20290,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "inherits": [
@@ -32968,6 +32918,8 @@
       }
     },
     {
+      "description": "A special single bucket aggregation that selects child documents that have the specified type, as defined in a join\nfield.",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-children-aggregation.html",
       "inherits": [
         {
           "type": {
@@ -32984,7 +32936,7 @@
       "properties": [
         {
           "name": "type",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -40876,6 +40828,8 @@
       ]
     },
     {
+      "description": "A multi-bucket aggregation that creates composite buckets from different sources.",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html",
       "inherits": [
         {
           "type": {
@@ -40890,6 +40844,41 @@
         "namespace": "aggregations.bucket.composite"
       },
       "properties": [
+        {
+          "name": "sources",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              },
+              "kind": "dictionary_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "CompositeAggregationSource",
+                  "namespace": "aggregations.bucket.composite"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "size",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "internal"
+            }
+          }
+        },
         {
           "name": "after",
           "required": false,
@@ -40914,7 +40903,7 @@
                 {
                   "kind": "instance_of",
                   "type": {
-                    "name": "float",
+                    "name": "number",
                     "namespace": "internal"
                   }
                 },
@@ -40927,41 +40916,6 @@
                 }
               ],
               "kind": "union_of"
-            }
-          }
-        },
-        {
-          "name": "size",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "sources",
-          "required": false,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "CompositeAggregationSource",
-                  "namespace": "aggregations.bucket.composite"
-                }
-              }
             }
           }
         }
@@ -41018,7 +40972,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "attachedBehaviors": [
@@ -41263,7 +41220,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "enum",
@@ -45451,7 +45411,7 @@
       "properties": [
         {
           "name": "field",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45540,39 +45500,6 @@
           }
         },
         {
-          "name": "from_as_string",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "to_as_string",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "key",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "to",
           "required": false,
           "type": {
@@ -45593,17 +45520,6 @@
               }
             ],
             "kind": "union_of"
-          }
-        },
-        {
-          "name": "doc_count",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "internal"
-            }
           }
         }
       ]
@@ -51842,6 +51758,13 @@
             "kind": "instance_of",
             "type": {
               "name": "long",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
               "namespace": "internal"
             }
           }
@@ -74461,7 +74384,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "inherits": [
@@ -75196,7 +75122,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "enum",
@@ -75467,7 +75396,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -83135,17 +83067,6 @@
         "namespace": "document.multiple.multi_get"
       },
       "properties": [
-        {
-          "name": "can_be_flattened",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
         {
           "name": "_id",
           "required": true,
@@ -92833,7 +92754,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -97387,50 +97311,6 @@
           }
         },
         {
-          "name": "is_conditionless",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "is_strict",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "is_verbatim",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "is_writable",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "match",
           "required": false,
           "type": {
@@ -98153,7 +98033,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -106123,7 +106006,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -107412,28 +107298,10 @@
         "kind": "properties",
         "properties": [
           {
+            "aliases": [
+              "aggregations"
+            ],
             "name": "aggs",
-            "required": false,
-            "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "AggregationContainer",
-                  "namespace": "aggregations"
-                }
-              }
-            }
-          },
-          {
-            "name": "aggregations",
             "required": false,
             "type": {
               "key": {
@@ -115532,7 +115400,7 @@
       "properties": [
         {
           "name": "laplace",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -115543,7 +115411,7 @@
         },
         {
           "name": "linear_interpolation",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -115554,7 +115422,7 @@
         },
         {
           "name": "stupid_backoff",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -115563,7 +115431,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -121185,7 +121056,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -126430,7 +126304,7 @@
       "properties": [
         {
           "name": "chain",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -126441,7 +126315,7 @@
         },
         {
           "name": "script",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -126452,7 +126326,7 @@
         },
         {
           "name": "search",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -126461,7 +126335,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -126918,7 +126795,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -127323,7 +127203,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -127343,7 +127226,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -98,7 +98,8 @@ export interface AdaptiveSelectionStats {
 }
 
 export interface AdjacencyMatrixAggregation extends BucketAggregationBase {
-  filters?: Record<string, QueryContainer>
+  filters: Record<string, QueryContainer>
+  separator?: string
 }
 
 export type Aggregate = SingleBucketAggregate | AutoDateHistogramAggregate | FiltersAggregate | SignificantTermsAggregate<any> | TermsAggregate<any> | BucketAggregate | CompositeBucketAggregate | MultiBucketAggregate<Bucket> | MatrixStatsAggregate | KeyedValueAggregate | MetricAggregate
@@ -110,8 +111,6 @@ export interface AggregateBase {
 export type AggregateName = string
 
 export interface Aggregation {
-  meta?: Record<string, any>
-  name?: string
 }
 
 export interface AggregationBreakdown {
@@ -130,9 +129,10 @@ export interface AggregationBreakdown {
 }
 
 export interface AggregationContainer {
-  adjacency_matrix?: AdjacencyMatrixAggregation
   aggs?: Record<string, AggregationContainer>
   aggregations?: Record<string, AggregationContainer>
+  meta?: Record<string, any>
+  adjacency_matrix?: AdjacencyMatrixAggregation
   auto_date_histogram?: AutoDateHistogramAggregation
   avg?: AverageAggregation
   avg_bucket?: AverageBucketAggregation
@@ -168,7 +168,6 @@ export interface AggregationContainer {
   max?: MaxAggregation
   max_bucket?: MaxBucketAggregation
   median_absolute_deviation?: MedianAbsoluteDeviationAggregation
-  meta?: Record<string, any>
   min?: MinAggregation
   min_bucket?: MinBucketAggregation
   missing?: MissingAggregation
@@ -527,7 +526,6 @@ export interface AsyncSearchDocumentResponseBase<TDocument = unknown> extends As
 
 export interface AsyncSearchGetRequest extends RequestBase {
   id: Id
-  typed_keys?: boolean
   body?: {
     keep_alive?: Time
     typed_keys?: boolean
@@ -776,7 +774,6 @@ export interface BucketAggregate extends AggregateBase {
 }
 
 export interface BucketAggregationBase extends Aggregation {
-  aggregations?: Record<string, AggregationContainer>
 }
 
 export interface BucketInfluencer {
@@ -2804,7 +2801,7 @@ export interface ChiSquareHeuristic {
 export type ChildScoreMode = 'none' | 'avg' | 'sum' | 'max' | 'min'
 
 export interface ChildrenAggregation extends BucketAggregationBase {
-  type?: RelationName
+  type: RelationName
 }
 
 export interface ChunkingConfig {
@@ -3697,9 +3694,9 @@ export interface ComponentTemplateSummary {
 }
 
 export interface CompositeAggregation extends BucketAggregationBase {
-  after?: Record<string, string | float | null>
+  sources: Array<Record<string, CompositeAggregationSource>>
   size?: integer
-  sources?: Array<Record<string, CompositeAggregationSource>>
+  after?: Record<string, string | number | null>
 }
 
 export interface CompositeAggregationSource {
@@ -4184,7 +4181,7 @@ export interface DateProperty extends DocValuesPropertyBase {
 }
 
 export interface DateRangeAggregation extends BucketAggregationBase {
-  field?: Field
+  field: Field
   format?: string
   missing?: Missing
   ranges?: Array<DateRangeExpression>
@@ -4193,11 +4190,7 @@ export interface DateRangeAggregation extends BucketAggregationBase {
 
 export interface DateRangeExpression {
   from?: DateMath | float
-  from_as_string?: string
-  to_as_string?: string
-  key?: string
   to?: DateMath | float
-  doc_count?: long
 }
 
 export interface DateRangeProperty extends RangePropertyBase {
@@ -4912,7 +4905,7 @@ export interface EnrichStatsResponse extends ResponseBase {
   executing_policies: Array<ExecutingPolicy>
 }
 
-export type EpochMillis = string | long
+export type EpochMillis = string | long | double
 
 export interface EqlDeleteRequest extends RequestBase {
   id: Id
@@ -8461,7 +8454,6 @@ export interface MultiGetHit<TDocument = unknown> {
 export type MultiGetId = string | integer
 
 export interface MultiGetOperation {
-  can_be_flattened?: boolean
   _id: MultiGetId
   _index?: IndexName
   routing?: Routing
@@ -10018,10 +10010,6 @@ export interface QueryContainer {
   has_parent?: HasParentQuery
   ids?: IdsQuery
   intervals?: NamedQuery<IntervalsQuery | string>
-  is_conditionless?: boolean
-  is_strict?: boolean
-  is_verbatim?: boolean
-  is_writable?: boolean
   match?: NamedQuery<MatchQuery | string | float | boolean>
   match_all?: MatchAllQuery
   match_bool_prefix?: NamedQuery<MatchBoolPrefixQuery | string>
@@ -11183,7 +11171,6 @@ export interface SearchRequest extends RequestBase {
   sort?: string | Array<string>
   body?: {
     aggs?: Record<string, AggregationContainer>
-    aggregations?: Record<string, AggregationContainer>
     collapse?: FieldCollapse
     explain?: boolean
     from?: integer
@@ -12016,9 +12003,9 @@ export interface SlmUsage extends XPackUsage {
 }
 
 export interface SmoothingModelContainer {
-  laplace: LaplaceSmoothingModel
-  linear_interpolation: LinearInterpolationSmoothingModel
-  stupid_backoff: StupidBackoffSmoothingModel
+  laplace?: LaplaceSmoothingModel
+  linear_interpolation?: LinearInterpolationSmoothingModel
+  stupid_backoff?: StupidBackoffSmoothingModel
 }
 
 export interface SnapshotIndexStats {
@@ -13194,9 +13181,9 @@ export interface TransformCheckpointingInfo {
 }
 
 export interface TransformContainer {
-  chain: ChainTransform
-  script: ScriptTransform
-  search: SearchTransform
+  chain?: ChainTransform
+  script?: ScriptTransform
+  search?: SearchTransform
 }
 
 export interface TransformDestination {

--- a/specification/compiler/model/metamodel.ts
+++ b/specification/compiler/model/metamodel.ts
@@ -140,6 +140,8 @@ export class Property {
   identifier?: string
   /** An optional set of aliases for `name` */
   aliases?: string[]
+  /** If the enclosing class is a variants container, is this a property of the container and not a variant? */
+  container_property?: boolean
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -159,6 +161,7 @@ export abstract class BaseType {
   docUrl?: string
   deprecation?: Deprecation
   kind: string
+  /** Variant name for externally tagged variants */
   variantName?: string
 }
 
@@ -288,7 +291,7 @@ export class TypeAlias extends BaseType {
   type: ValueOf
   /** generic parameters: either concrete types or open parameters from the enclosing type */
   generics?: ValueOf[]
-  /** Identify typed_key unions (external) and variant inventories (internal) */
+  /** Only applicable to `union_of` aliases: identify typed_key unions (external) and variant inventories (internal) */
   variants?: InternalTag | ExternalTag
 }
 

--- a/specification/compiler/model/utils.ts
+++ b/specification/compiler/model/utils.ts
@@ -552,11 +552,8 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
     } else if (tag === 'doc_url') {
       property.docUrl = value
     } else if (tag === 'variant') {
-      if (value === 'container_property') {
-        property.container_property = true
-      } else {
-        throw new Error(`Unknown 'variant' value '${value}' on property ${property.name}`)
-      }
+      assert(jsDocs, value === 'container_property', `Unknown 'variant' value '${value}' on property ${property.name}`)
+      property.container_property = true
     } else if (tag === 'since') {
       assert(jsDocs, semver.valid(value), `${property.name}'s @since is not valid semver: ${value}`)
       property.since = value

--- a/specification/compiler/model/utils.ts
+++ b/specification/compiler/model/utils.ts
@@ -47,7 +47,8 @@ export const knownBehaviors = [
   'ArrayResponseBase',
   'EmptyResponseBase',
   'CommonQueryParameters',
-  'CommonCatQueryParameters'
+  'CommonCatQueryParameters',
+  'TypedKeysContainer'
 ]
 
 /**
@@ -449,14 +450,9 @@ function setTags<TType extends model.BaseType | model.Property | model.EnumMembe
     }
   }
 
-  function getName (type: TType): string {
-    if (typeof type.name === 'string') {
-      return type.name
-    } else if (typeof type.name.name === 'string') {
-      return type.name.name
-    } else {
-      return 'unknown'
-    }
+  function getName (type): string {
+    if (type.name?.name != null) return type.name.name
+    return type.name
   }
 }
 
@@ -540,7 +536,7 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
   // We want to enforce a single jsDoc block.
   assert(jsDocs, jsDocs.length < 2, 'Use a single multiline jsDoc block instead of multiple single line blocks')
 
-  const validTags = ['stability', 'prop_serializer', 'doc_url', 'aliases', 'identifier', 'since', 'server_default']
+  const validTags = ['stability', 'prop_serializer', 'doc_url', 'aliases', 'identifier', 'since', 'server_default', 'variant']
   const tags = parseJsDocTags(jsDocs)
   if (jsDocs.length === 1) {
     const description = jsDocs[0].getDescription()
@@ -555,6 +551,12 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
       property.identifier = value
     } else if (tag === 'doc_url') {
       property.docUrl = value
+    } else if (tag === 'variant') {
+      if (value === 'container_property') {
+        property.container_property = true
+      } else {
+        throw new Error(`Unknown 'variant' value '${value}' on property ${property.name}`)
+      }
     } else if (tag === 'since') {
       assert(jsDocs, semver.valid(value), `${property.name}'s @since is not valid semver: ${value}`)
       property.since = value

--- a/specification/compiler/steps/validate-model.ts
+++ b/specification/compiler/steps/validate-model.ts
@@ -20,10 +20,20 @@
 import * as model from '../model/metamodel'
 import { ValidationErrors } from '../validation-errors'
 import { JsonSpec } from '../model/json-spec'
+import assert from 'assert'
 
 enum TypeDefKind {
   type,
   behavior
+}
+
+enum JsonEvent {
+  string = 'string',
+  number = 'number',
+  boolean = 'boolean',
+  null = 'null',
+  object = 'object',
+  array = 'array'
 }
 
 /**
@@ -417,7 +427,47 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       }
     }))
 
-    validateValueOf(typeDef.type, openGenerics)
+    if (typeDef.variants != null) {
+      if (typeDef.generics != null && typeDef.generics.length !== 0) {
+        modelError('A tagged union should not have generic parameters')
+      }
+
+      if (typeDef.type.kind !== 'union_of') {
+        modelError('The "variants" tag only applies to unions')
+      } else {
+        validateTaggedUnion(typeDef.type, typeDef.variants)
+      }
+    } else {
+      validateValueOf(typeDef.type, openGenerics)
+    }
+  }
+
+  function validateTaggedUnion (valueOf: model.UnionOf, variants: model.InternalTag | model.ExternalTag): void {
+    if (variants.kind === 'external_tag') {
+      // All items must have a 'variant' attribute
+      const items = flattenUnionMembers(valueOf)
+
+      for (const item of items) {
+        if (item.kind !== 'instance_of') {
+          modelError('Items of externally tagged unions must be types with a "variant_tag" annotation')
+        } else {
+          validateTypeRef(item.type, undefined, new Set<string>())
+          const type = getTypeDef(item.type)
+          if (type == null) {
+            modelError(`Type ${fqn(item.type)} not found`)
+          } else {
+            if (type.variantName == null) {
+              modelError(`Type ${fqn(item.type)} is part of a tagged union and should have a "@variant name"`)
+            } else {
+              // Check uniqueness
+            }
+          }
+        }
+      }
+    } else if (variants.kind === 'internal_tag') {
+      // TODO
+      validateValueOf(valueOf, new Set())
+    }
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -527,6 +577,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
 
       context.push(`Property '${prop.name}'`)
       validateValueOf(prop.type, openGenerics)
+      validateValueOfJsonEvents(prop.type)
       context.pop()
     }
   }
@@ -609,6 +660,157 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
         // @ts-expect-error
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         throw new Error(`Unknown kind: ${valueOf.kind}`)
+    }
+    context.pop()
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // JSON events validation
+
+  function validateValueOfJsonEvents (valueOf: model.ValueOf): void {
+    // TODO: disabled for now as it's too noisy until we have fully annotated variants
+
+    // const events = new Set<JsonEvent>()
+    // valueOfJsonEvents(events, valueOf)
+  }
+
+  function validateEvent (events: Set<JsonEvent>, event: JsonEvent): void {
+    if (events.has(event)) {
+      modelError('Ambiguous JSON type: ' + event)
+    }
+    events.add(event)
+  }
+
+  function typeDefJsonEvents (events: Set<JsonEvent>, typeDef: model.TypeDefinition): void {
+    if (typeDef.name.namespace === 'internal') {
+      switch (typeDef.name.name) {
+        case 'string':
+          validateEvent(events, JsonEvent.string)
+          return
+
+        case 'boolean':
+          validateEvent(events, JsonEvent.boolean)
+          return
+
+        case 'number':
+          validateEvent(events, JsonEvent.number)
+          return
+
+        case 'object':
+          validateEvent(events, JsonEvent.object)
+          return
+
+        case 'null':
+          validateEvent(events, JsonEvent.null)
+          return
+
+        case 'Array':
+          validateEvent(events, JsonEvent.array)
+          return
+      }
+    }
+
+    switch (typeDef.kind) {
+      case 'request':
+      case 'interface':
+        validateEvent(events, JsonEvent.object)
+        break
+
+      case 'enum':
+        validateEvent(events, JsonEvent.string)
+        break
+
+      case 'type_alias':
+        if (typeDef.variants == null) {
+          valueOfJsonEvents(events, typeDef.type)
+        } else {
+          // tagged union: the discriminant tells us what to look for, check each member in isolation
+          assert(typeDef.type.kind === 'union_of', 'Variants are only allowed on union_of type aliases')
+          for (const item of flattenUnionMembers(typeDef.type)) {
+            validateValueOfJsonEvents(item)
+          }
+
+          // Internally tagged variants will be objects, so check that we can read them
+          if (typeDef.variants.kind === 'internal_tag') {
+            // variant items will be objects
+            validateEvent(events, JsonEvent.object)
+          }
+        }
+        break
+    }
+  }
+
+  /** Build the flattened item list of potentially nested unions (this is used for large unions) */
+  function flattenUnionMembers (union: model.UnionOf): model.ValueOf[] {
+    const allItems = new Array<model.ValueOf>()
+
+    function collectItems (items: model.ValueOf[]): void {
+      for (const item of items) {
+        if (item.kind !== 'instance_of') {
+          validateValueOf(item, new Set<string>())
+          allItems.push(item)
+        } else {
+          const itemType = getTypeDef(item.type)
+          if (itemType?.kind === 'type_alias' && itemType.type.kind === 'union_of') {
+            // Mark it as seen
+            typesSeen.add(fqn(item.type))
+            // Recurse in nested union
+            collectItems(itemType.type.items)
+          } else {
+            validateValueOf(item, new Set<string>())
+            allItems.push(item)
+          }
+        }
+      }
+    }
+
+    collectItems(union.items)
+    return allItems
+  }
+
+  function typeRefJsonEvents (events: Set<JsonEvent>, name: model.TypeName): void {
+    const type = getTypeDef(name)
+    if (type != null) {
+      typeDefJsonEvents(events, type)
+    }
+  }
+
+  function valueOfJsonEvents (events: Set<JsonEvent>, valueOf: model.ValueOf): void {
+    context.push(valueOf.kind)
+    switch (valueOf.kind) {
+      case 'instance_of':
+        typeRefJsonEvents(events, valueOf.type)
+        break
+
+      case 'user_defined_value':
+        validateEvent(events, JsonEvent.object) // but can be anything
+        break
+
+      case 'array_of':
+        validateEvent(events, JsonEvent.array)
+        validateValueOfJsonEvents(valueOf.value)
+        break
+
+      case 'dictionary_of':
+        validateEvent(events, JsonEvent.object)
+        context.push('key')
+        validateValueOfJsonEvents(valueOf.value)
+        context.pop()
+        context.push('value')
+        validateValueOfJsonEvents(valueOf.key)
+        context.pop()
+        break
+
+      case 'named_value_of':
+        validateEvent(events, JsonEvent.object)
+        validateValueOfJsonEvents(valueOf.value)
+        break
+
+      case 'union_of':
+        for (const item of valueOf.items) {
+          valueOfJsonEvents(events, item)
+        }
+        break
     }
     context.pop()
   }

--- a/specification/compiler/validation-errors.ts
+++ b/specification/compiler/validation-errors.ts
@@ -74,7 +74,7 @@ export class ValidationErrors {
       const endpointErrs = this.endpointErrors[name]
       if (endpointErrs != null) {
         for (const part of ['request', 'response']) {
-          logArray(endpointErrs[part], `${name} ${part}`)
+          logArray(endpointErrs[part], `${name} ${part}: `)
         }
       }
     }

--- a/specification/specs/aggregations/Aggregation.ts
+++ b/specification/specs/aggregations/Aggregation.ts
@@ -18,6 +18,8 @@
  */
 
 class Aggregation {
-  meta?: Dictionary<string, UserDefinedValue>
-  name?: string
+  // Meta is a property of the container (one level higher in the JSON tree)
+  // meta?: Dictionary<string, UserDefinedValue>
+  // Name is in the container's enclosing structure (two levels higher in the JSON tree)
+  // name?: string
 }

--- a/specification/specs/aggregations/AggregationContainer.ts
+++ b/specification/specs/aggregations/AggregationContainer.ts
@@ -17,10 +17,30 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class AggregationContainer {
-  adjacency_matrix?: AdjacencyMatrixAggregation
+  // These two field are always available
+  /**
+   * Nested aggregations. Bucket aggregations support bucket or metric sub-aggregations.
+   *
+   * @variant container_property
+   * @aliases aggregations
+   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html#run-sub-aggs
+   */
+  // Note: this is only applicable to children of BucketAggregationBase, but the JSON format attaches it to the
+  // container. Code generators may want to move it down as a member of the BucketAggregationBase structure to only
+  // expose it where it makes sense.
   aggs?: Dictionary<string, AggregationContainer>
-  aggregations?: Dictionary<string, AggregationContainer>
+
+  /**
+   * @variant container_property
+   */
+  meta?: Dictionary<string, UserDefinedValue>
+
+  // Regular container fields. Only one of them can exist at a time.
+  adjacency_matrix?: AdjacencyMatrixAggregation
   auto_date_histogram?: AutoDateHistogramAggregation
   avg?: AverageAggregation
   avg_bucket?: AverageBucketAggregation
@@ -56,7 +76,6 @@ class AggregationContainer {
   max?: MaxAggregation
   max_bucket?: MaxBucketAggregation
   median_absolute_deviation?: MedianAbsoluteDeviationAggregation
-  meta?: Dictionary<string, UserDefinedValue>
   min?: MinAggregation
   min_bucket?: MinBucketAggregation
   missing?: MissingAggregation

--- a/specification/specs/aggregations/bucket/BucketAggregationBase.ts
+++ b/specification/specs/aggregations/bucket/BucketAggregationBase.ts
@@ -18,5 +18,7 @@
  */
 
 class BucketAggregationBase extends Aggregation {
-  aggregations?: Dictionary<string, AggregationContainer>
+  // This is a property of the container (one level higher in the JSON tree) even if semantically applicable
+  // only to bucket aggregations. See note in AggregationContainer.
+  // aggregations?: Dictionary<string, AggregationContainer>
 }

--- a/specification/specs/aggregations/bucket/adjacency_matrix/AdjacencyMatrixAggregation.ts
+++ b/specification/specs/aggregations/bucket/adjacency_matrix/AdjacencyMatrixAggregation.ts
@@ -17,6 +17,17 @@
  * under the License.
  */
 
+/**
+ * A bucket aggregation returning a form of [adjacency matrix](https://en.wikipedia.org/wiki/Adjacency_matrix). The
+ * request provides a collection of named filter expressions, similar to the filters aggregation request. Each bucket
+ * in the response represents a non-empty cell in the matrix of intersecting filters.
+ *
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-adjacency-matrix-aggregation.html
+ */
 class AdjacencyMatrixAggregation extends BucketAggregationBase {
-  filters?: Dictionary<string, QueryContainer>
+  /** Filters used to create buckets. */
+  filters: Dictionary<string, QueryContainer>
+
+  /** Separator used to concatenate filter names. Defaults to `&`. */
+  separator?: string
 }

--- a/specification/specs/aggregations/bucket/auto_date_histogram/AutoDateHistogramAggregation.ts
+++ b/specification/specs/aggregations/bucket/auto_date_histogram/AutoDateHistogramAggregation.ts
@@ -17,6 +17,14 @@
  * under the License.
  */
 
+/**
+ * A multi-bucket aggregation similar to `date_histogram` except instead of providing an interval to use as the width
+ * of each bucket, a target number of buckets is provided indicating the number of buckets needed and the interval of
+ * the buckets is automatically chosen to best achieve that target. The number of buckets returned will always be less
+ * than or equal to this target number.
+ *
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-autodatehistogram-aggregation.html
+ */
 class AutoDateHistogramAggregation extends BucketAggregationBase {
   buckets?: integer
   field?: Field

--- a/specification/specs/aggregations/bucket/children/ChildrenAggregation.ts
+++ b/specification/specs/aggregations/bucket/children/ChildrenAggregation.ts
@@ -17,6 +17,12 @@
  * under the License.
  */
 
+/**
+ * A special single bucket aggregation that selects child documents that have the specified type, as defined in a join
+ * field.
+ *
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-children-aggregation.html
+ */
 class ChildrenAggregation extends BucketAggregationBase {
-  type?: RelationName
+  type: RelationName
 }

--- a/specification/specs/aggregations/bucket/composite/CompositeAggregation.ts
+++ b/specification/specs/aggregations/bucket/composite/CompositeAggregation.ts
@@ -17,8 +17,15 @@
  * under the License.
  */
 
+/**
+ * A multi-bucket aggregation that creates composite buckets from different sources.
+ *
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html
+ */
 class CompositeAggregation extends BucketAggregationBase {
-  after?: Dictionary<string, string | float | null>
+  sources: Array<Dictionary<string, CompositeAggregationSource>>
   size?: integer
-  sources?: Array<Dictionary<string, CompositeAggregationSource>>
+  // FIXME: should 'null' be there? It can be returned if missing_bucket is true, but
+  // sending a request with 'null' causes an error
+  after?: Dictionary<string, string | number | null>
 }

--- a/specification/specs/aggregations/bucket/composite/CompositeAggregationSource.ts
+++ b/specification/specs/aggregations/bucket/composite/CompositeAggregationSource.ts
@@ -17,13 +17,10 @@
  * under the License.
  */
 
-@class_serializer('CompositeAggregationSourceFormatter')
+/**
+ * @variants container
+ */
 class CompositeAggregationSource {
-  // field: Field;
-  // missing_bucket: boolean;
-  // name: string;
-  // order: SortOrder;
-  // source_type: string;
   terms?: TermsAggregation
   histogram?: HistogramAggregation
   date_histogram?: DateHistogramAggregation

--- a/specification/specs/aggregations/bucket/date_histogram/DateHistogramAggregation.ts
+++ b/specification/specs/aggregations/bucket/date_histogram/DateHistogramAggregation.ts
@@ -32,4 +32,5 @@ class DateHistogramAggregation extends BucketAggregationBase {
   params?: Dictionary<string, UserDefinedValue>
   script?: Script
   time_zone?: string
+  // Note: "keyed" has been omitted. It changes the response format (see DateHistogramAggregate).
 }

--- a/specification/specs/aggregations/bucket/date_range/DateRangeAggregation.ts
+++ b/specification/specs/aggregations/bucket/date_range/DateRangeAggregation.ts
@@ -18,9 +18,10 @@
  */
 
 class DateRangeAggregation extends BucketAggregationBase {
-  field?: Field
+  field: Field
   format?: string
   missing?: Missing
   ranges?: DateRangeExpression[]
   time_zone?: string
+  // Note: "keyed" has been omitted. It changes the response format (see DateHistogramAggregate).
 }

--- a/specification/specs/aggregations/bucket/date_range/DateRangeExpression.ts
+++ b/specification/specs/aggregations/bucket/date_range/DateRangeExpression.ts
@@ -19,9 +19,5 @@
 
 class DateRangeExpression {
   from?: DateMath | float
-  from_as_string?: string
-  to_as_string?: string
-  key?: string
   to?: DateMath | float
-  doc_count?: long
 }

--- a/specification/specs/aggregations/pipeline/inference_bucket/InferenceBucketAggregation.ts
+++ b/specification/specs/aggregations/pipeline/inference_bucket/InferenceBucketAggregation.ts
@@ -22,6 +22,7 @@ class InferenceAggregation extends PipelineAggregationBase {
   inference_config?: InferenceConfigContainer
 }
 
+/** @variants container */
 class InferenceConfigContainer {
   regression?: RegressionInferenceOptions
   classification?: ClassificationInferenceOptions

--- a/specification/specs/behaviors.ts
+++ b/specification/specs/behaviors.ts
@@ -79,3 +79,9 @@ interface CommonCatQueryParameters {
   s?: string[]
   v?: boolean
 }
+
+/**
+ * Typed keys are used in responses for aggregation and suggesters which are represented as (name, value) pairs.
+ * The typed_keys parameter encodes the type as (type#name, value) pairs (default in 7.x)
+ */
+interface TypedKeysContainer<TKey, TValue> {}

--- a/specification/specs/common.ts
+++ b/specification/specs/common.ts
@@ -42,7 +42,7 @@ type Uri = string
 type DateString = string
 type Timestamp = string
 type TimeSpan = string
-type EpochMillis = string | long
+type EpochMillis = string | long | double // In some places (e.g. date range aggregation) it's output as a double value
 
 @class_serializer('ErrorCauseFormatter')
 class ErrorCause {

--- a/specification/specs/document/multiple/bulk/bulk_operation/BulkOperation.ts
+++ b/specification/specs/document/multiple/bulk/bulk_operation/BulkOperation.ts
@@ -26,6 +26,7 @@ class BulkOperation {
   version_type: VersionType
 }
 
+/** @variants container */
 class BulkOperationContainer {
   index?: BulkIndexOperation
   create?: BulkCreateOperation

--- a/specification/specs/document/multiple/bulk/bulk_response_item/BulkResponseItemBase.ts
+++ b/specification/specs/document/multiple/bulk/bulk_response_item/BulkResponseItemBase.ts
@@ -35,6 +35,7 @@ class BulkResponseItemBase {
   get?: InlineGet<Dictionary<string, UserDefinedValue>>
 }
 
+/** @variants container */
 class BulkResponseItemContainer {
   index?: BulkIndexResponseItem
   create?: BulkCreateResponseItem

--- a/specification/specs/document/multiple/multi_get/MultiGetRequest.ts
+++ b/specification/specs/document/multiple/multi_get/MultiGetRequest.ts
@@ -46,7 +46,6 @@ interface MultiGetRequest extends RequestBase {
 }
 
 class MultiGetOperation {
-  can_be_flattened?: boolean
   _id: MultiGetId
   _index?: IndexName
   routing?: Routing

--- a/specification/specs/ingest/ProcessorContainer.ts
+++ b/specification/specs/ingest/ProcessorContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class ProcessorContainer {
   attachment?: AttachmentProcessor
   append?: AppendProcessor

--- a/specification/specs/query_dsl/abstractions/container/QueryContainer.ts
+++ b/specification/specs/query_dsl/abstractions/container/QueryContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 @class_serializer('QueryContainerInterfaceFormatter')
 class QueryContainer {
   bool?: BoolQuery
@@ -40,10 +43,6 @@ class QueryContainer {
   has_parent?: HasParentQuery
   ids?: IdsQuery
   intervals?: NamedQuery<IntervalsQuery | string>
-  is_conditionless?: boolean
-  is_strict?: boolean
-  is_verbatim?: boolean
-  is_writable?: boolean
   match?: NamedQuery<MatchQuery | string | float | boolean>
   match_all?: MatchAllQuery
   match_bool_prefix?: NamedQuery<MatchBoolPrefixQuery | string>

--- a/specification/specs/query_dsl/full_text/intervals/IntervalsContainer.ts
+++ b/specification/specs/query_dsl/full_text/intervals/IntervalsContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class IntervalsContainer {
   all_of?: IntervalsAllOf
   any_of?: IntervalsAnyOf

--- a/specification/specs/search/search/SearchRequest.ts
+++ b/specification/specs/search/search/SearchRequest.ts
@@ -69,8 +69,8 @@ interface SearchRequest extends RequestBase {
     sort?: string | string[]
   }
   body?: {
+    /** @aliases aggregations */
     aggs?: Dictionary<string, AggregationContainer>
-    aggregations?: Dictionary<string, AggregationContainer>
     collapse?: FieldCollapse
     explain?: boolean
     from?: integer

--- a/specification/specs/search/suggesters/SuggestContainer.ts
+++ b/specification/specs/search/suggesters/SuggestContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class SuggestContainer {
   completion?: CompletionSuggester
   phrase?: PhraseSuggester

--- a/specification/specs/search/suggesters/phrase_suggester/smoothing_model/SmoothingModelContainer.ts
+++ b/specification/specs/search/suggesters/phrase_suggester/smoothing_model/SmoothingModelContainer.ts
@@ -17,8 +17,11 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class SmoothingModelContainer {
-  laplace: LaplaceSmoothingModel
-  linear_interpolation: LinearInterpolationSmoothingModel
-  stupid_backoff: StupidBackoffSmoothingModel
+  laplace?: LaplaceSmoothingModel
+  linear_interpolation?: LinearInterpolationSmoothingModel
+  stupid_backoff?: StupidBackoffSmoothingModel
 }

--- a/specification/specs/x_pack/async_search/get/AsyncSearchGetRequest.ts
+++ b/specification/specs/x_pack/async_search/get/AsyncSearchGetRequest.ts
@@ -25,7 +25,6 @@
 interface AsyncSearchGetRequest extends RequestBase {
   path_parts?: {
     id: Id
-    typed_keys?: boolean
   }
   query_parameters?: {}
   body?: {

--- a/specification/specs/x_pack/transform/TransformSyncContainer.ts
+++ b/specification/specs/x_pack/transform/TransformSyncContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class TransformSyncContainer {
   time: TransformTimeSync
 }

--- a/specification/specs/x_pack/watcher/condition/ConditionContainer.ts
+++ b/specification/specs/x_pack/watcher/condition/ConditionContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class ConditionContainer {
   always?: AlwaysCondition
   array_compare?: ArrayCompareCondition

--- a/specification/specs/x_pack/watcher/input/InputContainer.ts
+++ b/specification/specs/x_pack/watcher/input/InputContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class InputContainer {
   chain?: ChainInput
   http?: HttpInput

--- a/specification/specs/x_pack/watcher/schedule/ScheduleContainer.ts
+++ b/specification/specs/x_pack/watcher/schedule/ScheduleContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class ScheduleContainer {
   cron?: CronExpression
   daily?: DailySchedule

--- a/specification/specs/x_pack/watcher/transform/TransformContainer.ts
+++ b/specification/specs/x_pack/watcher/transform/TransformContainer.ts
@@ -17,8 +17,11 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class TransformContainer {
-  chain: ChainTransform
-  script: ScriptTransform
-  search: SearchTransform
+  chain?: ChainTransform
+  script?: ScriptTransform
+  search?: SearchTransform
 }

--- a/specification/specs/x_pack/watcher/trigger/TriggerContainer.ts
+++ b/specification/specs/x_pack/watcher/trigger/TriggerContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 @class_serializer('TriggerContainerInterfaceFormatter')
 class TriggerContainer {
   schedule: ScheduleContainer

--- a/specification/specs/x_pack/watcher/trigger/TriggerEventContainer.ts
+++ b/specification/specs/x_pack/watcher/trigger/TriggerEventContainer.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+/**
+ * @variants container
+ */
 class TriggerEventContainer {
   schedule: ScheduleTriggerEvent
 }


### PR DESCRIPTION
Add `variants` tag to polymorphic types.

This first part is about container, union types will come in a follow-up PR, as their current model (in particular agregations) requires some more in-depth refactoring to represent typed keys.

A new annotation is introduced for properties, `@variant container_property` to identify properties that belong to the container and aren't part of the variants. This is the case of `aggs` and `meta` on aggregations.

This PR also includes a "json ambiguity check" in the model validation, that verifies that the json structure of the model can be analyzed unambiguously with a streaming JSON parser, which is what strongly typed languages generally use to avoid creating an intermediate in-memory JSON AST.

This validation is currently disabled as polymorphic unions cause a lot of errors, which will go away once they are modelled and tagged correctly.