### PR TITLE
Introduce GenericResponseBody behaviour

### DIFF
--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -48,7 +48,8 @@ export const knownBehaviors = [
   'ArrayResponseBase',
   'EmptyResponseBase',
   'CommonQueryParameters',
-  'CommonCatQueryParameters'
+  'CommonCatQueryParameters',
+  'GenericResponseBody'
 ]
 
 /**

--- a/docs/behaviors.md
+++ b/docs/behaviors.md
@@ -64,3 +64,14 @@ Since these can break the request structure these are listed explicitly as a beh
 ```ts
 class CatRequestBase extends RequestBase implements CommonCatQueryParameters {}
 ```
+
+## GenericResponseBody
+
+Some APIs does not return a structured body, but a generic value instead.
+For examplke the `get_source` API return the source document.
+
+```ts
+class SourceResponse<TDocument>
+  extends ResponseBase
+  implements GenericResponseBody<TDocument> {}
+```

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -122282,6 +122282,26 @@
       ]
     },
     {
+      "attachedBehaviors": [
+        "GenericResponseBody"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "TDocument",
+                "namespace": "_global.get_source"
+              }
+            }
+          ],
+          "type": {
+            "name": "GenericResponseBody",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
       "generics": [
         {
           "name": "TDocument",
@@ -122301,19 +122321,7 @@
         "name": "SourceResponse",
         "namespace": "_global.get_source"
       },
-      "properties": [
-        {
-          "name": "body",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "TDocument",
-              "namespace": "_global.get_source"
-            }
-          }
-        }
-      ]
+      "properties": []
     },
     {
       "inherits": [
@@ -137726,6 +137734,21 @@
           }
         }
       ]
+    },
+    {
+      "description": "Some APIs does not return a structured body, but a generic value instead.\nFor examplke the `get_source` API return the source document.",
+      "generics": [
+        {
+          "name": "T",
+          "namespace": "_spec_utils"
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "GenericResponseBody",
+        "namespace": "_spec_utils"
+      },
+      "properties": []
     }
   ]
 }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -122238,20 +122238,8 @@
       ],
       "inherits": [
         {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "user_defined_value"
-            }
-          ],
           "type": {
-            "name": "DictionaryResponseBase",
+            "name": "ResponseBase",
             "namespace": "_types"
           }
         }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11809,12 +11809,7 @@ export interface SearchSourceFilteringSourceFilter {
 export interface GetSourceSourceRequest extends GetGetRequest {
 }
 
-<<<<<<< HEAD
 export type GetSourceSourceResponse<TDocument = unknown> = TDocument
-=======
-export interface GetSourceSourceResponse<TDocument = unknown> extends DictionaryResponseBase<Field, any> {
-}
->>>>>>> master
 
 export interface QueryDslSpanContainingSpanContainingQuery extends QueryDslAbstractionsQueryQueryBase {
   big?: QueryDslSpanSpanQuery

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11821,9 +11821,7 @@ export interface GetSourceSourceRequest extends RequestBase {
   version_type?: VersionType
 }
 
-export interface GetSourceSourceResponse<TDocument = unknown> extends ResponseBase {
-  body: TDocument
-}
+export type GetSourceSourceResponse<TDocument = unknown> = TDocument
 
 export interface QueryDslSpanContainingSpanContainingQuery extends QueryDslAbstractionsQueryQueryBase {
   big?: QueryDslSpanSpanQuery
@@ -13506,5 +13504,8 @@ export interface SpecUtilsCommonQueryParameters {
   human?: boolean
   pretty?: boolean
   source_query_string?: string
+}
+
+export interface SpecUtilsGenericResponseBody<T = unknown> {
 }
 

--- a/specification/_global/get_source/SourceResponse.ts
+++ b/specification/_global/get_source/SourceResponse.ts
@@ -17,8 +17,9 @@
  * under the License.
  */
 
+import { GenericResponseBody } from '@spec_utils/behaviors'
 import { ResponseBase } from '@_types/Base'
 
-export class SourceResponse<TDocument> extends ResponseBase {
-  body: TDocument
-}
+export class SourceResponse<TDocument>
+  extends ResponseBase
+  implements GenericResponseBody<TDocument> {}

--- a/specification/_spec_utils/behaviors.ts
+++ b/specification/_spec_utils/behaviors.ts
@@ -81,3 +81,10 @@ export interface CommonCatQueryParameters {
   s?: string[]
   v?: boolean
 }
+
+/**
+ * Some APIs does not return a structured body, but a generic value instead.
+ * For examplke the `get_source` API return the source document.
+ * @behavior Defines a trait that the response body is the given generic.
+ */
+export interface GenericResponseBody<T> {}

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -32,7 +32,8 @@ const model: M.Model = JSON.parse(readFileSync(join(__dirname, '..', 'output', '
 const skipBehaviors = [
   'ArrayResponseBase',
   'EmptyResponseBase',
-  'AdditionalProperties'
+  'AdditionalProperties',
+  'GenericResponseBody'
 ]
 
 let definitions = `/*
@@ -172,6 +173,13 @@ function buildBehaviorInterface (type: M.Interface): string {
   if (Array.isArray(type.attachedBehaviors)) {
     if (type.attachedBehaviors.includes('AdditionalProperties')) {
       return serializeAdditionalPropertiesType(type)
+    }
+
+    if (type.attachedBehaviors.includes('GenericResponseBody')) {
+      const generics = type.generics
+      assert(generics)
+      const name = generics[0].name
+      return `export type ${createName(type.name)}${buildGenerics(generics)} = ${name}\n`
     }
 
     if (type.attachedBehaviors.includes('ArrayResponseBase')) {


### PR DESCRIPTION
Some APIs, `get_source` for example, do not have a structured body, they return something we have no knowledge of.
This pr introduces a new behavior to handle these cases.

Fixes: #359 