### PR TITLE
Add annotations and validations for polymorphic types

### DIFF
--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -140,6 +140,8 @@ export class Property {
   identifier?: string
   /** An optional set of aliases for `name` */
   aliases?: string[]
+  /** If the enclosing class is a variants container, is this a property of the container and not a variant? */
+  container_property?: boolean
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -159,6 +161,7 @@ export abstract class BaseType {
   docUrl?: string
   deprecation?: Deprecation
   kind: string
+  /** Variant name for externally tagged variants */
   variantName?: string
 }
 
@@ -288,7 +291,7 @@ export class TypeAlias extends BaseType {
   type: ValueOf
   /** generic parameters: either concrete types or open parameters from the enclosing type */
   generics?: ValueOf[]
-  /** Identify typed_key unions (external) and variant inventories (internal) */
+  /** Only applicable to `union_of` aliases: identify typed_key unions (external) and variant inventories (internal) */
   variants?: InternalTag | ExternalTag
 }
 

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -453,10 +453,8 @@ function setTags<TType extends model.BaseType | model.Property | model.EnumMembe
   function getName (type: TType): string {
     if (typeof type.name === 'string') {
       return type.name
-    } else if (typeof type.name.name === 'string') {
-      return type.name.name
     } else {
-      return 'unknown'
+      return type.name.name
     }
   }
 }
@@ -541,7 +539,7 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
   // We want to enforce a single jsDoc block.
   assert(jsDocs, jsDocs.length < 2, 'Use a single multiline jsDoc block instead of multiple single line blocks')
 
-  const validTags = ['stability', 'prop_serializer', 'doc_url', 'aliases', 'identifier', 'since', 'server_default']
+  const validTags = ['stability', 'prop_serializer', 'doc_url', 'aliases', 'identifier', 'since', 'server_default', 'variant']
   const tags = parseJsDocTags(jsDocs)
   if (jsDocs.length === 1) {
     const description = jsDocs[0].getDescription()
@@ -574,6 +572,9 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
         default:
           property.serverDefault = value
       }
+    } else if (tag === 'variant') {
+      assert(jsDocs, value === 'container_property', `Unknown 'variant' value '${value}' on property ${property.name}`)
+      property.container_property = true
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on property ${property.name}`)
     }

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -31,5 +31,6 @@
   },
   "engines": {
     "node": ">=14"
-  }
+  },
+  "keywords": []
 }

--- a/compiler/steps/validate-model.ts
+++ b/compiler/steps/validate-model.ts
@@ -20,10 +20,20 @@
 import * as model from '../model/metamodel'
 import { ValidationErrors } from '../validation-errors'
 import { JsonSpec } from '../model/json-spec'
+import assert from 'assert'
 
 enum TypeDefKind {
   type,
   behavior
+}
+
+enum JsonEvent {
+  string = 'string',
+  number = 'number',
+  boolean = 'boolean',
+  null = 'null',
+  object = 'object',
+  array = 'array'
 }
 
 /**
@@ -385,6 +395,23 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     validateInherits(typeDef.inherits, openGenerics)
     validateBehaviors(typeDef, openGenerics)
     validateProperties(typeDef.properties, openGenerics)
+
+    if (typeDef.variants?.kind === 'container') {
+      const variants = typeDef.properties.filter(prop => !prop.container_property)
+      if (variants.length === 1) {
+        // Single-variant containers must have a required property
+        if (!variants[0].required) {
+          modelError(`Property ${variants[0].name} is a single-variant and must be required`)
+        }
+      } else {
+        // Multiple variants must all be optional
+        for (const v of variants) {
+          if (v.required) {
+            modelError(`Variant ${variants[0].name} must be optional`)
+          }
+        }
+      }
+    }
   }
 
   function validateEnum (typeDef: model.Enum): void {
@@ -417,7 +444,67 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       }
     }))
 
-    validateValueOf(typeDef.type, openGenerics)
+    if (typeDef.variants != null) {
+      if (typeDef.generics != null && typeDef.generics.length !== 0) {
+        modelError('A tagged union should not have generic parameters')
+      }
+
+      if (typeDef.type.kind !== 'union_of') {
+        modelError('The "variants" tag only applies to unions')
+      } else {
+        validateTaggedUnion(typeDef.type, typeDef.variants)
+      }
+    } else {
+      validateValueOf(typeDef.type, openGenerics)
+    }
+  }
+
+  function validateTaggedUnion (valueOf: model.UnionOf, variants: model.InternalTag | model.ExternalTag): void {
+    if (variants.kind === 'external_tag') {
+      // All items must have a 'variant' attribute
+      const items = flattenUnionMembers(valueOf)
+
+      for (const item of items) {
+        if (item.kind !== 'instance_of') {
+          modelError('Items of externally tagged unions must be types with a "variant_tag" annotation')
+        } else {
+          validateTypeRef(item.type, undefined, new Set<string>())
+          const type = getTypeDef(item.type)
+          if (type == null) {
+            modelError(`Type ${fqn(item.type)} not found`)
+          } else {
+            if (type.variantName == null) {
+              modelError(`Type ${fqn(item.type)} is part of a tagged union and should have a "@variant name"`)
+            } else {
+              // Check uniqueness
+            }
+          }
+        }
+      }
+
+    } else if (variants.kind === 'internal_tag') {
+      const tagName = variants.tag
+      const items = flattenUnionMembers(valueOf)
+
+      for (const item of items) {
+        if (item.kind !== 'instance_of') {
+          modelError('Items of internally tagged unions must be type references')
+        } else {
+          validateTypeRef(item.type, undefined, new Set<string>())
+          const type = getTypeDef(item.type)
+          if (type == null) {
+            modelError(`Type ${fqn(item.type)} not found`)
+          } else if (type.kind === 'interface') {
+            const tagProperty = type.properties.find(prop => prop.name === tagName);
+            if (tagProperty == null) {
+              modelError(`Type ${fqn(item.type)} should have a "${tagName}" variant tag property`)
+            }
+          }
+        }
+      }
+
+      validateValueOf(valueOf, new Set())
+    }
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -527,6 +614,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
 
       context.push(`Property '${prop.name}'`)
       validateValueOf(prop.type, openGenerics)
+      validateValueOfJsonEvents(prop.type)
       context.pop()
     }
   }
@@ -609,6 +697,157 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
         // @ts-expect-error
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         throw new Error(`Unknown kind: ${valueOf.kind}`)
+    }
+    context.pop()
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // JSON events validation
+
+  function validateValueOfJsonEvents (valueOf: model.ValueOf): void {
+    // TODO: disabled for now as it's too noisy until we have fully annotated variants
+
+    //const events = new Set<JsonEvent>()
+    //valueOfJsonEvents(events, valueOf)
+  }
+
+  function validateEvent (events: Set<JsonEvent>, event: JsonEvent): void {
+    if (events.has(event)) {
+      modelError('Ambiguous JSON type: ' + event)
+    }
+    events.add(event)
+  }
+
+  function typeDefJsonEvents (events: Set<JsonEvent>, typeDef: model.TypeDefinition): void {
+    if (typeDef.name.namespace === 'internal') {
+      switch (typeDef.name.name) {
+        case 'string':
+          validateEvent(events, JsonEvent.string)
+          return
+
+        case 'boolean':
+          validateEvent(events, JsonEvent.boolean)
+          return
+
+        case 'number':
+          validateEvent(events, JsonEvent.number)
+          return
+
+        case 'object':
+          validateEvent(events, JsonEvent.object)
+          return
+
+        case 'null':
+          validateEvent(events, JsonEvent.null)
+          return
+
+        case 'Array':
+          validateEvent(events, JsonEvent.array)
+          return
+      }
+    }
+
+    switch (typeDef.kind) {
+      case 'request':
+      case 'interface':
+        validateEvent(events, JsonEvent.object)
+        break
+
+      case 'enum':
+        validateEvent(events, JsonEvent.string)
+        break
+
+      case 'type_alias':
+        if (typeDef.variants == null) {
+          valueOfJsonEvents(events, typeDef.type)
+        } else {
+          // tagged union: the discriminant tells us what to look for, check each member in isolation
+          assert(typeDef.type.kind === 'union_of', 'Variants are only allowed on union_of type aliases')
+          for (const item of flattenUnionMembers(typeDef.type)) {
+            validateValueOfJsonEvents(item)
+          }
+
+          // Internally tagged variants will be objects, so check that we can read them
+          if (typeDef.variants.kind === 'internal_tag') {
+            // variant items will be objects
+            validateEvent(events, JsonEvent.object)
+          }
+        }
+        break
+    }
+  }
+
+  /** Build the flattened item list of potentially nested unions (this is used for large unions) */
+  function flattenUnionMembers (union: model.UnionOf): model.ValueOf[] {
+    const allItems = new Array<model.ValueOf>()
+
+    function collectItems (items: model.ValueOf[]): void {
+      for (const item of items) {
+        if (item.kind !== 'instance_of') {
+          validateValueOf(item, new Set<string>())
+          allItems.push(item)
+        } else {
+          const itemType = getTypeDef(item.type)
+          if (itemType?.kind === 'type_alias' && itemType.type.kind === 'union_of') {
+            // Mark it as seen
+            typesSeen.add(fqn(item.type))
+            // Recurse in nested union
+            collectItems(itemType.type.items)
+          } else {
+            validateValueOf(item, new Set<string>())
+            allItems.push(item)
+          }
+        }
+      }
+    }
+
+    collectItems(union.items)
+    return allItems
+  }
+
+  function typeRefJsonEvents (events: Set<JsonEvent>, name: model.TypeName): void {
+    const type = getTypeDef(name)
+    if (type != null) {
+      typeDefJsonEvents(events, type)
+    }
+  }
+
+  function valueOfJsonEvents (events: Set<JsonEvent>, valueOf: model.ValueOf): void {
+    context.push(valueOf.kind)
+    switch (valueOf.kind) {
+      case 'instance_of':
+        typeRefJsonEvents(events, valueOf.type)
+        break
+
+      case 'user_defined_value':
+        validateEvent(events, JsonEvent.object) // but can be anything
+        break
+
+      case 'array_of':
+        validateEvent(events, JsonEvent.array)
+        validateValueOfJsonEvents(valueOf.value)
+        break
+
+      case 'dictionary_of':
+        validateEvent(events, JsonEvent.object)
+        context.push('key')
+        validateValueOfJsonEvents(valueOf.key)
+        context.pop()
+        context.push('value')
+        validateValueOfJsonEvents(valueOf.value)
+        context.pop()
+        break
+
+      case 'named_value_of':
+        validateEvent(events, JsonEvent.object)
+        validateValueOfJsonEvents(valueOf.value)
+        break
+
+      case 'union_of':
+        for (const item of valueOf.items) {
+          valueOfJsonEvents(events, item)
+        }
+        break
     }
     context.pop()
   }

--- a/compiler/steps/validate-model.ts
+++ b/compiler/steps/validate-model.ts
@@ -397,7 +397,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     validateProperties(typeDef.properties, openGenerics)
 
     if (typeDef.variants?.kind === 'container') {
-      const variants = typeDef.properties.filter(prop => !prop.container_property)
+      const variants = typeDef.properties.filter(prop => !(prop.container_property ?? false))
       if (variants.length === 1) {
         // Single-variant containers must have a required property
         if (!variants[0].required) {
@@ -481,7 +481,6 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
           }
         }
       }
-
     } else if (variants.kind === 'internal_tag') {
       const tagName = variants.tag
       const items = flattenUnionMembers(valueOf)
@@ -495,7 +494,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
           if (type == null) {
             modelError(`Type ${fqn(item.type)} not found`)
           } else if (type.kind === 'interface') {
-            const tagProperty = type.properties.find(prop => prop.name === tagName);
+            const tagProperty = type.properties.find(prop => prop.name === tagName)
             if (tagProperty == null) {
               modelError(`Type ${fqn(item.type)} should have a "${tagName}" variant tag property`)
             }
@@ -707,8 +706,8 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
   function validateValueOfJsonEvents (valueOf: model.ValueOf): void {
     // TODO: disabled for now as it's too noisy until we have fully annotated variants
 
-    //const events = new Set<JsonEvent>()
-    //valueOfJsonEvents(events, valueOf)
+    // const events = new Set<JsonEvent>()
+    // valueOfJsonEvents(events, valueOf)
   }
 
   function validateEvent (events: Set<JsonEvent>, event: JsonEvent): void {

--- a/compiler/validation-errors.ts
+++ b/compiler/validation-errors.ts
@@ -74,7 +74,7 @@ export class ValidationErrors {
       const endpointErrs = this.endpointErrors[name]
       if (endpointErrs != null) {
         for (const part of ['request', 'response']) {
-          logArray(endpointErrs[part], `${name} ${part}`)
+          logArray(endpointErrs[part], `${name} ${part}: `)
         }
       }
     }

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -274,12 +274,39 @@ For example:
 ```ts
 /** @variants container */
 class FooContainer {
-  bar: BarDefinition
-  baz: BazDefinition
-  faz: FazDefinition
+  bar?: BarDefinition
+  baz?: BazDefinition
+  faz?: FazDefinition
 }
+
+```
+Some containers have properties associated to the container that are not part of the list of variants,
+for example `AggregationContainer` and its `aggs` and `meta` properties.
+
+An annotation allows distinguishing these properties from container variants:
+
+```ts
+/** @variant container_property */
 ```
 
+For example:
+
+```
+/**
+ * @variants container
+ */
+class AggregationContainer {
+  // These two field are always available
+  /** @variant container_property */
+  aggs?: Dictionary<string, AggregationContainer>
+  /** @variant container_property */
+  meta?: Dictionary<string, UserDefinedValue>
+  // Regular container fields. Only one of them can exist at a time.
+  adjacency_matrix?: AdjacencyMatrixAggregation
+  auto_date_histogram?: AutoDateHistogramAggregation
+  avg?: AverageAggregation
+  ...
+```
 ### Additional information
 
 If needed, you can specify additional information on each type with the approariate JSDoc tag.

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -12856,17 +12856,7 @@
       },
       "properties": [
         {
-          "name": "adjacency_matrix",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "AdjacencyMatrixAggregation",
-              "namespace": "__common.aggregations.bucket.adjacency_matrix"
-            }
-          }
-        },
-        {
+          "container_property": true,
           "name": "aggs",
           "required": false,
           "type": {
@@ -12884,6 +12874,35 @@
                 "name": "AggregationContainer",
                 "namespace": "__common.aggregations"
               }
+            }
+          }
+        },
+        {
+          "container_property": true,
+          "name": "meta",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "value": {
+              "kind": "user_defined_value"
+            }
+          }
+        },
+        {
+          "name": "adjacency_matrix",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "AdjacencyMatrixAggregation",
+              "namespace": "__common.aggregations.bucket.adjacency_matrix"
             }
           }
         },
@@ -13294,23 +13313,6 @@
           }
         },
         {
-          "name": "meta",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "value": {
-              "kind": "user_defined_value"
-            }
-          }
-        },
-        {
           "name": "min",
           "required": false,
           "type": {
@@ -13684,7 +13686,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -39527,7 +39532,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "enum",
@@ -71831,7 +71839,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "enum",
@@ -72102,7 +72113,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -85390,17 +85404,6 @@
       },
       "properties": [
         {
-          "name": "can_be_flattened",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "_id",
           "required": true,
           "type": {
@@ -94490,7 +94493,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -96431,50 +96437,6 @@
           }
         },
         {
-          "name": "is_conditionless",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "is_strict",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "is_verbatim",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "is_writable",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "match",
           "required": false,
           "type": {
@@ -97197,7 +97159,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -104152,7 +104117,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -116459,7 +116427,7 @@
       "properties": [
         {
           "name": "laplace",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -116470,7 +116438,7 @@
         },
         {
           "name": "linear_interpolation",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -116481,7 +116449,7 @@
         },
         {
           "name": "stupid_backoff",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -116490,7 +116458,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "attachedBehaviors": [
@@ -122570,7 +122541,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -127704,7 +127678,7 @@
       "properties": [
         {
           "name": "chain",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -127715,7 +127689,7 @@
         },
         {
           "name": "script",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -127726,7 +127700,7 @@
         },
         {
           "name": "search",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -127735,7 +127709,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -128192,7 +128169,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -128597,7 +128577,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -128617,7 +128600,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -113,8 +113,9 @@ export interface AggregationBreakdown {
 }
 
 export interface AggregationContainer {
-  adjacency_matrix?: AdjacencyMatrixAggregation
   aggs?: Record<string, AggregationContainer>
+  meta?: Record<string, any>
+  adjacency_matrix?: AdjacencyMatrixAggregation
   aggregations?: Record<string, AggregationContainer>
   auto_date_histogram?: AutoDateHistogramAggregation
   avg?: AverageAggregation
@@ -151,7 +152,6 @@ export interface AggregationContainer {
   max?: MaxAggregation
   max_bucket?: MaxBucketAggregation
   median_absolute_deviation?: MedianAbsoluteDeviationAggregation
-  meta?: Record<string, any>
   min?: MinAggregation
   min_bucket?: MinBucketAggregation
   missing?: MissingAggregation
@@ -8673,7 +8673,6 @@ export interface MultiGetHit<TDocument = unknown> {
 export type MultiGetId = string | integer
 
 export interface MultiGetOperation {
-  can_be_flattened?: boolean
   _id: MultiGetId
   _index?: IndexName
   routing?: Routing
@@ -9900,10 +9899,6 @@ export interface QueryContainer {
   has_parent?: HasParentQuery
   ids?: IdsQuery
   intervals?: NamedQuery<IntervalsQuery | string>
-  is_conditionless?: boolean
-  is_strict?: boolean
-  is_verbatim?: boolean
-  is_writable?: boolean
   match?: NamedQuery<MatchQuery | string | float | boolean>
   match_all?: MatchAllQuery
   match_bool_prefix?: NamedQuery<MatchBoolPrefixQuery | string>
@@ -12101,9 +12096,9 @@ export interface SlmUsage extends XPackUsage {
 }
 
 export interface SmoothingModelContainer {
-  laplace: LaplaceSmoothingModel
-  linear_interpolation: LinearInterpolationSmoothingModel
-  stupid_backoff: StupidBackoffSmoothingModel
+  laplace?: LaplaceSmoothingModel
+  linear_interpolation?: LinearInterpolationSmoothingModel
+  stupid_backoff?: StupidBackoffSmoothingModel
 }
 
 export interface SnapshotCloneRequest extends RequestBase {
@@ -13317,9 +13312,9 @@ export interface TransformCheckpointingInfo {
 }
 
 export interface TransformContainer {
-  chain: ChainTransform
-  script: ScriptTransform
-  search: SearchTransform
+  chain?: ChainTransform
+  script?: ScriptTransform
+  search?: SearchTransform
 }
 
 export interface TransformDestination {

--- a/specification/__common/aggregations/AggregationContainer.ts
+++ b/specification/__common/aggregations/AggregationContainer.ts
@@ -90,9 +90,16 @@ import { SerialDifferencingAggregation } from './pipeline/serial_differencing/Se
 import { StatsBucketAggregation } from './pipeline/stats_bucket/StatsBucketAggregation'
 import { SumBucketAggregation } from './pipeline/sum_bucket/SumBucketAggregation'
 
+/**
+ * @variants container
+ */
 export class AggregationContainer {
-  adjacency_matrix?: AdjacencyMatrixAggregation
+  /** @variant container_property */
   aggs?: Dictionary<string, AggregationContainer>
+  /** @variant container_property */
+  meta?: Dictionary<string, UserDefinedValue>
+
+  adjacency_matrix?: AdjacencyMatrixAggregation
   aggregations?: Dictionary<string, AggregationContainer>
   auto_date_histogram?: AutoDateHistogramAggregation
   avg?: AverageAggregation
@@ -129,7 +136,6 @@ export class AggregationContainer {
   max?: MaxAggregation
   max_bucket?: MaxBucketAggregation
   median_absolute_deviation?: MedianAbsoluteDeviationAggregation
-  meta?: Dictionary<string, UserDefinedValue>
   min?: MinAggregation
   min_bucket?: MinBucketAggregation
   missing?: MissingAggregation

--- a/specification/__common/query_dsl/abstractions/container/QueryContainer.ts
+++ b/specification/__common/query_dsl/abstractions/container/QueryContainer.ts
@@ -74,6 +74,9 @@ import { SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { NamedQuery } from '../query/Query'
 import { QueryTemplate } from './QueryTemplate'
 
+/**
+ * @variants container
+ */
 export class QueryContainer {
   bool?: BoolQuery
   boosting?: BoostingQuery
@@ -96,10 +99,6 @@ export class QueryContainer {
   has_parent?: HasParentQuery
   ids?: IdsQuery
   intervals?: NamedQuery<IntervalsQuery | string>
-  is_conditionless?: boolean
-  is_strict?: boolean
-  is_verbatim?: boolean
-  is_writable?: boolean
   match?: NamedQuery<MatchQuery | string | float | boolean>
   match_all?: MatchAllQuery
   match_bool_prefix?: NamedQuery<MatchBoolPrefixQuery | string>

--- a/specification/__common/query_dsl/full_text/intervals/IntervalsContainer.ts
+++ b/specification/__common/query_dsl/full_text/intervals/IntervalsContainer.ts
@@ -24,6 +24,9 @@ import { IntervalsMatch } from './IntervalsMatch'
 import { IntervalsPrefix } from './IntervalsPrefix'
 import { IntervalsWildcard } from './IntervalsWildcard'
 
+/**
+ * @variants container
+ */
 export class IntervalsContainer {
   all_of?: IntervalsAllOf
   any_of?: IntervalsAnyOf

--- a/specification/__common/watcher/conditions/ConditionContainer.ts
+++ b/specification/__common/watcher/conditions/ConditionContainer.ts
@@ -23,6 +23,9 @@ import { CompareCondition } from './CompareCondition'
 import { NeverCondition } from './NeverCondition'
 import { ScriptCondition } from './ScriptCondition'
 
+/**
+ * @variants container
+ */
 export class ConditionContainer {
   always?: AlwaysCondition
   array_compare?: ArrayCompareCondition

--- a/specification/__common/watcher/input/InputContainer.ts
+++ b/specification/__common/watcher/input/InputContainer.ts
@@ -22,6 +22,9 @@ import { HttpInput } from './HttpInput'
 import { SearchInput } from './SearchInput'
 import { SimpleInput } from './SimpleInput'
 
+/**
+ * @variants container
+ */
 export class InputContainer {
   chain?: ChainInput
   http?: HttpInput

--- a/specification/__common/watcher/schedule/ScheduleContainer.ts
+++ b/specification/__common/watcher/schedule/ScheduleContainer.ts
@@ -25,6 +25,9 @@ import { TimeOfMonth } from './TimeOfMonth'
 import { TimeOfWeek } from './TimeOfWeek'
 import { TimeOfYear } from './TimeOfYear'
 
+/**
+ * @variants container
+ */
 export class ScheduleContainer {
   cron?: CronExpression
   daily?: DailySchedule

--- a/specification/__common/watcher/transform/TransformContainer.ts
+++ b/specification/__common/watcher/transform/TransformContainer.ts
@@ -21,8 +21,11 @@ import { ChainTransform } from './ChainTransform'
 import { ScriptTransform } from './ScriptTransform'
 import { SearchTransform } from './SearchTransform'
 
+/**
+ * @variants container
+ */
 export class TransformContainer {
-  chain: ChainTransform
-  script: ScriptTransform
-  search: SearchTransform
+  chain?: ChainTransform
+  script?: ScriptTransform
+  search?: SearchTransform
 }

--- a/specification/__common/watcher/trigger/TriggerContainer.ts
+++ b/specification/__common/watcher/trigger/TriggerContainer.ts
@@ -19,6 +19,9 @@
 
 import { ScheduleContainer } from '../schedule/ScheduleContainer'
 
+/**
+ * @variants container
+ */
 export class TriggerContainer {
   schedule: ScheduleContainer
 }

--- a/specification/__common/watcher/trigger/TriggerEventContainer.ts
+++ b/specification/__common/watcher/trigger/TriggerEventContainer.ts
@@ -19,6 +19,9 @@
 
 import { ScheduleTriggerEvent } from '../schedule/ScheduleTriggerEvent'
 
+/**
+ * @variants container
+ */
 export class TriggerEventContainer {
   schedule: ScheduleTriggerEvent
 }

--- a/specification/__global/mget/MultiGetRequest.ts
+++ b/specification/__global/mget/MultiGetRequest.ts
@@ -58,7 +58,6 @@ export interface MultiGetRequest extends RequestBase {
 }
 
 export class MultiGetOperation {
-  can_be_flattened?: boolean
   _id: MultiGetId
   _index?: IndexName
   routing?: Routing

--- a/specification/__global/search/suggesters/SuggestContainer.ts
+++ b/specification/__global/search/suggesters/SuggestContainer.ts
@@ -21,6 +21,9 @@ import { CompletionSuggester } from './completion_suggester/CompletionSuggester'
 import { PhraseSuggester } from './phrase_suggester/PhraseSuggester'
 import { TermSuggester } from './term_suggester/TermSuggester'
 
+/**
+ * @variants container
+ */
 export class SuggestContainer {
   completion?: CompletionSuggester
   phrase?: PhraseSuggester

--- a/specification/__global/search/suggesters/phrase_suggester/smoothing_model/SmoothingModelContainer.ts
+++ b/specification/__global/search/suggesters/phrase_suggester/smoothing_model/SmoothingModelContainer.ts
@@ -21,8 +21,11 @@ import { LaplaceSmoothingModel } from './LaplaceSmoothingModel'
 import { LinearInterpolationSmoothingModel } from './LinearInterpolationSmoothingModel'
 import { StupidBackoffSmoothingModel } from './StupidBackoffSmoothingModel'
 
+/**
+ * @variants container
+ */
 export class SmoothingModelContainer {
-  laplace: LaplaceSmoothingModel
-  linear_interpolation: LinearInterpolationSmoothingModel
-  stupid_backoff: StupidBackoffSmoothingModel
+  laplace?: LaplaceSmoothingModel
+  linear_interpolation?: LinearInterpolationSmoothingModel
+  stupid_backoff?: StupidBackoffSmoothingModel
 }

--- a/specification/ingest/ProcessorContainer.ts
+++ b/specification/ingest/ProcessorContainer.ts
@@ -52,6 +52,9 @@ import { TrimProcessor } from './processors/TrimProcessor'
 import { UppercaseProcessor } from './processors/UppercaseProcessor'
 import { UrlDecodeProcessor } from './processors/UrlDecodeProcessor'
 
+/**
+ * @variants container
+ */
 export class ProcessorContainer {
   attachment?: AttachmentProcessor
   append?: AppendProcessor

--- a/specification/transform/TransformSyncContainer.ts
+++ b/specification/transform/TransformSyncContainer.ts
@@ -19,6 +19,9 @@
 
 import { TransformTimeSync } from './TransformTimeSync'
 
+/**
+ * @variants container
+ */
 export class TransformSyncContainer {
   time: TransformTimeSync
 }


### PR DESCRIPTION
Backport of #333 with additional validations and fewer spec changes.

This adds `variants` tags to polymorphic types (container classes and variant unions) and additional related model validations.

The `Aggregate` container class has been left out for now as it requires extensive refactoring, which will be done in a separate PR.

A new annotation is introduced for properties, `@variant container_property` to identify properties that belong to the container and aren't part of the variants. This is the case of `aggs` and `meta` on aggregations.

This PR also includes a "json ambiguity check" in the model validation, that verifies that the json structure of the model can be analyzed unambiguously with a streaming JSON parser, which is what strongly typed languages generally use to avoid creating an intermediate in-memory JSON AST.

This validation is currently disabled as polymorphic unions cause a lot of errors, which will go away once they are modelled and tagged correctly.