### PR TITLE
Only output one validation message for "todo" endpoints, fix non-todo endpoints

### DIFF
--- a/compiler/compiler.ts
+++ b/compiler/compiler.ts
@@ -20,8 +20,8 @@
 import { writeFile } from 'fs/promises'
 import { join } from 'path'
 import stringify from 'safe-stable-stringify'
-import { Model } from './model/metamodel'
-import { compileSpecification, compileEndpoints } from './model/build-model'
+import { Model, Stability } from './model/metamodel'
+import { compileEndpoints, compileSpecification } from './model/build-model'
 import buildJsonSpec, { JsonSpec } from './model/json-spec'
 import { ValidationErrors } from './validation-errors'
 
@@ -64,7 +64,9 @@ export default class Compiler {
       'utf8'
     )
 
-    this.errors.cleanup()
+    this.errors.cleanup(
+      this.model.endpoints.filter(e => e.stability === Stability.TODO).map(e => e.name)
+    )
     this.errors.log()
 
     await writeFile(

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -492,9 +492,7 @@ export function hoistRequestAnnotations (
       }
       endpoint.visibility = model.Visibility[value]
     } else if (tag === 'stability') {
-      // still need to follow up on this in a new PR
-      if (value === 'TODO') return
-      if (endpoint.stability !== null && endpoint.stability !== undefined) {
+      if (value !== 'TODO' && endpoint.stability !== null && endpoint.stability !== undefined) {
         assert(jsDocs, endpoint.stability === value,
           `Request ${request.name.name} stability on annotation ${value} does not match spec: ${endpoint.stability ?? ''}`)
       }

--- a/compiler/validation-errors.ts
+++ b/compiler/validation-errors.ts
@@ -49,21 +49,27 @@ export class ValidationErrors {
     this.generalErrors.push(message)
   }
 
-  /** Remove all endpoint records that have no associated errors */
-  cleanup (): void {
-    for (const [name, errors] of Object.entries(this.endpointErrors)) {
-      if (errors.request.length === 0 || errors.response.length === 0) {
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete this.endpointErrors[name]
+  /** Replace multiple errors for endpoints in the "TODO" state by a single one, to avoid clogging up the report */
+  cleanup (todoEndpoints: string[]): void {
+    const names = new Set<string>(todoEndpoints)
+
+    for (const name of Object.keys(this.endpointErrors)) {
+      if (names.has(name)) {
+        this.endpointErrors[name] = {
+          request: ['Endpoint has "@stability: TODO'],
+          response: []
+        }
       }
     }
   }
 
   /** Output this error log to the console */
   log (): void {
+    let count = 0
     const logArray = function (errs: string[], prefix = ''): void {
       for (const err of errs) {
         console.error(`${prefix}${err}`)
+        count++
       }
     }
 
@@ -78,5 +84,7 @@ export class ValidationErrors {
         }
       }
     }
+
+    console.error(`${count} errors found.`)
   }
 }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -25,7 +25,7 @@
         "namespace": "async_search.delete"
       },
       "since": "7.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -53,7 +53,7 @@
         "namespace": "async_search.get"
       },
       "since": "7.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -81,7 +81,7 @@
         "namespace": "async_search.status"
       },
       "since": "7.11.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -112,7 +112,7 @@
         "namespace": "async_search.submit"
       },
       "since": "7.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -146,7 +146,7 @@
         "namespace": "autoscaling.policy_delete"
       },
       "since": "7.11.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -174,7 +174,7 @@
         "namespace": "autoscaling.capacity_get"
       },
       "since": "7.11.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -202,7 +202,7 @@
         "namespace": "autoscaling.policy_get"
       },
       "since": "7.11.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -233,7 +233,7 @@
         "namespace": "autoscaling.policy_put"
       },
       "since": "7.11.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -308,7 +308,7 @@
         "namespace": "cat.cat_aliases"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -343,7 +343,7 @@
         "namespace": "cat.cat_allocation"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -378,7 +378,7 @@
         "namespace": "cat.cat_count"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -413,7 +413,7 @@
         "namespace": "cat.cat_fielddata"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -448,7 +448,7 @@
         "namespace": "cat.cat_health"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -476,7 +476,7 @@
         "namespace": "cat.cat_help"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -505,7 +505,7 @@
         "namespace": "cat.cat_indices"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -540,7 +540,7 @@
         "namespace": "cat.cat_master"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -569,7 +569,7 @@
         "namespace": "cat.cat_data_frame_analytics"
       },
       "since": "7.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -604,7 +604,7 @@
         "namespace": "cat.cat_datafeeds"
       },
       "since": "7.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -639,7 +639,7 @@
         "namespace": "cat.cat_jobs"
       },
       "since": "7.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -674,7 +674,7 @@
         "namespace": "cat.cat_trained_models"
       },
       "since": "7.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -709,7 +709,7 @@
         "namespace": "cat.cat_node_attributes"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -738,7 +738,7 @@
         "namespace": "cat.cat_nodes"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -767,7 +767,7 @@
         "namespace": "cat.cat_pending_tasks"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -796,7 +796,7 @@
         "namespace": "cat.cat_plugins"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -825,7 +825,7 @@
         "namespace": "cat.cat_recovery"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -860,7 +860,7 @@
         "namespace": "cat.cat_repositories"
       },
       "since": "2.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -889,7 +889,7 @@
         "namespace": "cat.cat_segments"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -924,7 +924,7 @@
         "namespace": "cat.cat_shards"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -959,7 +959,7 @@
         "namespace": "cat.cat_snapshots"
       },
       "since": "2.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -994,7 +994,7 @@
         "namespace": "cat.cat_tasks"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1023,7 +1023,7 @@
         "namespace": "cat.cat_templates"
       },
       "since": "5.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1058,7 +1058,7 @@
         "namespace": "cat.cat_thread_pool"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1093,7 +1093,7 @@
         "namespace": "cat.cat_transforms"
       },
       "since": "7.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1127,7 +1127,7 @@
         "namespace": "ccr.delete_auto_follow_pattern"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1158,7 +1158,7 @@
         "namespace": "ccr.create_follow_index"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1186,7 +1186,7 @@
         "namespace": "ccr.follow_info"
       },
       "since": "6.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1214,7 +1214,7 @@
         "namespace": "ccr.follow_index_stats"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1245,7 +1245,7 @@
         "namespace": "ccr.forget_follower_index"
       },
       "since": "6.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1273,7 +1273,7 @@
         "namespace": "ccr.get_auto_follow_pattern"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1307,7 +1307,7 @@
         "namespace": "ccr.pause_auto_follow_pattern"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1335,7 +1335,7 @@
         "namespace": "ccr.pause_follow_index"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1366,7 +1366,7 @@
         "namespace": "ccr.put_auto_follow_pattern"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1394,7 +1394,7 @@
         "namespace": "ccr.resume_auto_follow_pattern"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1425,7 +1425,7 @@
         "namespace": "ccr.resume_follow_index"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1453,7 +1453,7 @@
         "namespace": "ccr.stats"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1481,7 +1481,7 @@
         "namespace": "ccr.unfollow_index"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1513,7 +1513,7 @@
         "namespace": "__global.clear_scroll"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1551,7 +1551,7 @@
         "namespace": "__global.close_point_in_time"
       },
       "since": "7.10.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1582,7 +1582,7 @@
         "namespace": "cluster.cluster_allocation_explain"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1611,7 +1611,7 @@
         "namespace": "cluster.cluster_delete_component_template"
       },
       "since": "7.8.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1639,7 +1639,7 @@
         "namespace": "cluster.cluster_delete_voting_config_exclusions"
       },
       "since": "7.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1667,7 +1667,7 @@
         "namespace": "cluster.cluster_exists_component_template"
       },
       "since": "7.8.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1695,7 +1695,7 @@
         "namespace": "cluster.cluster_get_component_template"
       },
       "since": "7.8.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1729,7 +1729,7 @@
         "namespace": "cluster.cluster_get_settings"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1757,7 +1757,7 @@
         "namespace": "cluster.cluster_health"
       },
       "since": "1.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1791,7 +1791,7 @@
         "namespace": "cluster.cluster_pending_tasks"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1819,7 +1819,7 @@
         "namespace": "cluster.cluster_put_voting_config_exclusions"
       },
       "since": "7.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1850,7 +1850,7 @@
         "namespace": "cluster.cluster_put_component_template"
       },
       "since": "7.8.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1882,7 +1882,7 @@
         "namespace": "cluster.cluster_put_settings"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1910,7 +1910,7 @@
         "namespace": "cluster.cluster_remote_info"
       },
       "since": "6.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1941,7 +1941,7 @@
         "namespace": "cluster.cluster_reroute"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -1969,7 +1969,7 @@
         "namespace": "cluster.cluster_state"
       },
       "since": "1.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2009,7 +2009,7 @@
         "namespace": "cluster.cluster_stats"
       },
       "since": "1.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2046,7 +2046,7 @@
         "namespace": "__global.count"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2136,7 +2136,7 @@
         "namespace": "dangling_indices.index_delete"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2164,7 +2164,7 @@
         "namespace": "dangling_indices.index_import"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2192,7 +2192,7 @@
         "namespace": "dangling_indices.indices_list"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2439,7 +2439,7 @@
         "namespace": "__global.delete"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2480,7 +2480,7 @@
         "namespace": "__global.delete_by_query"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2518,7 +2518,7 @@
         "namespace": "__global.delete_by_query_rethrottle"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2546,7 +2546,7 @@
         "namespace": "__global.delete_script"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2574,7 +2574,7 @@
         "namespace": "enrich.delete_policy"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2602,7 +2602,7 @@
         "namespace": "enrich.execute_policy"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2630,7 +2630,7 @@
         "namespace": "enrich.get_policy"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2667,7 +2667,7 @@
         "namespace": "enrich.put_policy"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2695,7 +2695,7 @@
         "namespace": "enrich.stats"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2723,7 +2723,7 @@
         "namespace": "eql.delete"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2751,7 +2751,7 @@
         "namespace": "eql.get"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2779,7 +2779,7 @@
         "namespace": "eql.get_status"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2810,7 +2810,7 @@
         "namespace": "eql.search"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2839,7 +2839,7 @@
         "namespace": "__global.exists"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2877,7 +2877,7 @@
         "namespace": "__global.exists_source"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2918,7 +2918,7 @@
         "namespace": "__global.explain"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -2958,7 +2958,7 @@
         "namespace": "features.get_features"
       },
       "since": "7.12.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3007,7 +3007,7 @@
         "namespace": "__global.field_caps"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3043,7 +3043,7 @@
         "namespace": "__global.get"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3081,7 +3081,7 @@
         "namespace": "__global.get_script"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3109,7 +3109,7 @@
         "namespace": "__global.get_script_context"
       },
       "since": "0.0.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3137,7 +3137,7 @@
         "namespace": "__global.get_script_languages"
       },
       "since": "0.0.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3165,7 +3165,7 @@
         "namespace": "__global.get_source"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3206,7 +3206,7 @@
         "namespace": "graph.explore"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3246,7 +3246,7 @@
         "namespace": "ilm.delete_lifecycle"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3274,7 +3274,7 @@
         "namespace": "ilm.explain_lifecycle"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3302,7 +3302,7 @@
         "namespace": "ilm.get_lifecycle"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3336,7 +3336,7 @@
         "namespace": "ilm.get_status"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3367,7 +3367,7 @@
         "namespace": "ilm.move_to_step"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3398,7 +3398,7 @@
         "namespace": "ilm.put_lifecycle"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3426,7 +3426,7 @@
         "namespace": "ilm.remove_policy"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3454,7 +3454,7 @@
         "namespace": "ilm.retry"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3482,7 +3482,7 @@
         "namespace": "ilm.start"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3510,7 +3510,7 @@
         "namespace": "ilm.stop"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3597,7 +3597,7 @@
         "namespace": "indices.add_block"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3628,7 +3628,7 @@
         "namespace": "indices.analyze"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3664,7 +3664,7 @@
         "namespace": "indices.clear_cache"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3701,7 +3701,7 @@
         "namespace": "indices.clone"
       },
       "since": "7.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3730,7 +3730,7 @@
         "namespace": "indices.close"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3761,7 +3761,7 @@
         "namespace": "indices.create"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3789,7 +3789,7 @@
         "namespace": "indices.create_data_stream"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3817,7 +3817,7 @@
         "namespace": "indices.data_streams_stats"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3851,7 +3851,7 @@
         "namespace": "indices.delete"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3879,7 +3879,7 @@
         "namespace": "indices.delete_alias"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3913,7 +3913,7 @@
         "namespace": "indices.delete_data_stream"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3962,7 +3962,7 @@
         "namespace": "indices.delete_template"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -3990,7 +3990,7 @@
         "namespace": "indices.exists"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4018,7 +4018,7 @@
         "namespace": "indices.exists_alias"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4073,7 +4073,7 @@
         "namespace": "indices.exists_template"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4101,7 +4101,7 @@
         "namespace": "indices.exists_type"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4129,7 +4129,7 @@
         "namespace": "indices.flush"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4165,7 +4165,7 @@
         "namespace": "indices.flush_synced"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "deprecation": {
@@ -4209,7 +4209,7 @@
         "namespace": "indices.forcemerge"
       },
       "since": "2.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4243,7 +4243,7 @@
         "namespace": "indices.freeze"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4271,7 +4271,7 @@
         "namespace": "indices.get"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4299,7 +4299,7 @@
         "namespace": "indices.get_alias"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4345,7 +4345,7 @@
         "namespace": "indices.get_data_stream"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4379,7 +4379,7 @@
         "namespace": "indices.get_field_mapping"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4460,7 +4460,7 @@
         "namespace": "indices.get_mapping"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4514,7 +4514,7 @@
         "namespace": "indices.get_settings"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4560,7 +4560,7 @@
         "namespace": "indices.get_template"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4629,7 +4629,7 @@
         "namespace": "indices.migrate_to_data_stream"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4657,7 +4657,7 @@
         "namespace": "indices.open"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4685,7 +4685,7 @@
         "namespace": "indices.promote_data_stream"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4716,7 +4716,7 @@
         "namespace": "indices.put_alias"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4780,7 +4780,7 @@
         "namespace": "indices.put_mapping"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4889,7 +4889,7 @@
         "namespace": "indices.put_settings"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4926,7 +4926,7 @@
         "namespace": "indices.put_template"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4955,7 +4955,7 @@
         "namespace": "indices.recovery"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -4989,7 +4989,7 @@
         "namespace": "indices.refresh"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5025,7 +5025,7 @@
         "namespace": "indices.reload_search_analyzers"
       },
       "since": "7.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5054,7 +5054,7 @@
         "namespace": "indices.resolve_index"
       },
       "since": "7.9.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5085,7 +5085,7 @@
         "namespace": "indices.rollover"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5119,7 +5119,7 @@
         "namespace": "indices.segments"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5153,7 +5153,7 @@
         "namespace": "indices.shard_stores"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5190,7 +5190,7 @@
         "namespace": "indices.shrink"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5276,7 +5276,7 @@
         "namespace": "indices.split"
       },
       "since": "6.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5305,7 +5305,7 @@
         "namespace": "indices.stats"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5351,7 +5351,7 @@
         "namespace": "indices.unfreeze"
       },
       "since": "6.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5382,7 +5382,7 @@
         "namespace": "indices.update_aliases"
       },
       "since": "1.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5410,7 +5410,7 @@
         "namespace": "indices.upgrade"
       },
       "since": "7.13.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "deprecation": {
@@ -5455,7 +5455,7 @@
         "namespace": "indices.validate_query"
       },
       "since": "1.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5502,7 +5502,7 @@
         "namespace": "__global.info"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5530,7 +5530,7 @@
         "namespace": "ingest.delete_pipeline"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5558,7 +5558,7 @@
         "namespace": "ingest.geo_ip_stats"
       },
       "since": "7.13.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5620,7 +5620,7 @@
         "namespace": "ingest.processor"
       },
       "since": "6.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5651,7 +5651,7 @@
         "namespace": "ingest.put_pipeline"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5682,7 +5682,7 @@
         "namespace": "ingest.simulate_pipeline"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5718,7 +5718,7 @@
         "namespace": "license.delete_license"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5746,7 +5746,7 @@
         "namespace": "license.get_license"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5774,7 +5774,7 @@
         "namespace": "license.get_basic_license_status"
       },
       "since": "6.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5802,7 +5802,7 @@
         "namespace": "license.get_trial_license_status"
       },
       "since": "6.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5833,7 +5833,7 @@
         "namespace": "license.post_license"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5862,7 +5862,7 @@
         "namespace": "license.start_basic_license"
       },
       "since": "6.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5890,7 +5890,7 @@
         "namespace": "license.start_trial_license"
       },
       "since": "6.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5918,7 +5918,7 @@
         "namespace": "logstash.pipeline_delete"
       },
       "since": "7.12.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5946,7 +5946,7 @@
         "namespace": "logstash.pipeline_get"
       },
       "since": "7.12.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -5977,7 +5977,7 @@
         "namespace": "logstash.pipeline_put"
       },
       "since": "7.12.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6055,7 +6055,7 @@
         "namespace": "migration.deprecation_info"
       },
       "since": "6.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6092,7 +6092,7 @@
         "namespace": "ml.close_job"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6120,7 +6120,7 @@
         "namespace": "ml.delete_calendar"
       },
       "since": "6.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6148,7 +6148,7 @@
         "namespace": "ml.delete_calendar_event"
       },
       "since": "6.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6176,7 +6176,7 @@
         "namespace": "ml.delete_calendar_job"
       },
       "since": "6.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6204,7 +6204,7 @@
         "namespace": "ml.delete_data_frame_analytics"
       },
       "since": "7.3.0",
-      "stability": "beta",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6232,7 +6232,7 @@
         "namespace": "ml.delete_datafeed"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6260,7 +6260,7 @@
         "namespace": "ml.delete_expired_data"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6294,7 +6294,7 @@
         "namespace": "ml.delete_filter"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6322,7 +6322,7 @@
         "namespace": "ml.delete_forecast"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6356,7 +6356,7 @@
         "namespace": "ml.delete_job"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6384,7 +6384,7 @@
         "namespace": "ml.delete_model_snapshot"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6412,7 +6412,7 @@
         "namespace": "ml.delete_trained_model"
       },
       "since": "7.10.0",
-      "stability": "beta",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6443,7 +6443,7 @@
         "namespace": "ml.delete_trained_model_alias"
       },
       "since": "7.13.0",
-      "stability": "beta",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6474,7 +6474,7 @@
         "namespace": "ml.estimate_model_memory"
       },
       "since": "7.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6589,7 +6589,7 @@
         "namespace": "ml.flush_job"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6617,7 +6617,7 @@
         "namespace": "ml.forecast_job"
       },
       "since": "6.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6648,7 +6648,7 @@
         "namespace": "ml.get_buckets"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6684,7 +6684,7 @@
         "namespace": "ml.get_calendar_events"
       },
       "since": "6.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6715,7 +6715,7 @@
         "namespace": "ml.get_calendars"
       },
       "since": "6.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6754,7 +6754,7 @@
         "namespace": "ml.get_categories"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6844,7 +6844,7 @@
         "namespace": "ml.get_datafeed_stats"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6878,7 +6878,7 @@
         "namespace": "ml.get_datafeeds"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6912,7 +6912,7 @@
         "namespace": "ml.get_filters"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6949,7 +6949,7 @@
         "namespace": "ml.get_influencers"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -6978,7 +6978,7 @@
         "namespace": "ml.get_job_stats"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7012,7 +7012,7 @@
         "namespace": "ml.get_jobs"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7049,7 +7049,7 @@
         "namespace": "ml.get_model_snapshots"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7088,7 +7088,7 @@
         "namespace": "ml.get_overall_buckets"
       },
       "since": "6.1.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7120,7 +7120,7 @@
         "namespace": "ml.get_anomaly_records"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7200,7 +7200,7 @@
       "requestBodyRequired": false,
       "response": null,
       "since": "6.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7228,7 +7228,7 @@
         "namespace": "ml.open_job"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7259,7 +7259,7 @@
         "namespace": "ml.post_calendar_events"
       },
       "since": "6.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7291,7 +7291,7 @@
         "namespace": "ml.post_job_data"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7351,7 +7351,7 @@
         "namespace": "ml.preview_datafeed"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7390,7 +7390,7 @@
         "namespace": "ml.put_calendar"
       },
       "since": "6.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7418,7 +7418,7 @@
         "namespace": "ml.put_calendar_job"
       },
       "since": "6.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7473,7 +7473,7 @@
         "namespace": "ml.put_datafeed"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7504,7 +7504,7 @@
         "namespace": "ml.put_filter"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7535,7 +7535,7 @@
         "namespace": "ml.put_job"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7614,7 +7614,7 @@
         "namespace": "ml.revert_model_snapshot"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7642,7 +7642,7 @@
         "namespace": "ml.set_upgrade_mode"
       },
       "since": "6.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7697,7 +7697,7 @@
         "namespace": "ml.start_datafeed"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7728,7 +7728,7 @@
         "namespace": "ml.stop_data_frame_analytics"
       },
       "since": "7.3.0",
-      "stability": "beta",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7756,7 +7756,7 @@
         "namespace": "ml.stop_datafeed"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7811,7 +7811,7 @@
         "namespace": "ml.update_data_feed"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7842,7 +7842,7 @@
         "namespace": "ml.update_filter"
       },
       "since": "6.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7873,7 +7873,7 @@
         "namespace": "ml.update_job"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7904,7 +7904,7 @@
         "namespace": "ml.update_model_snapshot"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7956,7 +7956,7 @@
         "namespace": "ml.validate_job"
       },
       "since": "6.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -7987,7 +7987,7 @@
         "namespace": "ml.validate_detector"
       },
       "since": "5.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8018,7 +8018,7 @@
         "namespace": "monitoring.bulk"
       },
       "since": "6.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8061,7 +8061,7 @@
         "namespace": "__global.msearch"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8111,7 +8111,7 @@
         "namespace": "__global.msearch_template"
       },
       "since": "5.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8161,7 +8161,7 @@
         "namespace": "__global.mtermvectors"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8208,7 +8208,7 @@
         "namespace": "nodes.nodes_hot_threads"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8302,7 +8302,7 @@
         "namespace": "nodes.nodes_info"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8351,7 +8351,7 @@
         "namespace": "nodes.reload_secure_settings"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8385,7 +8385,7 @@
         "namespace": "nodes.nodes_stats"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8443,7 +8443,7 @@
         "namespace": "nodes.nodes_usage"
       },
       "since": "6.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8489,7 +8489,7 @@
         "namespace": "__global.open_point_in_time"
       },
       "since": "7.10.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8523,7 +8523,7 @@
         "namespace": "__global.ping"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8554,7 +8554,7 @@
         "namespace": "__global.put_script"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8593,7 +8593,7 @@
         "namespace": "__global.rank_eval"
       },
       "since": "6.2.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8632,7 +8632,7 @@
         "namespace": "__global.reindex"
       },
       "since": "2.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8660,7 +8660,7 @@
         "namespace": "__global.reindex_rethrottle"
       },
       "since": "2.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8691,7 +8691,7 @@
         "namespace": "__global.render_search_template"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8727,7 +8727,7 @@
         "namespace": "rollup.delete_rollup_job"
       },
       "since": "6.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8755,7 +8755,7 @@
         "namespace": "rollup.get_rollup_job"
       },
       "since": "6.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8789,7 +8789,7 @@
         "namespace": "rollup.get_rollup_capabilities"
       },
       "since": "6.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8823,7 +8823,7 @@
         "namespace": "rollup.get_rollup_index_capabilities"
       },
       "since": "6.4.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8854,7 +8854,7 @@
         "namespace": "rollup.create_rollup_job"
       },
       "since": "6.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8885,7 +8885,7 @@
         "namespace": "rollup.rollup"
       },
       "since": "7.13.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8916,7 +8916,7 @@
         "namespace": "rollup.rollup_search"
       },
       "since": "6.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8956,7 +8956,7 @@
         "namespace": "rollup.start_rollup_job"
       },
       "since": "6.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -8984,7 +8984,7 @@
         "namespace": "rollup.stop_rollup_job"
       },
       "since": "6.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9015,7 +9015,7 @@
         "namespace": "__global.scripts_painless_execute"
       },
       "since": "6.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9047,7 +9047,7 @@
         "namespace": "__global.scroll"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9090,7 +9090,7 @@
         "namespace": "__global.search"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9137,7 +9137,7 @@
         "namespace": "__global.search_shards"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9176,7 +9176,7 @@
         "namespace": "__global.search_template"
       },
       "since": "2.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9223,7 +9223,7 @@
         "namespace": "searchable_snapshots.clear_cache"
       },
       "since": "7.10.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9260,7 +9260,7 @@
         "namespace": "searchable_snapshots.mount"
       },
       "since": "7.10.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9288,7 +9288,7 @@
         "namespace": "searchable_snapshots.repository_stats"
       },
       "since": "7.10.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9316,7 +9316,7 @@
         "namespace": "searchable_snapshots.stats"
       },
       "since": "7.10.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9350,7 +9350,7 @@
         "namespace": "security.authenticate"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9381,7 +9381,7 @@
         "namespace": "security.change_password"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9417,7 +9417,7 @@
         "namespace": "security.clear_api_key_cache"
       },
       "since": "7.10.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9445,7 +9445,7 @@
         "namespace": "security.clear_cached_privileges"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9473,7 +9473,7 @@
         "namespace": "security.clear_cached_realms"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9501,7 +9501,7 @@
         "namespace": "security.clear_cached_roles"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9532,7 +9532,7 @@
         "namespace": "security.create_api_key"
       },
       "since": "6.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9561,7 +9561,7 @@
         "namespace": "security.delete_privileges"
       },
       "since": "6.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9589,7 +9589,7 @@
         "namespace": "security.delete_role"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9617,7 +9617,7 @@
         "namespace": "security.delete_role_mapping"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9645,7 +9645,7 @@
         "namespace": "security.delete_user"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9673,7 +9673,7 @@
         "namespace": "security.disable_user"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9702,7 +9702,7 @@
         "namespace": "security.enable_user"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9731,7 +9731,7 @@
         "namespace": "security.get_api_key"
       },
       "since": "6.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9759,7 +9759,7 @@
         "namespace": "security.get_builtin_privileges"
       },
       "since": "7.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9787,7 +9787,7 @@
         "namespace": "security.get_privileges"
       },
       "since": "6.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9827,7 +9827,7 @@
         "namespace": "security.get_role"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9861,7 +9861,7 @@
         "namespace": "security.get_role_mapping"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9898,7 +9898,7 @@
         "namespace": "security.get_token"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9926,7 +9926,7 @@
         "namespace": "security.get_user"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9960,7 +9960,7 @@
         "namespace": "security.get_user_privileges"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -9991,7 +9991,7 @@
         "namespace": "security.grant_api_key"
       },
       "since": "7.9.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10022,7 +10022,7 @@
         "namespace": "security.has_privileges"
       },
       "since": "6.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10061,7 +10061,7 @@
         "namespace": "security.invalidate_api_key"
       },
       "since": "6.7.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10092,7 +10092,7 @@
         "namespace": "security.invalidate_token"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10123,7 +10123,7 @@
         "namespace": "security.put_privileges"
       },
       "since": "6.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10155,7 +10155,7 @@
         "namespace": "security.put_role"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10187,7 +10187,7 @@
         "namespace": "security.put_role_mapping"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10219,7 +10219,7 @@
         "namespace": "security.put_user"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10251,7 +10251,7 @@
         "namespace": "shutdown.delete_node"
       },
       "since": "7.13.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10282,7 +10282,7 @@
         "namespace": "shutdown.get_node"
       },
       "since": "7.13.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10319,7 +10319,7 @@
         "namespace": "shutdown.put_node"
       },
       "since": "7.13.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10347,7 +10347,7 @@
         "namespace": "slm.delete_lifecycle"
       },
       "since": "7.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10375,7 +10375,7 @@
         "namespace": "slm.execute_lifecycle"
       },
       "since": "7.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10403,7 +10403,7 @@
         "namespace": "slm.execute_retention"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10431,7 +10431,7 @@
         "namespace": "slm.get_lifecycle"
       },
       "since": "7.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10465,7 +10465,7 @@
         "namespace": "slm.get_stats"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10493,7 +10493,7 @@
         "namespace": "slm.get_status"
       },
       "since": "7.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10524,7 +10524,7 @@
         "namespace": "slm.put_lifecycle"
       },
       "since": "7.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10552,7 +10552,7 @@
         "namespace": "slm.start"
       },
       "since": "7.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10580,7 +10580,7 @@
         "namespace": "slm.stop"
       },
       "since": "7.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10608,7 +10608,7 @@
         "namespace": "snapshot.cleanup_repository"
       },
       "since": "7.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10639,7 +10639,7 @@
         "namespace": "snapshot.clone"
       },
       "since": "7.10.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10670,7 +10670,7 @@
         "namespace": "snapshot.create"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10702,7 +10702,7 @@
         "namespace": "snapshot.create_repository"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10731,7 +10731,7 @@
         "namespace": "snapshot.delete"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10759,7 +10759,7 @@
         "namespace": "snapshot.delete_repository"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10787,7 +10787,7 @@
         "namespace": "snapshot.get"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10815,7 +10815,7 @@
         "namespace": "snapshot.get_repository"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10852,7 +10852,7 @@
         "namespace": "snapshot.restore"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10880,7 +10880,7 @@
         "namespace": "snapshot.status"
       },
       "since": "7.8.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10920,7 +10920,7 @@
         "namespace": "snapshot.verify_repository"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10951,7 +10951,7 @@
         "namespace": "sql.clear_sql_cursor"
       },
       "since": "6.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -10982,7 +10982,7 @@
         "namespace": "sql.query_sql"
       },
       "since": "6.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11014,7 +11014,7 @@
         "namespace": "sql.translate_sql"
       },
       "since": "6.3.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11043,7 +11043,7 @@
         "namespace": "ssl.get_certificates"
       },
       "since": "6.2.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11071,7 +11071,7 @@
         "namespace": "task.cancel_tasks"
       },
       "since": "2.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11105,7 +11105,7 @@
         "namespace": "task.get_task"
       },
       "since": "5.0.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11133,7 +11133,7 @@
         "namespace": "task.list_tasks"
       },
       "since": "2.3.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11164,7 +11164,7 @@
         "namespace": "__global.termvectors"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11225,7 +11225,7 @@
         "namespace": "text_structure.find_structure"
       },
       "since": "7.13.0",
-      "stability": "experimental",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11253,7 +11253,7 @@
         "namespace": "transform.delete_transform"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11281,7 +11281,7 @@
         "namespace": "transform.get_transform"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11315,7 +11315,7 @@
         "namespace": "transform.get_transform_stats"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11346,7 +11346,7 @@
         "namespace": "transform.preview_transform"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11377,7 +11377,7 @@
         "namespace": "transform.put_transform"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11405,7 +11405,7 @@
         "namespace": "transform.start_transform"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11433,7 +11433,7 @@
         "namespace": "transform.stop_transform"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11464,7 +11464,7 @@
         "namespace": "transform.update_transform"
       },
       "since": "7.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11495,7 +11495,7 @@
         "namespace": "__global.update"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11536,7 +11536,7 @@
         "namespace": "__global.update_by_query"
       },
       "since": "2.4.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11574,7 +11574,7 @@
         "namespace": "__global.update_by_query_rethrottle"
       },
       "since": "6.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11602,7 +11602,7 @@
         "namespace": "watcher.ack_watch"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11638,7 +11638,7 @@
         "namespace": "watcher.activate_watch"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11667,7 +11667,7 @@
         "namespace": "watcher.deactivate_watch"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11696,7 +11696,7 @@
         "namespace": "watcher.delete_watch"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11727,7 +11727,7 @@
         "namespace": "watcher.execute_watch"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11763,7 +11763,7 @@
         "namespace": "watcher.get_watch"
       },
       "since": "5.6.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11794,7 +11794,7 @@
         "namespace": "watcher.put_watch"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11826,7 +11826,7 @@
         "namespace": "watcher.query_watches"
       },
       "since": "7.11.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11855,7 +11855,7 @@
         "namespace": "watcher.start"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11883,7 +11883,7 @@
         "namespace": "watcher.stats"
       },
       "since": "5.5.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11917,7 +11917,7 @@
         "namespace": "watcher.stop"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11945,7 +11945,7 @@
         "namespace": "xpack.info"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -11973,7 +11973,7 @@
         "namespace": "xpack.usage"
       },
       "since": "0.0.0",
-      "stability": "stable",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -16206,44 +16206,6 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "keep_alive",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Time",
-                "namespace": "__common.common_options.time_unit"
-              }
-            }
-          },
-          {
-            "name": "typed_keys",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "boolean",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "wait_for_completion_timeout",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Time",
-                "namespace": "__common.common_options.time_unit"
-              }
-            }
-          }
-        ]
-      },
       "inherits": [
         {
           "type": {
@@ -16269,6 +16231,19 @@
               "namespace": "__common"
             }
           }
+        }
+      ],
+      "query": [
+        {
+          "name": "keep_alive",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "__common.common_options.time_unit"
+            }
+          }
         },
         {
           "name": "typed_keys",
@@ -16280,9 +16255,19 @@
               "namespace": "internal"
             }
           }
+        },
+        {
+          "name": "wait_for_completion_timeout",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "__common.common_options.time_unit"
+            }
+          }
         }
-      ],
-      "query": []
+      ]
     },
     {
       "generics": [
@@ -19377,11 +19362,23 @@
           "name": "_source",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "boolean",
+                  "namespace": "internal"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Fields",
+                  "namespace": "__common"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -19418,7 +19415,7 @@
           }
         },
         {
-          "name": "type_query_string",
+          "name": "type",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -20098,6 +20095,17 @@
             "kind": "instance_of",
             "type": {
               "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "wait_for_completion",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
               "namespace": "internal"
             }
           }
@@ -42980,11 +42988,23 @@
           "name": "date_rounding",
           "required": true,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "DateRounding",
-              "namespace": "ingest.processors"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "DateRounding",
+                  "namespace": "ingest.processors"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -43587,24 +43607,31 @@
       "kind": "enum",
       "members": [
         {
+          "identifier": "Second",
           "name": "s"
         },
         {
+          "identifier": "Minute",
           "name": "m"
         },
         {
+          "identifier": "Hour",
           "name": "h"
         },
         {
+          "identifier": "Day",
           "name": "d"
         },
         {
+          "identifier": "Week",
           "name": "w"
         },
         {
+          "identifier": "Month",
           "name": "M"
         },
         {
+          "identifier": "Year",
           "name": "y"
         }
       ],
@@ -44251,18 +44278,18 @@
           }
         },
         {
-          "name": "preference",
+          "name": "max_docs",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "long",
+              "namespace": "__common"
             }
           }
         },
         {
-          "name": "query_on_query_string",
+          "name": "preference",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -44419,7 +44446,30 @@
           }
         },
         {
-          "name": "source_excludes",
+          "name": "_source",
+          "required": true,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "boolean",
+                  "namespace": "internal"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Fields",
+                  "namespace": "__common"
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        },
+        {
+          "name": "_source_excludes",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -44430,7 +44480,7 @@
           }
         },
         {
-          "name": "source_includes",
+          "name": "_source_includes",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -51079,13 +51129,6 @@
                 "type": {
                   "name": "Fields",
                   "namespace": "__common"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "SourceFilter",
-                  "namespace": "__global.search.source_filtering"
                 }
               }
             ],
@@ -57954,18 +57997,8 @@
               {
                 "kind": "instance_of",
                 "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
+                  "name": "Fields",
+                  "namespace": "__common"
                 }
               }
             ],
@@ -81380,6 +81413,18 @@
       ],
       "query": [
         {
+          "name": "allow_no_match",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "allow_no_jobs",
           "required": false,
           "serverDefault": true,
@@ -86676,17 +86721,6 @@
           }
         },
         {
-          "name": "source_enabled",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "_source",
           "required": false,
           "type": {
@@ -87617,7 +87651,7 @@
           }
         },
         {
-          "name": "total_hits_as_integer",
+          "name": "rest_total_hits_as_int",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -107821,17 +107855,6 @@
           }
         },
         {
-          "name": "explain",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -107839,6 +107862,17 @@
             "type": {
               "name": "ExpandWildcards",
               "namespace": "__common.common"
+            }
+          }
+        },
+        {
+          "name": "explain",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         },
@@ -107887,6 +107921,17 @@
           }
         },
         {
+          "name": "min_compatible_shard_node",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "__common"
+            }
+          }
+        },
+        {
           "name": "preference",
           "required": false,
           "type": {
@@ -107905,17 +107950,6 @@
             "type": {
               "name": "long",
               "namespace": "__common"
-            }
-          }
-        },
-        {
-          "name": "query_on_query_string",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
             }
           }
         },
@@ -107960,17 +107994,6 @@
             "type": {
               "name": "SearchType",
               "namespace": "__common.common"
-            }
-          }
-        },
-        {
-          "name": "sequence_number_primary_term",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
             }
           }
         },
@@ -108044,13 +108067,24 @@
           }
         },
         {
-          "name": "total_hits_as_integer",
+          "name": "terminate_after",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "boolean",
-              "namespace": "internal"
+              "name": "long",
+              "namespace": "__common"
+            }
+          }
+        },
+        {
+          "name": "timeout",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "__common.common_options.time_unit"
             }
           }
         },
@@ -108078,6 +108112,17 @@
           }
         },
         {
+          "name": "track_scores",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "typed_keys",
           "required": false,
           "type": {
@@ -108097,6 +108142,40 @@
               "name": "boolean",
               "namespace": "internal"
             }
+          }
+        },
+        {
+          "name": "version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "_source",
+          "required": false,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "boolean",
+                  "namespace": "internal"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Fields",
+                  "namespace": "__common"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -132322,18 +132401,8 @@
               {
                 "kind": "instance_of",
                 "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
+                  "name": "Fields",
+                  "namespace": "__common"
                 }
               }
             ],
@@ -134303,6 +134372,27 @@
       ]
     },
     {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "_all"
+        },
+        {
+          "name": "queued_watches"
+        },
+        {
+          "name": "current_watches"
+        },
+        {
+          "name": "pending_watches"
+        }
+      ],
+      "name": {
+        "name": "WatcherMetric",
+        "namespace": "watcher.stats"
+      }
+    },
+    {
       "kind": "interface",
       "name": {
         "name": "WatcherNodeStats",
@@ -134815,11 +134905,26 @@
           "name": "metric",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Metrics",
-              "namespace": "__common"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "WatcherMetric",
+                  "namespace": "watcher.stats"
+                }
+              },
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "WatcherMetric",
+                    "namespace": "watcher.stats"
+                  }
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         }
       ],
@@ -134833,6 +134938,32 @@
               "name": "boolean",
               "namespace": "internal"
             }
+          }
+        },
+        {
+          "name": "metric",
+          "required": false,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "WatcherMetric",
+                  "namespace": "watcher.stats"
+                }
+              },
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "WatcherMetric",
+                    "namespace": "watcher.stats"
+                  }
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         }
       ]

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -44435,19 +44435,8 @@
           }
         },
         {
-          "name": "source_enabled",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "_source",
-          "required": true,
+          "required": false,
           "type": {
             "items": [
               {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -300,12 +300,6 @@
       ],
       "response": []
     },
-    "delete_by_query": {
-      "request": [
-        "Endpoint has \"@stability: TODO"
-      ],
-      "response": []
-    },
     "enrich.put_policy": {
       "request": [
         "Endpoint has \"@stability: TODO"

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -2,380 +2,976 @@
   "endpointErrors": {
     "async_search.get": {
       "request": [
-        "AsyncSearchGetRequest: path parameter 'typed_keys' does not exist in the json spec",
-        "AsyncSearchGetRequest: missing json spec query parameter 'wait_for_completion_timeout'",
-        "AsyncSearchGetRequest: missing json spec query parameter 'keep_alive'",
-        "AsyncSearchGetRequest: missing json spec query parameter 'typed_keys'",
-        "Request path property 'typed_keys' doesn't exist in endpoint URL templates"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "type_alias definition __common.aggregations:Aggregate / union_of / instance_of - Non-leaf type cannot be used here: '__common.aggregations:MultiBucketAggregate'",
-        "type_alias definition __common.aggregations:MetricAggregate / union_of / instance_of - Non-leaf type cannot be used here: '__common.aggregations:ValueAggregate'",
-        "type_alias definition __common.aggregations:MetricAggregate / union_of / instance_of - Non-leaf type cannot be used here: '__common.aggregations:StatsAggregate'",
-        "interface definition __common:ErrorCause / Property 'caused_by' / instance_of - Non-leaf type cannot be used here: '__common:ErrorCause'",
-        "interface definition __common:ErrorCause / Property 'root_cause' / array_of / instance_of - Non-leaf type cannot be used here: '__common:ErrorCause'",
-        "interface definition __common.common:ShardFailure / Property 'reason' / instance_of - Non-leaf type cannot be used here: '__common:ErrorCause'",
-        "type_alias definition __global.search.suggesters:SuggestOption / union_of / instance_of / Generics / instance_of - No type definition for '__global.search.suggesters:TDocument'"
-      ]
+      "response": []
     },
-    "bulk": {
+    "async_search.submit": {
       "request": [
-        "BulkRequest: query parameter 'type_query_string' does not exist in the json spec",
-        "BulkRequest: missing json spec query parameter 'type'",
-        "BulkRequest: should have a body definition"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "interface definition __global.bulk:BulkResponseItemBase / Property 'error' / instance_of - Non-leaf type cannot be used here: '__common:ErrorCause'"
-      ]
+      "response": []
+    },
+    "autoscaling.delete_autoscaling_policy": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "autoscaling.get_autoscaling_capacity": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "autoscaling.get_autoscaling_policy": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "autoscaling.put_autoscaling_policy": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.aliases": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.allocation": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.count": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.fielddata": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.health": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.help": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.indices": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.master": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.ml_data_frame_analytics": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.ml_datafeeds": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.ml_jobs": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.ml_trained_models": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.nodeattrs": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.nodes": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.pending_tasks": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.plugins": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.recovery": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.repositories": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.segments": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.shards": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.snapshots": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.tasks": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.templates": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.thread_pool": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cat.transforms": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.delete_voting_config_exclusions": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.exists_component_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "cluster.get_component_template": {
       "request": [
-        "ClusterGetComponentTemplateRequest: query parameter 'flat_settings' does not exist in the json spec"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "interface definition cluster:ComponentTemplateSummary / Property 'settings' / dictionary_of / instance_of - Non-leaf type cannot be used here: '__common.index:IndexSettings'",
-        "enum definition __common.mapping.types.geo.geo_shape:GeoOrientation - Duplicate enum member identifier 'RIGHT'",
-        "enum definition __common.mapping.types.geo.geo_shape:GeoOrientation - Duplicate enum member identifier 'COUNTERCLOCKWISE'",
-        "enum definition __common.mapping.types.geo.geo_shape:GeoOrientation - Duplicate enum member identifier 'CCW'",
-        "enum definition __common.mapping.types.geo.geo_shape:GeoOrientation - Duplicate enum member identifier 'LEFT'",
-        "enum definition __common.mapping.types.geo.geo_shape:GeoOrientation - Duplicate enum member identifier 'CLOCKWISE'",
-        "enum definition __common.mapping.types.geo.geo_shape:GeoOrientation - Duplicate enum member identifier 'CW'",
-        "interface definition __common.mapping.dynamic_template:DynamicTemplate / Property 'mapping' / instance_of - Non-leaf type cannot be used here: '__common.mapping.types:PropertyBase'"
-      ]
+      "response": []
     },
-    "create": {
+    "cluster.post_voting_config_exclusions": {
       "request": [
-        "CreateRequest: should have a body definition"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "interface definition __common:WriteResponseBase / Property 'error' / instance_of - Non-leaf type cannot be used here: '__common:ErrorCause'"
-      ]
+      "response": []
+    },
+    "cluster.put_component_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.remote_info": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.reroute": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "count": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "dangling_indices.delete_dangling_index": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "dangling_indices.import_dangling_index": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "dangling_indices.list_dangling_indices": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "data_frame_transform_deprecated.delete_transform": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "data_frame_transform_deprecated.get_transform": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "data_frame_transform_deprecated.get_transform_stats": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "data_frame_transform_deprecated.preview_transform": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "data_frame_transform_deprecated.put_transform": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "data_frame_transform_deprecated.start_transform": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "data_frame_transform_deprecated.stop_transform": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "data_frame_transform_deprecated.update_transform": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "delete_by_query": {
       "request": [
-        "DeleteByQueryRequest: query parameter 'query_on_query_string' does not exist in the json spec",
-        "DeleteByQueryRequest: query parameter 'source_enabled' does not exist in the json spec",
-        "DeleteByQueryRequest: query parameter 'source_excludes' does not exist in the json spec",
-        "DeleteByQueryRequest: query parameter 'source_includes' does not exist in the json spec",
-        "DeleteByQueryRequest: missing json spec query parameter 'max_docs'",
-        "DeleteByQueryRequest: missing json spec query parameter '_source'",
-        "DeleteByQueryRequest: missing json spec query parameter '_source_excludes'",
-        "DeleteByQueryRequest: missing json spec query parameter '_source_includes'",
-        "DeleteByQueryRequest: should have a body definition"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "interface definition __common:MainError / Property 'root_cause' / array_of / instance_of - Non-leaf type cannot be used here: '__common:ErrorCause'"
-      ]
+      "response": []
+    },
+    "enrich.put_policy": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "eql.search": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "exists": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "exists_source": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "explain": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "features.get_features": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "features.reset_features": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "get": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "get_script_context": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "get_script_languages": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "get_source": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ilm.delete_lifecycle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ilm.get_lifecycle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ilm.put_lifecycle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ilm.start": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ilm.stop": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.analyze": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.clear_cache": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.delete_data_stream": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "indices.delete_index_template": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "indices.exists_index_template": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "indices.get_data_stream": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "indices.get_index_template": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "indices.get_upgrade": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "indices.put_index_template": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "indices.put_settings": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.put_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.shrink": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "indices.simulate_index_template": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "indices.simulate_template": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "indices.split": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.upgrade": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.validate_query": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ingest.geo_ip_stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "license.post_start_trial": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "logstash.delete_pipeline": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "logstash.get_pipeline": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "logstash.put_pipeline": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.close_job": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_expired_data": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "ml.evaluate_data_frame": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "ml.explain_data_frame_analytics": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "ml.find_file_structure": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "ml.flush_job": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.forecast": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_buckets": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_calendar_events": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_calendars": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_categories": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "ml.get_data_frame_analytics": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "ml.get_data_frame_analytics_stats": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "ml.get_datafeed_stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_datafeeds": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_influencers": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_job_stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "ml.get_jobs": {
       "request": [
-        "MlGetJobsRequest: missing json spec query parameter 'allow_no_match'"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "type_alias definition xpack.usage:UrlConfig / union_of / instance_of - Non-leaf type cannot be used here: 'xpack.usage:BaseUrlConfig'"
-      ]
+      "response": []
+    },
+    "ml.get_model_snapshots": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_overall_buckets": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_records": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "ml.get_trained_models": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "ml.get_trained_models_stats": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "ml.info": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.open_job": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "ml.preview_data_frame_analytics": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "ml.put_data_frame_analytics": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "ml.put_trained_model": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "ml.put_trained_model_alias": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "ml.revert_model_snapshot": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "ml.start_data_frame_analytics": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "ml.start_datafeed": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.stop_datafeed": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "ml.update_data_frame_analytics": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
     },
     "ml.upgrade_job_snapshot": {
       "request": [
-        "Missing request"
+        "Missing request & response"
       ],
-      "response": [
-        "Missing response"
-      ]
+      "response": []
+    },
+    "monitoring.bulk": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "msearch_template": {
       "request": [
-        "MultiSearchTemplateRequest: query parameter 'total_hits_as_integer' does not exist in the json spec",
-        "MultiSearchTemplateRequest: missing json spec query parameter 'rest_total_hits_as_int'",
-        "MultiSearchTemplateRequest: should have a body definition",
-        "request definition __global.msearch_template:MultiSearchTemplateRequest / body / Property 'operations' / dictionary_of / instance_of - '__global.search_template:SearchTemplateRequest' is a request and must only be used in endpoints"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "interface definition __global.msearch_template:MultiSearchTemplateResponse / Property 'responses' / array_of / instance_of - Non-leaf type cannot be used here: '__global.search:SearchResponse'"
-      ]
+      "response": []
+    },
+    "mtermvectors": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "nodes.hot_threads": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "nodes.reload_secure_settings": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "nodes.stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "open_point_in_time": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "put_script": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "reindex": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "render_search_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "rollup.rollup": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "scroll": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "search": {
       "request": [
-        "SearchRequest: query parameter 'query_on_query_string' does not exist in the json spec",
-        "SearchRequest: query parameter 'sequence_number_primary_term' does not exist in the json spec",
-        "SearchRequest: query parameter 'total_hits_as_integer' does not exist in the json spec",
-        "SearchRequest: missing json spec query parameter '_source'",
-        "SearchRequest: missing json spec query parameter 'terminate_after'",
-        "SearchRequest: missing json spec query parameter 'timeout'",
-        "SearchRequest: missing json spec query parameter 'track_scores'",
-        "SearchRequest: missing json spec query parameter 'version'",
-        "SearchRequest: missing json spec query parameter 'min_compatible_shard_node'"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "Non-leaf type cannot be used here: '__global.search:SearchResponse'"
-      ]
+      "response": []
     },
-    "security.invalidate_api_key": {
+    "search_template": {
       "request": [
-        "SecurityInvalidateApiKeyRequest: should have a body definition"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "interface definition security.invalidate_api_key:SecurityInvalidateApiKeyResponse / Property 'error_details' / array_of / instance_of - Non-leaf type cannot be used here: '__common:ErrorCause'"
-      ]
+      "response": []
     },
-    "security.invalidate_token": {
+    "searchable_snapshots.clear_cache": {
       "request": [
-        "SecurityInvalidateTokenRequest: should have a body definition"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "interface definition security.invalidate_token:SecurityInvalidateTokenResponse / Property 'error_details' / array_of / instance_of - Non-leaf type cannot be used here: '__common:ErrorCause'"
-      ]
+      "response": []
     },
-    "tasks.cancel": {
+    "searchable_snapshots.repository_stats": {
       "request": [
-        "CancelTasksRequest: missing json spec query parameter 'wait_for_completion'"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "interface definition task.cancel_tasks:CancelTasksResponse / Property 'node_failures' / array_of / instance_of - Non-leaf type cannot be used here: '__common:ErrorCause'"
-      ]
+      "response": []
+    },
+    "searchable_snapshots.stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.authenticate": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.get_builtin_privileges": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.get_user": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.get_user_privileges": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.grant_api_key": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "shutdown.delete_node": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "shutdown.get_node": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "shutdown.put_node": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "snapshot.clone": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "snapshot.restore": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "tasks.list": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "update": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "update_by_query": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.execute_watch": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.put_watch": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.query_watches": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.start": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     },
     "watcher.stats": {
       "request": [
-        "WatcherStatsRequest: missing json spec query parameter 'metric'"
+        "Endpoint has \"@stability: TODO"
       ],
-      "response": [
-        "interface definition watcher.stats:WatcherNodeStats / Property 'queued_watches' / array_of / instance_of - Non-leaf type cannot be used here: 'watcher.stats:WatchRecordQueuedStats'"
-      ]
+      "response": []
+    },
+    "watcher.stop": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "xpack.info": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "xpack.usage": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
     }
   },
-  "generalErrors": [
-    "No type definition for 'common_abstractions.response:ErrorResponse'"
-  ]
+  "generalErrors": []
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4050,8 +4050,7 @@ export interface DeleteByQueryRequest extends RequestBase {
   size?: long
   slices?: long
   sort?: Array<string>
-  source_enabled?: boolean
-  _source: boolean | Fields
+  _source?: boolean | Fields
   _source_excludes?: Fields
   _source_includes?: Fields
   stats?: Array<string>

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -470,12 +470,9 @@ export interface AsyncSearchDocumentResponseBase<TDocument = unknown> extends As
 
 export interface AsyncSearchGetRequest extends RequestBase {
   id: Id
+  keep_alive?: Time
   typed_keys?: boolean
-  body?: {
-    keep_alive?: Time
-    typed_keys?: boolean
-    wait_for_completion_timeout?: Time
-  }
+  wait_for_completion_timeout?: Time
 }
 
 export interface AsyncSearchGetResponse<TDocument = unknown> extends AsyncSearchDocumentResponseBase<TDocument> {
@@ -807,11 +804,10 @@ export interface BulkRequest<TSource = unknown> extends RequestBase {
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
-  _source?: boolean
+  _source?: boolean | Fields
   _source_excludes?: Fields
   _source_includes?: Fields
   timeout?: Time
-  type_query_string?: string
   wait_for_active_shards?: WaitForActiveShards
   require_alias?: boolean
   body: Array<BulkOperationContainer | TSource>
@@ -883,6 +879,7 @@ export interface CancelTasksRequest extends RequestBase {
   actions?: string | Array<string>
   nodes?: Array<string>
   parent_task_id?: string
+  wait_for_completion?: boolean
 }
 
 export interface CancelTasksResponse extends ResponseBase {
@@ -3906,7 +3903,7 @@ export interface DateHistogramRollupGrouping {
 
 export interface DateIndexNameProcessor extends ProcessorBase {
   date_formats: Array<string>
-  date_rounding: DateRounding
+  date_rounding: string | DateRounding
   field: Field
   index_name_format: string
   index_name_prefix: string
@@ -4039,8 +4036,8 @@ export interface DeleteByQueryRequest extends RequestBase {
   from?: long
   ignore_unavailable?: boolean
   lenient?: boolean
+  max_docs?: long
   preference?: string
-  query_on_query_string?: string
   refresh?: boolean
   request_cache?: boolean
   requests_per_second?: long
@@ -4054,8 +4051,9 @@ export interface DeleteByQueryRequest extends RequestBase {
   slices?: long
   sort?: Array<string>
   source_enabled?: boolean
-  source_excludes?: Fields
-  source_includes?: Fields
+  _source: boolean | Fields
+  _source_excludes?: Fields
+  _source_includes?: Fields
   stats?: Array<string>
   terminate_after?: long
   timeout?: Time
@@ -4787,7 +4785,7 @@ export interface ExplainRequest extends RequestBase {
   preference?: string
   query_on_query_string?: string
   routing?: Routing
-  _source?: boolean | Fields | SourceFilter
+  _source?: boolean | Fields
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
@@ -5571,7 +5569,7 @@ export interface GetRequest extends RequestBase {
   stored_fields?: Fields
   version?: VersionNumber
   version_type?: VersionType
-  _source?: boolean | string | Array<string>
+  _source?: boolean | Fields
 }
 
 export interface GetResponse<TDocument = unknown> extends ResponseBase {
@@ -8226,6 +8224,7 @@ export interface MlGetJobStatsResponse extends ResponseBase {
 
 export interface MlGetJobsRequest extends RequestBase {
   job_id?: Ids
+  allow_no_match?: boolean
   allow_no_jobs?: boolean
   exclude_generated?: boolean
 }
@@ -8801,7 +8800,6 @@ export interface MultiGetRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  source_enabled?: boolean
   _source?: boolean | Fields
   _source_excludes?: Fields
   _source_includes?: Fields
@@ -8887,7 +8885,7 @@ export interface MultiSearchTemplateRequest extends RequestBase {
   ccs_minimize_roundtrips?: boolean
   max_concurrent_searches?: long
   search_type?: SearchType
-  total_hits_as_integer?: boolean
+  rest_total_hits_as_int?: boolean
   typed_keys?: boolean
   body: {
     operations?: Record<string, SearchTemplateRequest>
@@ -11115,30 +11113,33 @@ export interface SearchRequest extends RequestBase {
   default_operator?: DefaultOperator
   df?: string
   docvalue_fields?: Fields
-  explain?: boolean
   expand_wildcards?: ExpandWildcards
+  explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
   lenient?: boolean
   max_concurrent_shard_requests?: long
+  min_compatible_shard_node?: VersionString
   preference?: string
   pre_filter_shard_size?: long
-  query_on_query_string?: string
   request_cache?: boolean
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
-  sequence_number_primary_term?: boolean
   stats?: Array<string>
   stored_fields?: Fields
   suggest_field?: Field
   suggest_mode?: SuggestMode
   suggest_size?: long
   suggest_text?: string
-  total_hits_as_integer?: boolean
+  terminate_after?: long
+  timeout?: Time
   track_total_hits?: boolean | integer
+  track_scores?: boolean
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
+  version?: boolean
+  _source?: boolean | Fields
   _source_excludes?: Fields
   _source_includes?: Fields
   seq_no_primary_term?: boolean
@@ -13823,7 +13824,7 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
   source_enabled?: boolean
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
-  _source?: boolean | string | Array<string>
+  _source?: boolean | Fields
   _source_excludes?: Fields
   _source_includes?: Fields
   body: {
@@ -14059,6 +14060,8 @@ export interface WatcherExecuteWatchResponse extends ResponseBase {
   watch_record: WatchRecord
 }
 
+export type WatcherMetric = '_all' | 'queued_watches' | 'current_watches' | 'pending_watches'
+
 export interface WatcherNodeStats {
   current_watches?: Array<WatchRecordStats>
   execution_thread_pool: ExecutionThreadPool
@@ -14117,7 +14120,7 @@ export interface WatcherStartResponse extends AcknowledgedResponseBase {
 export type WatcherState = 'stopped' | 'starting' | 'started' | 'stopping'
 
 export interface WatcherStatsRequest extends RequestBase {
-  metric?: Metrics
+  metric?: WatcherMetric | Array<WatcherMetric>
   emit_stacktraces?: boolean
 }
 

--- a/specification/__common/common.ts
+++ b/specification/__common/common.ts
@@ -158,7 +158,7 @@ export type ByteSize = long | string
 /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
 export type IndexMetaData = Dictionary<string, UserDefinedValue>
 
-// Versionining Numbers & Strings
+// Versioning Numbers & Strings
 export type VersionNumber = long
 export type VersionNumbers = VersionNumber[]
 export type VersionString = string

--- a/specification/__global/bulk/BulkRequest.ts
+++ b/specification/__global/bulk/BulkRequest.ts
@@ -44,11 +44,11 @@ export interface BulkRequest<TSource> extends RequestBase {
     pipeline?: string
     refresh?: Refresh
     routing?: Routing
-    _source?: boolean
+    _source?: boolean | Fields
     _source_excludes?: Fields
     _source_includes?: Fields
     timeout?: Time
-    type_query_string?: string
+    type?: string
     wait_for_active_shards?: WaitForActiveShards
     require_alias?: boolean
   }

--- a/specification/__global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/__global/delete_by_query/DeleteByQueryRequest.ts
@@ -69,8 +69,7 @@ export interface DeleteByQueryRequest extends RequestBase {
     size?: long
     slices?: long
     sort?: string[]
-    source_enabled?: boolean
-    _source: boolean | Fields
+    _source?: boolean | Fields
     _source_excludes?: Fields
     _source_includes?: Fields
     stats?: string[]

--- a/specification/__global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/__global/delete_by_query/DeleteByQueryRequest.ts
@@ -55,8 +55,8 @@ export interface DeleteByQueryRequest extends RequestBase {
     from?: long
     ignore_unavailable?: boolean
     lenient?: boolean
+    max_docs?: long
     preference?: string
-    query_on_query_string?: string
     refresh?: boolean
     request_cache?: boolean
     requests_per_second?: long
@@ -70,8 +70,9 @@ export interface DeleteByQueryRequest extends RequestBase {
     slices?: long
     sort?: string[]
     source_enabled?: boolean
-    source_excludes?: Fields
-    source_includes?: Fields
+    _source: boolean | Fields
+    _source_excludes?: Fields
+    _source_includes?: Fields
     stats?: string[]
     terminate_after?: long
     timeout?: Time

--- a/specification/__global/explain/ExplainRequest.ts
+++ b/specification/__global/explain/ExplainRequest.ts
@@ -43,7 +43,7 @@ export interface ExplainRequest extends RequestBase {
     preference?: string
     query_on_query_string?: string
     routing?: Routing
-    _source?: boolean | Fields | SourceFilter
+    _source?: boolean | Fields
     _source_excludes?: Fields
     _source_includes?: Fields
     stored_fields?: Fields

--- a/specification/__global/get/GetRequest.ts
+++ b/specification/__global/get/GetRequest.ts
@@ -50,7 +50,7 @@ export interface GetRequest extends RequestBase {
     stored_fields?: Fields
     version?: VersionNumber
     version_type?: VersionType
-    _source?: boolean | string | string[]
+    _source?: boolean | Fields
   }
   body?: {}
 }

--- a/specification/__global/mget/MultiGetRequest.ts
+++ b/specification/__global/mget/MultiGetRequest.ts
@@ -45,7 +45,6 @@ export interface MultiGetRequest extends RequestBase {
     realtime?: boolean // default: true
     refresh?: boolean // default: false
     routing?: Routing
-    source_enabled?: boolean
     _source?: boolean | Fields
     _source_excludes?: Fields
     _source_includes?: Fields

--- a/specification/__global/msearch_template/MultiSearchTemplateRequest.ts
+++ b/specification/__global/msearch_template/MultiSearchTemplateRequest.ts
@@ -38,7 +38,7 @@ export interface MultiSearchTemplateRequest extends RequestBase {
     ccs_minimize_roundtrips?: boolean
     max_concurrent_searches?: long
     search_type?: SearchType
-    total_hits_as_integer?: boolean
+    rest_total_hits_as_int?: boolean
     typed_keys?: boolean
   }
   body?: {

--- a/specification/__global/search/SearchRequest.ts
+++ b/specification/__global/search/SearchRequest.ts
@@ -28,7 +28,8 @@ import {
   integer,
   long,
   Routing,
-  Types
+  Types,
+  VersionString
 } from '@common/common'
 import { DefaultOperator } from '@common/common/DefaultOperator'
 import { ExpandWildcards } from '@common/common/ExpandWildcards'
@@ -69,30 +70,33 @@ export interface SearchRequest extends RequestBase {
     default_operator?: DefaultOperator
     df?: string
     docvalue_fields?: Fields
-    explain?: boolean
     expand_wildcards?: ExpandWildcards
+    explain?: boolean
     ignore_throttled?: boolean
     ignore_unavailable?: boolean
     lenient?: boolean
     max_concurrent_shard_requests?: long
+    min_compatible_shard_node?: VersionString
     preference?: string
     pre_filter_shard_size?: long
-    query_on_query_string?: string
     request_cache?: boolean
     routing?: Routing
     scroll?: Time
     search_type?: SearchType
-    sequence_number_primary_term?: boolean
     stats?: string[]
     stored_fields?: Fields
     suggest_field?: Field
     suggest_mode?: SuggestMode
     suggest_size?: long
     suggest_text?: string
-    total_hits_as_integer?: boolean
+    terminate_after?: long
+    timeout?: Time
     track_total_hits?: boolean | integer
+    track_scores?: boolean
     typed_keys?: boolean
     rest_total_hits_as_int?: boolean
+    version?: boolean
+    _source?: boolean | Fields
     _source_excludes?: Fields
     _source_includes?: Fields
     seq_no_primary_term?: boolean

--- a/specification/__global/update/UpdateRequest.ts
+++ b/specification/__global/update/UpdateRequest.ts
@@ -56,7 +56,7 @@ export interface UpdateRequest<TDocument, TPartialDocument>
     source_enabled?: boolean
     timeout?: Time
     wait_for_active_shards?: WaitForActiveShards
-    _source?: boolean | string | string[]
+    _source?: boolean | Fields
     _source_excludes?: Fields
     _source_includes?: Fields
   }

--- a/specification/async_search/get/AsyncSearchGetRequest.ts
+++ b/specification/async_search/get/AsyncSearchGetRequest.ts
@@ -29,12 +29,11 @@ import { Time } from '@common/common_options/time_unit/Time'
 export interface AsyncSearchGetRequest extends RequestBase {
   path_parts?: {
     id: Id
-    typed_keys?: boolean
   }
-  query_parameters?: {}
-  body?: {
+  query_parameters?: {
     keep_alive?: Time
     typed_keys?: boolean
     wait_for_completion_timeout?: Time
   }
+  body?: {}
 }

--- a/specification/indices/upgrade/IndicesUpgradeRequest.ts
+++ b/specification/indices/upgrade/IndicesUpgradeRequest.ts
@@ -23,7 +23,7 @@ import { RequestBase } from '@common/common_abstractions/request/RequestBase'
 /**
  * @rest_spec_name indices.upgrade
  * @since 7.13.0
- * @stability stable
+ * @stability TODO
  */
 export interface IndicesUpgradeRequest extends RequestBase {
   path_parts?: {

--- a/specification/ingest/geo_ip_stats/IngestGeoIpStatsRequest.ts
+++ b/specification/ingest/geo_ip_stats/IngestGeoIpStatsRequest.ts
@@ -23,7 +23,7 @@ import { RequestBase } from '@common/common_abstractions/request/RequestBase'
 /**
  * @rest_spec_name ingest.geo_ip_stats
  * @since 7.13.0
- * @stability stable
+ * @stability TODO
  */
 export interface IngestGeoIpStatsRequest extends RequestBase {
   path_parts?: {

--- a/specification/ingest/processors/DateIndexNameProcessor.ts
+++ b/specification/ingest/processors/DateIndexNameProcessor.ts
@@ -23,7 +23,7 @@ import { DateRounding } from './DateRounding'
 
 export class DateIndexNameProcessor extends ProcessorBase {
   date_formats: string[]
-  date_rounding: DateRounding
+  date_rounding: string | DateRounding
   field: Field
   index_name_format: string
   index_name_prefix: string

--- a/specification/ingest/processors/DateRounding.ts
+++ b/specification/ingest/processors/DateRounding.ts
@@ -18,11 +18,18 @@
  */
 
 export enum DateRounding {
+  /** @identifier Second */
   s = 0,
+  /** @identifier Minute */
   m = 1,
+  /** @identifier Hour */
   h = 2,
+  /** @identifier Day */
   d = 3,
+  /** @identifier Week */
   w = 4,
+  /** @identifier Month */
   M = 5,
+  /** @identifier Year */
   y = 6
 }

--- a/specification/task/cancel_tasks/CancelTasksRequest.ts
+++ b/specification/task/cancel_tasks/CancelTasksRequest.ts
@@ -33,6 +33,7 @@ export interface CancelTasksRequest extends RequestBase {
     actions?: string | string[]
     nodes?: string[]
     parent_task_id?: string
+    wait_for_completion?: boolean
   }
   body?: {}
 }

--- a/specification/watcher/stats/WatcherMetric.ts
+++ b/specification/watcher/stats/WatcherMetric.ts
@@ -17,24 +17,9 @@
  * under the License.
  */
 
-import { Ids } from '@common/common'
-import { RequestBase } from '@common/common_abstractions/request/RequestBase'
-
-/**
- * @rest_spec_name ml.get_jobs
- * @since 5.5.0
- * @stability TODO
- */
-export interface MlGetJobsRequest extends RequestBase {
-  path_parts?: {
-    job_id?: Ids
-  }
-  query_parameters?: {
-    /** @server_default true */
-    allow_no_match?: boolean
-    /** @server_default true */
-    allow_no_jobs?: boolean
-    /** @server_default false */
-    exclude_generated?: boolean
-  }
+export enum WatcherMetric {
+  '_all'= 0,
+  'queued_watches' = 1,
+  'current_watches' = 2,
+  'pending_watches' = 3
 }

--- a/specification/watcher/stats/WatcherMetric.ts
+++ b/specification/watcher/stats/WatcherMetric.ts
@@ -18,7 +18,7 @@
  */
 
 export enum WatcherMetric {
-  '_all'= 0,
+  '_all' = 0,
   'queued_watches' = 1,
   'current_watches' = 2,
   'pending_watches' = 3

--- a/specification/watcher/stats/WatcherStatsRequest.ts
+++ b/specification/watcher/stats/WatcherStatsRequest.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { Metrics } from '@common/common'
 import { RequestBase } from '@common/common_abstractions/request/RequestBase'
+import { WatcherMetric } from './WatcherMetric'
 
 /**
  * @rest_spec_name watcher.stats
@@ -27,10 +27,11 @@ import { RequestBase } from '@common/common_abstractions/request/RequestBase'
  */
 export interface WatcherStatsRequest extends RequestBase {
   path_parts?: {
-    metric?: Metrics
+    metric?: WatcherMetric | WatcherMetric[]
   }
   query_parameters?: {
     emit_stacktraces?: boolean
+    metric?: WatcherMetric | WatcherMetric[]
   }
   body?: {}
 }


### PR DESCRIPTION
The input specification has a lot of endpoints that are still a work in progress. They have either `@stability TODO` or do not have associated requests and responses. Validating these endpoints creates a lot of validation errors (we had 600+), making the validation report practically useless.

This PR makes sure we only output one single validation error for these work-in-progress endpoints, so that work to be done is tracked, but we're not flooded with non-actionable errors.

Note that model validation still happens, which allows these endpoints and their transitive dependent types to be output in `schema.json`, even if incomplete/incorrect.

After this fitlering phase, some non-TODO endpoints showed some validation errors that this PR also fixes.
