### PR TITLE
Use a single value for inherits in metamodel

### DIFF
--- a/compiler/model/build-model.ts
+++ b/compiler/model/build-model.ts
@@ -234,7 +234,9 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
     }
 
     for (const inherit of declaration.getHeritageClauses()) {
-      type.inherits = (type.inherits ?? []).concat(modelInherits(inherit))
+      const extended = modelInherits(inherit)
+      assert(inherit, extended.length <= 1, '??? TypeScript only allows to extend a single class')
+      type.inherits = extended[0]
     }
 
     for (const typeParameter of declaration.getTypeParameters()) {
@@ -298,7 +300,9 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
 
     for (const inherit of declaration.getHeritageClauses()) {
       if (inherit.getToken() === ts.SyntaxKind.ExtendsKeyword) {
-        type.inherits = (type.inherits ?? []).concat(modelInherits(inherit))
+        const extended = modelInherits(inherit)
+        assert(inherit, extended.length <= 1, '??? TypeScript only allows to extend a single class')
+        type.inherits = extended[0]
       }
     }
 

--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -198,7 +198,7 @@ export class Interface extends BaseType {
    * this fully qualified type name to be used when this open generic parameter is used in property's type.
    */
   generics?: TypeName[]
-  inherits?: Inherits[]
+  inherits?: Inherits
   implements?: Inherits[]
 
   /**
@@ -223,7 +223,7 @@ export class Request extends BaseType {
   // Note: does not extend Interface as properties are split across path, query and body
   kind: 'request'
   generics?: TypeName[]
-  inherits?: Inherits[]
+  inherits?: Inherits
   implements?: Inherits[]
   /** URL path properties */
   path: Property[]

--- a/compiler/steps/validate-model.ts
+++ b/compiler/steps/validate-model.ts
@@ -524,18 +524,11 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     return new Set((typeDef.generics ?? []).map(name => fqn(name)))
   }
 
-  function validateInherits (parents: (model.Inherits[] | undefined), openGenerics: Set<string>): void {
-    if (parents == null || parents.length === 0) return
+  function validateInherits (parent: (model.Inherits | undefined), openGenerics: Set<string>): void {
+    if (parent == null) return
 
     context.push('Inherits')
-    // FIXME: remove this check once metamodel only allows 1 inherit
-    if (parents.length > 1) {
-      modelError('Multiple inheritance is not allowed')
-    }
-
-    for (const parent of parents) {
-      validateTypeRef(parent.type, parent.generics, openGenerics)
-    }
+    validateTypeRef(parent.type, parent.generics, openGenerics)
     context.pop()
   }
 

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -19025,8 +19025,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "Id",
+              "namespace": "_types"
             }
           }
         },
@@ -19036,8 +19036,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "IndexName",
+              "namespace": "_types"
             }
           }
         },
@@ -32921,6 +32921,19 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "Specifies the node ID or the name of the node to only explain a shard that is currently located on the specified node.",
+            "name": "current_node",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "Specifies the name of the index that you would like an explanation for.",
             "name": "index",
             "required": false,
             "type": {
@@ -32932,6 +32945,7 @@
             }
           },
           {
+            "description": "If true, returns explanation for the primary shard for the given shard ID.",
             "name": "primary",
             "required": false,
             "type": {
@@ -32943,6 +32957,7 @@
             }
           },
           {
+            "description": "Specifies the ID of the shard that you would like an explanation for.",
             "name": "shard",
             "required": false,
             "type": {
@@ -32969,8 +32984,10 @@
       "path": [],
       "query": [
         {
+          "description": "If true, returns information about disk usage and shard sizes.",
           "name": "include_disk_info",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -32980,8 +32997,10 @@
           }
         },
         {
+          "description": "If true, returns YES decisions in explanation.",
           "name": "include_yes_decisions",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -33182,8 +33201,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "IndexName",
+              "namespace": "_types"
             }
           }
         },
@@ -34241,6 +34260,7 @@
       },
       "properties": [
         {
+          "description": "Contains statistics about the number of primary shards assigned to selected nodes.",
           "name": "primaries",
           "required": true,
           "type": {
@@ -34252,6 +34272,7 @@
           }
         },
         {
+          "description": "Contains statistics about the number of replication shards assigned to selected nodes.",
           "name": "replication",
           "required": true,
           "type": {
@@ -34263,6 +34284,7 @@
           }
         },
         {
+          "description": "Contains statistics about the number of shards assigned to selected nodes.",
           "name": "shards",
           "required": true,
           "type": {
@@ -34276,6 +34298,7 @@
       ]
     },
     {
+      "description": "Contains statistics about shards assigned to selected nodes.",
       "kind": "interface",
       "name": {
         "name": "ClusterIndicesShardsStats",
@@ -34283,6 +34306,7 @@
       },
       "properties": [
         {
+          "description": "Contains statistics about shards assigned to selected nodes.",
           "name": "index",
           "required": false,
           "type": {
@@ -34294,6 +34318,7 @@
           }
         },
         {
+          "description": "Number of primary shards assigned to selected nodes.",
           "name": "primaries",
           "required": false,
           "type": {
@@ -34305,6 +34330,7 @@
           }
         },
         {
+          "description": "Ratio of replica shards to primary shards across all selected nodes.",
           "name": "replication",
           "required": false,
           "type": {
@@ -34316,6 +34342,7 @@
           }
         },
         {
+          "description": "Total number of shards assigned to selected nodes.",
           "name": "total",
           "required": false,
           "type": {
@@ -34336,6 +34363,7 @@
       },
       "properties": [
         {
+          "description": "Contains statistics about memory used for completion in selected nodes.",
           "name": "completion",
           "required": true,
           "type": {
@@ -34347,6 +34375,7 @@
           }
         },
         {
+          "description": "Total number of indices with shards assigned to selected nodes.",
           "name": "count",
           "required": true,
           "type": {
@@ -34358,6 +34387,7 @@
           }
         },
         {
+          "description": "Contains counts for documents in selected nodes.",
           "name": "docs",
           "required": true,
           "type": {
@@ -34369,6 +34399,8 @@
           }
         },
         {
+          "description": "Contains statistics about the field data cache of selected nodes.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-fielddata.html",
           "name": "fielddata",
           "required": true,
           "type": {
@@ -34380,6 +34412,7 @@
           }
         },
         {
+          "description": "Contains statistics about the query cache of selected nodes.",
           "name": "query_cache",
           "required": true,
           "type": {
@@ -34391,6 +34424,7 @@
           }
         },
         {
+          "description": "Contains statistics about segments in selected nodes.",
           "name": "segments",
           "required": true,
           "type": {
@@ -34402,6 +34436,7 @@
           }
         },
         {
+          "description": "Contains statistics about indices with shards assigned to selected nodes.",
           "name": "shards",
           "required": true,
           "type": {
@@ -34413,6 +34448,7 @@
           }
         },
         {
+          "description": "Contains statistics about the size of shards assigned to selected nodes.",
           "name": "store",
           "required": true,
           "type": {
@@ -34424,6 +34460,8 @@
           }
         },
         {
+          "description": "Contains statistics about field mappings in selected nodes.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html",
           "name": "mappings",
           "required": true,
           "type": {
@@ -34435,6 +34473,8 @@
           }
         },
         {
+          "description": "Contains statistics about analyzers and analyzer components used in selected nodes.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analyzer-anatomy.html",
           "name": "analysis",
           "required": true,
           "type": {
@@ -34506,6 +34546,27 @@
               "type": {
                 "name": "long",
                 "namespace": "_types"
+              }
+            }
+          }
+        },
+        {
+          "name": "shard_data_set_sizes",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
               }
             }
           }
@@ -34983,6 +35044,7 @@
       },
       "properties": [
         {
+          "description": "Contains counts for nodes selected by the request’s node filters.",
           "name": "count",
           "required": true,
           "type": {
@@ -34994,6 +35056,8 @@
           }
         },
         {
+          "description": "Contains statistics about the discovery types used by selected nodes.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-hosts-providers.html",
           "name": "discovery_types",
           "required": true,
           "type": {
@@ -35015,6 +35079,7 @@
           }
         },
         {
+          "description": "Contains statistics about file stores by selected nodes.",
           "name": "fs",
           "required": true,
           "type": {
@@ -35037,6 +35102,7 @@
           }
         },
         {
+          "description": "Contains statistics about the Java Virtual Machines (JVMs) used by selected nodes.",
           "name": "jvm",
           "required": true,
           "type": {
@@ -35048,6 +35114,7 @@
           }
         },
         {
+          "description": "Contains statistics about the transport and HTTP networks used by selected nodes.",
           "name": "network_types",
           "required": true,
           "type": {
@@ -35059,6 +35126,7 @@
           }
         },
         {
+          "description": "Contains statistics about the operating systems used by selected nodes.",
           "name": "os",
           "required": true,
           "type": {
@@ -35070,6 +35138,7 @@
           }
         },
         {
+          "description": "Contains statistics about Elasticsearch distributions installed on selected nodes.",
           "name": "packaging_types",
           "required": true,
           "type": {
@@ -35084,6 +35153,7 @@
           }
         },
         {
+          "description": "Contains statistics about installed plugins and modules by selected nodes.",
           "name": "plugins",
           "required": true,
           "type": {
@@ -35098,6 +35168,7 @@
           }
         },
         {
+          "description": "Contains statistics about processes used by selected nodes.",
           "name": "process",
           "required": true,
           "type": {
@@ -35109,6 +35180,7 @@
           }
         },
         {
+          "description": "Array of Elasticsearch versions used on selected nodes.",
           "name": "versions",
           "required": true,
           "type": {
@@ -35116,8 +35188,8 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "VersionString",
+                "namespace": "_types"
               }
             }
           }
@@ -38137,6 +38209,7 @@
           }
         },
         {
+          "description": "Period to wait for each node to respond. If a node does not respond before its timeout expires, the response does not include its stats. However, timed out nodes are included in the response’s _nodes.failed property. Defaults to no timeout.",
           "name": "timeout",
           "required": false,
           "type": {
@@ -38163,17 +38236,8 @@
       },
       "properties": [
         {
-          "name": "_nodes",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "NodeStatistics",
-              "namespace": "nodes._types"
-            }
-          }
-        },
-        {
+          "description": "Name of the cluster, based on the Cluster name setting setting.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name",
           "name": "cluster_name",
           "required": true,
           "type": {
@@ -38185,6 +38249,7 @@
           }
         },
         {
+          "description": "Unique identifier for the cluster.",
           "name": "cluster_uuid",
           "required": true,
           "type": {
@@ -38196,6 +38261,7 @@
           }
         },
         {
+          "description": "Contains statistics about indices with shards assigned to selected nodes.",
           "name": "indices",
           "required": true,
           "type": {
@@ -38207,6 +38273,8 @@
           }
         },
         {
+          "description": "Contains statistics about nodes selected by the request’s node filters.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes",
           "name": "nodes",
           "required": true,
           "type": {
@@ -38218,6 +38286,7 @@
           }
         },
         {
+          "description": "Health status of the cluster, based on the state of its primary and replica shards.",
           "name": "status",
           "required": true,
           "type": {
@@ -38229,6 +38298,8 @@
           }
         },
         {
+          "description": "Unix timestamp, in milliseconds, of the last time the cluster statistics were refreshed.",
+          "docUrl": "https://en.wikipedia.org/wiki/Unix_time",
           "name": "timestamp",
           "required": true,
           "type": {
@@ -38245,12 +38316,15 @@
       "kind": "enum",
       "members": [
         {
+          "description": "All shards are assigned.",
           "name": "green"
         },
         {
+          "description": "All primary shards are assigned, but one or more replica shards are unassigned. If a node in the cluster fails, some data could be unavailable until that node is repaired.",
           "name": "yellow"
         },
         {
+          "description": "One or more primary shards are unassigned, so some data is unavailable. This can occur briefly during cluster startup as primary shards are assigned.",
           "name": "red"
         }
       ],
@@ -52451,6 +52525,18 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "name": "script_count",
+          "required": false,
+          "since": "7.13.0",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
         }
       ]
     },
@@ -57499,6 +57585,7 @@
       ],
       "query": [
         {
+          "description": "Specifies the node or shard the operation should be performed on. Random by default.",
           "name": "preference",
           "required": false,
           "type": {
@@ -57510,8 +57597,11 @@
           }
         },
         {
+          "description": " Boolean) If true, the request is real-time as opposed to near-real-time.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#realtime",
           "name": "realtime",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -57521,8 +57611,10 @@
           }
         },
         {
+          "description": " If true, Elasticsearch refreshes the affected shards to make this operation visible to search. If false, do nothing with refreshes.",
           "name": "refresh",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -57532,6 +57624,8 @@
           }
         },
         {
+          "description": "Target the specified primary shard.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#get-routing",
           "name": "routing",
           "required": false,
           "type": {
@@ -57554,6 +57648,7 @@
           }
         },
         {
+          "description": "A comma-separated list of source fields to exclude in the response.",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -57565,6 +57660,7 @@
           }
         },
         {
+          "description": "A comma-separated list of source fields to include in the response.",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -57587,6 +57683,7 @@
           }
         },
         {
+          "description": "Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.",
           "name": "version",
           "required": false,
           "type": {
@@ -57598,6 +57695,7 @@
           }
         },
         {
+          "description": "Specific version type: internal, external, external_gte.",
           "name": "version_type",
           "required": false,
           "type": {
@@ -57609,6 +57707,7 @@
           }
         },
         {
+          "description": "True or false to return the _source field or not, or a list of fields to return.",
           "name": "_source",
           "required": false,
           "type": {
@@ -57747,8 +57846,9 @@
           }
         },
         {
+          "description": "deprecated since 7.0.0",
           "name": "_type",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -67175,6 +67275,18 @@
         {
           "name": "hidden",
           "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "system",
+          "required": false,
+          "since": "7.10.0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -89163,8 +89275,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "Name",
+              "namespace": "_types"
             }
           }
         },
@@ -90624,17 +90736,6 @@
       },
       "properties": [
         {
-          "name": "failed",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
           "name": "failures",
           "required": false,
           "type": {
@@ -90649,6 +90750,19 @@
           }
         },
         {
+          "description": "Total number of nodes selected by the request.",
+          "name": "total",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Number of nodes that responded successfully to the request.",
           "name": "successful",
           "required": true,
           "type": {
@@ -90660,7 +90774,8 @@
           }
         },
         {
-          "name": "total",
+          "description": "Number of nodes that rejected the request or failed to respond. If this value is not 0, a reason for the rejection or failure is included in the response.",
+          "name": "failed",
           "required": true,
           "type": {
             "kind": "instance_of",
@@ -91313,6 +91428,8 @@
       },
       "properties": [
         {
+          "description": "Contains statistics about the number of nodes selected by the request’s node filters.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes",
           "name": "_nodes",
           "required": true,
           "type": {
@@ -103022,8 +103139,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "Id",
+              "namespace": "_types"
             }
           }
         },
@@ -106465,8 +106582,11 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "Period to retain the search context for scrolling.",
+            "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results",
             "name": "scroll",
             "required": false,
+            "serverDefault": "1d",
             "type": {
               "kind": "instance_of",
               "type": {
@@ -106476,8 +106596,9 @@
             }
           },
           {
+            "description": "Scroll ID of the search.",
             "name": "scroll_id",
-            "required": false,
+            "required": true,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -106487,8 +106608,10 @@
             }
           },
           {
+            "description": "If true, the API response’s hit.total property is returned as an integer. If false, the API response’s hit.total property is returned as an object.",
             "name": "rest_total_hits_as_int",
             "required": false,
+            "serverDefault": false,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -106526,8 +106649,11 @@
       ],
       "query": [
         {
+          "description": "Period to retain the search context for scrolling.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results",
           "name": "scroll",
           "required": false,
+          "serverDefault": "1d",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -106537,6 +106663,7 @@
           }
         },
         {
+          "description": "Deprecated with 7.0.0",
           "name": "scroll_id",
           "required": false,
           "type": {
@@ -106548,8 +106675,10 @@
           }
         },
         {
+          "description": "If true, the API response’s hit.total property is returned as an integer. If false, the API response’s hit.total property is returned as an object.",
           "name": "rest_total_hits_as_int",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -106598,84 +106727,7 @@
         "name": "ScrollResponse",
         "namespace": "_global.scroll"
       },
-      "properties": [
-        {
-          "name": "failed_shards",
-          "required": false,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "ScrollResponseFailedShard",
-                "namespace": "_global.scroll"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ScrollResponseErrorReason",
-        "namespace": "_global.scroll"
-      },
-      "properties": [
-        {
-          "name": "type",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "reason",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ScrollResponseFailedShard",
-        "namespace": "_global.scroll"
-      },
-      "properties": [
-        {
-          "name": "shard",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "reason",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ScrollResponseErrorReason",
-              "namespace": "_global.scroll"
-            }
-          }
-        }
-      ]
+      "properties": []
     },
     {
       "inherits": {
@@ -113825,8 +113877,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "IndexName",
+              "namespace": "_types"
             }
           }
         },
@@ -120294,8 +120346,8 @@
       ],
       "inherits": {
         "type": {
-          "name": "RequestBase",
-          "namespace": "_types"
+          "name": "GetRequest",
+          "namespace": "_global.get"
         }
       },
       "kind": "request",
@@ -120303,145 +120355,8 @@
         "name": "SourceRequest",
         "namespace": "_global.get_source"
       },
-      "path": [
-        {
-          "description": "The document ID",
-          "name": "id",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Id",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "The name of the index",
-          "name": "index",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "IndexName",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "The type of the document; deprecated and optional starting with 7.0",
-          "name": "type",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Type",
-              "namespace": "_types"
-            }
-          }
-        }
-      ],
-      "query": [
-        {
-          "name": "preference",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "realtime",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "refresh",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "routing",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Routing",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "source_enabled",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "_source_excludes",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Fields",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "_source_includes",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Fields",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "version",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "VersionNumber",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "version_type",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "VersionType",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
+      "path": [],
+      "query": []
     },
     {
       "generics": [
@@ -120451,8 +120366,20 @@
         }
       ],
       "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "Field",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "user_defined_value"
+          }
+        ],
         "type": {
-          "name": "ResponseBase",
+          "name": "DictionaryResponseBase",
           "namespace": "_types"
         }
       },
@@ -120461,19 +120388,7 @@
         "name": "SourceResponse",
         "namespace": "_global.get_source"
       },
-      "properties": [
-        {
-          "name": "body",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "TDocument",
-              "namespace": "_global.get_source"
-            }
-          }
-        }
-      ]
+      "properties": []
     },
     {
       "inherits": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -12112,14 +12112,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AcknowledgedResponseBase",
@@ -12614,14 +12612,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AdjacencyMatrixAggregation",
@@ -14678,14 +14674,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AnalyticsUsage",
@@ -15686,14 +15680,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AppendProcessor",
@@ -16004,14 +15996,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AsciiFoldingTokenFilter",
@@ -16251,14 +16241,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "AsyncSearchDeleteRequest",
@@ -16281,14 +16269,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AsyncSearchDeleteResponse",
@@ -16303,14 +16289,12 @@
           "namespace": "async_search._types"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "AsyncSearchResponseBase",
-            "namespace": "async_search._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AsyncSearchResponseBase",
+          "namespace": "async_search._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AsyncSearchDocumentResponseBase",
@@ -16343,14 +16327,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "AsyncSearchGetRequest",
@@ -16413,23 +16395,21 @@
           "namespace": "async_search.get"
         }
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TDocument",
-                "namespace": "async_search.get"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "async_search.get"
             }
-          ],
-          "type": {
-            "name": "AsyncSearchDocumentResponseBase",
-            "namespace": "async_search._types"
           }
+        ],
+        "type": {
+          "name": "AsyncSearchDocumentResponseBase",
+          "namespace": "async_search._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AsyncSearchGetResponse",
@@ -16438,14 +16418,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AsyncSearchResponseBase",
@@ -16513,14 +16491,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "AsyncSearchStatusRequest",
@@ -16549,14 +16525,12 @@
           "namespace": "async_search.status"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "AsyncSearchResponseBase",
-            "namespace": "async_search._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AsyncSearchResponseBase",
+          "namespace": "async_search._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AsyncSearchStatusResponse",
@@ -17254,14 +17228,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "AsyncSearchSubmitRequest",
@@ -17335,23 +17307,21 @@
           "namespace": "async_search.submit"
         }
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TDocument",
-                "namespace": "async_search.submit"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "async_search.submit"
             }
-          ],
-          "type": {
-            "name": "AsyncSearchDocumentResponseBase",
-            "namespace": "async_search._types"
           }
+        ],
+        "type": {
+          "name": "AsyncSearchDocumentResponseBase",
+          "namespace": "async_search._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AsyncSearchSubmitResponse",
@@ -17360,14 +17330,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AttachmentProcessor",
@@ -17457,14 +17425,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "SecurityFeatureToggle",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "SecurityFeatureToggle",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AuditUsage",
@@ -17488,14 +17454,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUser",
-            "namespace": "security._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUser",
+          "namespace": "security._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AuthenticatedUser",
@@ -17580,32 +17544,30 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "generics": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "long",
-                    "namespace": "_types"
-                  }
+      "inherits": {
+        "generics": [
+          {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "long",
+                  "namespace": "_types"
                 }
-              ],
-              "kind": "instance_of",
-              "type": {
-                "name": "KeyedBucket",
-                "namespace": "_types.aggregations"
               }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "KeyedBucket",
+              "namespace": "_types.aggregations"
             }
-          ],
-          "type": {
-            "name": "MultiBucketAggregate",
-            "namespace": "_types.aggregations"
           }
+        ],
+        "type": {
+          "name": "MultiBucketAggregate",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AutoDateHistogramAggregate",
@@ -17626,14 +17588,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AutoDateHistogramAggregation",
@@ -17885,14 +17845,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AverageAggregation",
@@ -17901,14 +17859,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "AverageBucketAggregation",
@@ -18036,14 +17992,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BinaryProperty",
@@ -18061,14 +18015,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BoolQuery",
@@ -18193,14 +18145,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BooleanProperty",
@@ -18262,14 +18212,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BoostingQuery",
@@ -18372,14 +18320,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BoxPlotAggregate",
@@ -18444,14 +18390,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BoxplotAggregation",
@@ -18630,14 +18574,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BucketAggregate",
@@ -18730,14 +18672,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "Aggregation",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "Aggregation",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BucketAggregationBase",
@@ -18887,14 +18827,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BucketScriptAggregation",
@@ -18915,14 +18853,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BucketSelectorAggregation",
@@ -18943,14 +18879,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "Aggregation",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "Aggregation",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BucketSortAggregation",
@@ -19012,14 +18946,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BulkOperation",
-            "namespace": "_global.bulk"
-          }
+      "inherits": {
+        "type": {
+          "name": "BulkOperation",
+          "namespace": "_global.bulk"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkCreateOperation",
@@ -19028,14 +18960,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BulkResponseItemBase",
-            "namespace": "_global.bulk"
-          }
+      "inherits": {
+        "type": {
+          "name": "BulkResponseItemBase",
+          "namespace": "_global.bulk"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkCreateResponseItem",
@@ -19044,14 +18974,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BulkOperation",
-            "namespace": "_global.bulk"
-          }
+      "inherits": {
+        "type": {
+          "name": "BulkOperation",
+          "namespace": "_global.bulk"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkDeleteOperation",
@@ -19060,14 +18988,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BulkResponseItemBase",
-            "namespace": "_global.bulk"
-          }
+      "inherits": {
+        "type": {
+          "name": "BulkResponseItemBase",
+          "namespace": "_global.bulk"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkDeleteResponseItem",
@@ -19099,8 +19025,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "Id",
-              "namespace": "_types"
+              "name": "string",
+              "namespace": "internal"
             }
           }
         },
@@ -19110,8 +19036,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "IndexName",
-              "namespace": "_types"
+              "name": "string",
+              "namespace": "internal"
             }
           }
         },
@@ -19140,14 +19066,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BulkOperation",
-            "namespace": "_global.bulk"
-          }
+      "inherits": {
+        "type": {
+          "name": "BulkOperation",
+          "namespace": "_global.bulk"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkIndexOperation",
@@ -19156,14 +19080,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BulkResponseItemBase",
-            "namespace": "_global.bulk"
-          }
+      "inherits": {
+        "type": {
+          "name": "BulkResponseItemBase",
+          "namespace": "_global.bulk"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkIndexResponseItem",
@@ -19191,14 +19113,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "BulkMonitoringRequest",
@@ -19232,14 +19152,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkMonitoringResponse",
@@ -19422,14 +19340,12 @@
           "namespace": "_global.bulk"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "BulkRequest",
@@ -19587,14 +19503,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkResponse",
@@ -19980,14 +19894,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BulkOperation",
-            "namespace": "_global.bulk"
-          }
+      "inherits": {
+        "type": {
+          "name": "BulkOperation",
+          "namespace": "_global.bulk"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkUpdateOperation",
@@ -19996,14 +19908,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BulkResponseItemBase",
-            "namespace": "_global.bulk"
-          }
+      "inherits": {
+        "type": {
+          "name": "BulkResponseItemBase",
+          "namespace": "_global.bulk"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BulkUpdateResponseItem",
@@ -20081,14 +19991,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "BytesProcessor",
@@ -20265,14 +20173,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CancelTasksRequest",
@@ -20358,14 +20264,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CancelTasksResponse",
@@ -20410,14 +20314,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CardinalityAggregation",
@@ -20557,14 +20459,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatAliasesRequest",
@@ -20602,23 +20502,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatAliasesRecord",
-                "namespace": "cat.cat_aliases"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatAliasesRecord",
+              "namespace": "cat.cat_aliases"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatAliasesResponse",
@@ -20777,14 +20675,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatAllocationRequest",
@@ -20822,23 +20718,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatAllocationRecord",
-                "namespace": "cat.cat_allocation"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatAllocationRecord",
+              "namespace": "cat.cat_allocation"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatAllocationResponse",
@@ -20910,14 +20804,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatCountRequest",
@@ -20943,23 +20835,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatCountRecord",
-                "namespace": "cat.cat_count"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatCountRecord",
+              "namespace": "cat.cat_count"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatCountResponse",
@@ -21228,14 +21118,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatDataFrameAnalyticsRequest",
@@ -21284,23 +21172,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatDataFrameAnalyticsRecord",
-                "namespace": "cat.cat_data_frame_analytics"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatDataFrameAnalyticsRecord",
+              "namespace": "cat.cat_data_frame_analytics"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatDataFrameAnalyticsResponse",
@@ -21508,14 +21394,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatDatafeedsRequest",
@@ -21553,23 +21437,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatDatafeedsRecord",
-                "namespace": "cat.cat_datafeeds"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatDatafeedsRecord",
+              "namespace": "cat.cat_datafeeds"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatDatafeedsResponse",
@@ -21672,14 +21554,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatFielddataRequest",
@@ -21717,23 +21597,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatFielddataRecord",
-                "namespace": "cat.cat_fielddata"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatFielddataRecord",
+              "namespace": "cat.cat_fielddata"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatFielddataResponse",
@@ -21983,14 +21861,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatHealthRequest",
@@ -22026,23 +21902,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatHealthRecord",
-                "namespace": "cat.cat_health"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatHealthRecord",
+              "namespace": "cat.cat_health"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatHealthResponse",
@@ -22075,14 +21949,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatHelpRequest",
@@ -22095,23 +21967,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatHelpRecord",
-                "namespace": "cat.cat_help"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatHelpRecord",
+              "namespace": "cat.cat_help"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatHelpResponse",
@@ -24123,14 +23993,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatIndicesRequest",
@@ -24212,23 +24080,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatIndicesRecord",
-                "namespace": "cat.cat_indices"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatIndicesRecord",
+              "namespace": "cat.cat_indices"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatIndicesResponse",
@@ -25202,14 +25068,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatJobsRequest",
@@ -25258,23 +25122,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatJobsRecord",
-                "namespace": "cat.cat_jobs"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatJobsRecord",
+              "namespace": "cat.cat_jobs"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatJobsResponse",
@@ -25350,14 +25212,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatMasterRequest",
@@ -25370,23 +25230,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatMasterRecord",
-                "namespace": "cat.cat_master"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatMasterRecord",
+              "namespace": "cat.cat_master"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatMasterResponse",
@@ -25510,14 +25368,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatNodeAttributesRequest",
@@ -25530,23 +25386,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatNodeAttributesRecord",
-                "namespace": "cat.cat_node_attributes"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatNodeAttributesRecord",
+              "namespace": "cat.cat_node_attributes"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatNodeAttributesResponse",
@@ -27073,14 +26927,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatNodesRequest",
@@ -27128,23 +26980,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatNodesRecord",
-                "namespace": "cat.cat_nodes"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatNodesRecord",
+              "namespace": "cat.cat_nodes"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatNodesResponse",
@@ -27226,14 +27076,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatPendingTasksRequest",
@@ -27246,23 +27094,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatPendingTasksRecord",
-                "namespace": "cat.cat_pending_tasks"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatPendingTasksRecord",
+              "namespace": "cat.cat_pending_tasks"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatPendingTasksResponse",
@@ -27371,14 +27217,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatPluginsRequest",
@@ -27391,23 +27235,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatPluginsRecord",
-                "namespace": "cat.cat_plugins"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatPluginsRecord",
+              "namespace": "cat.cat_plugins"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatPluginsResponse",
@@ -27822,14 +27664,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatRecoveryRequest",
@@ -27889,23 +27729,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatRecoveryRecord",
-                "namespace": "cat.cat_recovery"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatRecoveryRecord",
+              "namespace": "cat.cat_recovery"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatRecoveryResponse",
@@ -27957,14 +27795,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatRepositoriesRequest",
@@ -27977,23 +27813,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatRepositoriesRecord",
-                "namespace": "cat.cat_repositories"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatRepositoriesRecord",
+              "namespace": "cat.cat_repositories"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatRepositoriesResponse",
@@ -28014,14 +27848,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatRequestBase",
@@ -28056,14 +27888,12 @@
           "namespace": "cat._types"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatResponseBase",
@@ -28315,14 +28145,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatSegmentsRequest",
@@ -28360,23 +28188,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatSegmentsRecord",
-                "namespace": "cat.cat_segments"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatSegmentsRecord",
+              "namespace": "cat.cat_segments"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatSegmentsResponse",
@@ -29587,14 +29413,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatShardsRequest",
@@ -29632,23 +29456,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatShardsRecord",
-                "namespace": "cat.cat_shards"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatShardsRecord",
+              "namespace": "cat.cat_shards"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatShardsResponse",
@@ -29870,14 +29692,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatSnapshotsRequest",
@@ -29915,23 +29735,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatSnapshotsRecord",
-                "namespace": "cat.cat_snapshots"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatSnapshotsRecord",
+              "namespace": "cat.cat_snapshots"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatSnapshotsResponse",
@@ -30189,14 +30007,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatTasksRequest",
@@ -30260,23 +30076,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatTasksRecord",
-                "namespace": "cat.cat_tasks"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatTasksRecord",
+              "namespace": "cat.cat_tasks"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatTasksResponse",
@@ -30374,14 +30188,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatTemplatesRequest",
@@ -30407,23 +30219,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatTemplatesRecord",
-                "namespace": "cat.cat_templates"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatTemplatesRecord",
+              "namespace": "cat.cat_templates"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatTemplatesResponse",
@@ -30745,14 +30555,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatThreadPoolRequest",
@@ -30802,23 +30610,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatThreadPoolRecord",
-                "namespace": "cat.cat_thread_pool"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatThreadPoolRecord",
+              "namespace": "cat.cat_thread_pool"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatThreadPoolResponse",
@@ -31104,14 +30910,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatTrainedModelsRequest",
@@ -31182,23 +30986,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatTrainedModelsRecord",
-                "namespace": "cat.cat_trained_models"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatTrainedModelsRecord",
+              "namespace": "cat.cat_trained_models"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatTrainedModelsResponse",
@@ -31719,14 +31521,12 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "CatRequestBase",
-            "namespace": "cat._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CatRequestBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CatTransformsRequest",
@@ -31786,23 +31586,21 @@
       "attachedBehaviors": [
         "ArrayResponseBase"
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "CatTransformsRecord",
-                "namespace": "cat.cat_transforms"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CatTransformsRecord",
+              "namespace": "cat.cat_transforms"
             }
-          ],
-          "type": {
-            "name": "CatResponseBase",
-            "namespace": "cat._types"
           }
+        ],
+        "type": {
+          "name": "CatResponseBase",
+          "namespace": "cat._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CatTransformsResponse",
@@ -32083,14 +31881,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CcrStatsRequest",
@@ -32100,14 +31896,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CcrStatsResponse",
@@ -32139,14 +31933,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CcrUsage",
@@ -32443,14 +32235,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CharGroupTokenizer",
@@ -32529,14 +32319,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ChildrenAggregation",
@@ -32607,14 +32395,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CircleProcessor",
@@ -32724,14 +32510,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CleanupRepositoryRequest",
@@ -32777,14 +32561,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CleanupRepositoryResponse",
@@ -32895,14 +32677,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClearScrollRequest",
@@ -32925,14 +32705,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClearScrollResponse",
@@ -32960,14 +32738,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClearSqlCursorRequest",
@@ -32977,14 +32753,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClearSqlCursorResponse",
@@ -33065,14 +32839,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClosePointInTimeRequest",
@@ -33082,14 +32854,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClosePointInTimeResponse",
@@ -33151,19 +32921,6 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "Specifies the node ID or the name of the node to only explain a shard that is currently located on the specified node.",
-            "name": "current_node",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "description": "Specifies the name of the index that you would like an explanation for.",
             "name": "index",
             "required": false,
             "type": {
@@ -33175,7 +32932,6 @@
             }
           },
           {
-            "description": "If true, returns explanation for the primary shard for the given shard ID.",
             "name": "primary",
             "required": false,
             "type": {
@@ -33187,7 +32943,6 @@
             }
           },
           {
-            "description": "Specifies the ID of the shard that you would like an explanation for.",
             "name": "shard",
             "required": false,
             "type": {
@@ -33200,14 +32955,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterAllocationExplainRequest",
@@ -33216,10 +32969,8 @@
       "path": [],
       "query": [
         {
-          "description": "If true, returns information about disk usage and shard sizes.",
           "name": "include_disk_info",
           "required": false,
-          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -33229,10 +32980,8 @@
           }
         },
         {
-          "description": "If true, returns YES decisions in explanation.",
           "name": "include_yes_decisions",
           "required": false,
-          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -33244,14 +32993,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterAllocationExplainResponse",
@@ -33435,8 +33182,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "IndexName",
-              "namespace": "_types"
+              "name": "string",
+              "namespace": "internal"
             }
           }
         },
@@ -33639,14 +33386,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterComponentTemplateExistsRequest",
@@ -33680,14 +33425,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterComponentTemplateExistsResponse",
@@ -33711,14 +33454,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterDeleteComponentTemplateRequest",
@@ -33766,14 +33507,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterDeleteComponentTemplateResponse",
@@ -33801,14 +33540,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterDeleteVotingConfigExclusionsRequest",
@@ -33818,14 +33555,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterDeleteVotingConfigExclusionsResponse",
@@ -33891,14 +33626,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterGetComponentTemplateRequest",
@@ -33958,14 +33691,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterGetComponentTemplateResponse",
@@ -33992,14 +33723,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterGetSettingsRequest",
@@ -34054,14 +33783,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterGetSettingsResponse",
@@ -34125,14 +33852,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterHealthRequest",
@@ -34295,14 +34020,12 @@
     },
     {
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html#cluster-health-api-response-body",
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterHealthResponse",
@@ -34518,7 +34241,6 @@
       },
       "properties": [
         {
-          "description": "Contains statistics about the number of primary shards assigned to selected nodes.",
           "name": "primaries",
           "required": true,
           "type": {
@@ -34530,7 +34252,6 @@
           }
         },
         {
-          "description": "Contains statistics about the number of replication shards assigned to selected nodes.",
           "name": "replication",
           "required": true,
           "type": {
@@ -34542,7 +34263,6 @@
           }
         },
         {
-          "description": "Contains statistics about the number of shards assigned to selected nodes.",
           "name": "shards",
           "required": true,
           "type": {
@@ -34556,7 +34276,6 @@
       ]
     },
     {
-      "description": "Contains statistics about shards assigned to selected nodes.",
       "kind": "interface",
       "name": {
         "name": "ClusterIndicesShardsStats",
@@ -34564,7 +34283,6 @@
       },
       "properties": [
         {
-          "description": "Contains statistics about shards assigned to selected nodes.",
           "name": "index",
           "required": false,
           "type": {
@@ -34576,7 +34294,6 @@
           }
         },
         {
-          "description": "Number of primary shards assigned to selected nodes.",
           "name": "primaries",
           "required": false,
           "type": {
@@ -34588,7 +34305,6 @@
           }
         },
         {
-          "description": "Ratio of replica shards to primary shards across all selected nodes.",
           "name": "replication",
           "required": false,
           "type": {
@@ -34600,7 +34316,6 @@
           }
         },
         {
-          "description": "Total number of shards assigned to selected nodes.",
           "name": "total",
           "required": false,
           "type": {
@@ -34621,7 +34336,6 @@
       },
       "properties": [
         {
-          "description": "Contains statistics about memory used for completion in selected nodes.",
           "name": "completion",
           "required": true,
           "type": {
@@ -34633,7 +34347,6 @@
           }
         },
         {
-          "description": "Total number of indices with shards assigned to selected nodes.",
           "name": "count",
           "required": true,
           "type": {
@@ -34645,7 +34358,6 @@
           }
         },
         {
-          "description": "Contains counts for documents in selected nodes.",
           "name": "docs",
           "required": true,
           "type": {
@@ -34657,8 +34369,6 @@
           }
         },
         {
-          "description": "Contains statistics about the field data cache of selected nodes.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-fielddata.html",
           "name": "fielddata",
           "required": true,
           "type": {
@@ -34670,7 +34380,6 @@
           }
         },
         {
-          "description": "Contains statistics about the query cache of selected nodes.",
           "name": "query_cache",
           "required": true,
           "type": {
@@ -34682,7 +34391,6 @@
           }
         },
         {
-          "description": "Contains statistics about segments in selected nodes.",
           "name": "segments",
           "required": true,
           "type": {
@@ -34694,7 +34402,6 @@
           }
         },
         {
-          "description": "Contains statistics about indices with shards assigned to selected nodes.",
           "name": "shards",
           "required": true,
           "type": {
@@ -34706,7 +34413,6 @@
           }
         },
         {
-          "description": "Contains statistics about the size of shards assigned to selected nodes.",
           "name": "store",
           "required": true,
           "type": {
@@ -34718,8 +34424,6 @@
           }
         },
         {
-          "description": "Contains statistics about field mappings in selected nodes.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html",
           "name": "mappings",
           "required": true,
           "type": {
@@ -34731,8 +34435,6 @@
           }
         },
         {
-          "description": "Contains statistics about analyzers and analyzer components used in selected nodes.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analyzer-anatomy.html",
           "name": "analysis",
           "required": true,
           "type": {
@@ -34804,27 +34506,6 @@
               "type": {
                 "name": "long",
                 "namespace": "_types"
-              }
-            }
-          }
-        },
-        {
-          "name": "shard_data_set_sizes",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
               }
             }
           }
@@ -35302,7 +34983,6 @@
       },
       "properties": [
         {
-          "description": "Contains counts for nodes selected by the request’s node filters.",
           "name": "count",
           "required": true,
           "type": {
@@ -35314,8 +34994,6 @@
           }
         },
         {
-          "description": "Contains statistics about the discovery types used by selected nodes.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-hosts-providers.html",
           "name": "discovery_types",
           "required": true,
           "type": {
@@ -35337,7 +35015,6 @@
           }
         },
         {
-          "description": "Contains statistics about file stores by selected nodes.",
           "name": "fs",
           "required": true,
           "type": {
@@ -35360,7 +35037,6 @@
           }
         },
         {
-          "description": "Contains statistics about the Java Virtual Machines (JVMs) used by selected nodes.",
           "name": "jvm",
           "required": true,
           "type": {
@@ -35372,7 +35048,6 @@
           }
         },
         {
-          "description": "Contains statistics about the transport and HTTP networks used by selected nodes.",
           "name": "network_types",
           "required": true,
           "type": {
@@ -35384,7 +35059,6 @@
           }
         },
         {
-          "description": "Contains statistics about the operating systems used by selected nodes.",
           "name": "os",
           "required": true,
           "type": {
@@ -35396,7 +35070,6 @@
           }
         },
         {
-          "description": "Contains statistics about Elasticsearch distributions installed on selected nodes.",
           "name": "packaging_types",
           "required": true,
           "type": {
@@ -35411,7 +35084,6 @@
           }
         },
         {
-          "description": "Contains statistics about installed plugins and modules by selected nodes.",
           "name": "plugins",
           "required": true,
           "type": {
@@ -35426,7 +35098,6 @@
           }
         },
         {
-          "description": "Contains statistics about processes used by selected nodes.",
           "name": "process",
           "required": true,
           "type": {
@@ -35438,7 +35109,6 @@
           }
         },
         {
-          "description": "Array of Elasticsearch versions used on selected nodes.",
           "name": "versions",
           "required": true,
           "type": {
@@ -35446,8 +35116,8 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "VersionString",
-                "namespace": "_types"
+                "name": "string",
+                "namespace": "internal"
               }
             }
           }
@@ -35635,14 +35305,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterPendingTasksRequest",
@@ -35676,14 +35344,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterPendingTasksResponse",
@@ -35710,14 +35376,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterPostVotingConfigExclusionsRequest",
@@ -35774,14 +35438,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterPostVotingConfigExclusionsResponse",
@@ -36032,14 +35694,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterPutComponentTemplateRequest",
@@ -36087,14 +35747,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterPutComponentTemplateResponse",
@@ -36145,14 +35803,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterPutSettingsRequest",
@@ -36198,14 +35854,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterPutSettingsResponse",
@@ -36357,14 +36011,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterRemoteInfoRequest",
@@ -36374,30 +36026,28 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "ClusterRemoteInfo",
-                "namespace": "cluster.cluster_remote_info"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "ClusterRemoteInfo",
+              "namespace": "cluster.cluster_remote_info"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterRemoteInfoResponse",
@@ -36866,14 +36516,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterRerouteRequest",
@@ -36962,14 +36610,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterRerouteResponse",
@@ -38023,14 +37669,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterStateRequest",
@@ -38159,14 +37803,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterStateResponse",
@@ -38457,14 +38099,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ClusterStatsRequest",
@@ -38497,7 +38137,6 @@
           }
         },
         {
-          "description": "Period to wait for each node to respond. If a node does not respond before its timeout expires, the response does not include its stats. However, timed out nodes are included in the response’s _nodes.failed property. Defaults to no timeout.",
           "name": "timeout",
           "required": false,
           "type": {
@@ -38511,14 +38150,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "NodesResponseBase",
-            "namespace": "nodes._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "NodesResponseBase",
+          "namespace": "nodes._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ClusterStatsResponse",
@@ -38526,8 +38163,17 @@
       },
       "properties": [
         {
-          "description": "Name of the cluster, based on the Cluster name setting setting.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name",
+          "name": "_nodes",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "NodeStatistics",
+              "namespace": "nodes._types"
+            }
+          }
+        },
+        {
           "name": "cluster_name",
           "required": true,
           "type": {
@@ -38539,7 +38185,6 @@
           }
         },
         {
-          "description": "Unique identifier for the cluster.",
           "name": "cluster_uuid",
           "required": true,
           "type": {
@@ -38551,7 +38196,6 @@
           }
         },
         {
-          "description": "Contains statistics about indices with shards assigned to selected nodes.",
           "name": "indices",
           "required": true,
           "type": {
@@ -38563,8 +38207,6 @@
           }
         },
         {
-          "description": "Contains statistics about nodes selected by the request’s node filters.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes",
           "name": "nodes",
           "required": true,
           "type": {
@@ -38576,7 +38218,6 @@
           }
         },
         {
-          "description": "Health status of the cluster, based on the state of its primary and replica shards.",
           "name": "status",
           "required": true,
           "type": {
@@ -38588,8 +38229,6 @@
           }
         },
         {
-          "description": "Unix timestamp, in milliseconds, of the last time the cluster statistics were refreshed.",
-          "docUrl": "https://en.wikipedia.org/wiki/Unix_time",
           "name": "timestamp",
           "required": true,
           "type": {
@@ -38606,15 +38245,12 @@
       "kind": "enum",
       "members": [
         {
-          "description": "All shards are assigned.",
           "name": "green"
         },
         {
-          "description": "All primary shards are assigned, but one or more replica shards are unassigned. If a node in the cluster fails, some data could be unavailable until that node is repaired.",
           "name": "yellow"
         },
         {
-          "description": "One or more primary shards are unassigned, so some data is unavailable. This can occur briefly during cluster startup as primary shards are assigned.",
           "name": "red"
         }
       ],
@@ -38680,14 +38316,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CommonGramsTokenFilter",
@@ -38744,14 +38378,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CommonTermsQuery",
@@ -38951,14 +38583,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CompletionProperty",
@@ -39241,14 +38871,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "SuggesterBase",
-            "namespace": "_global.search.suggesters"
-          }
+      "inherits": {
+        "type": {
+          "name": "SuggesterBase",
+          "namespace": "_global.search.suggesters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CompletionSuggester",
@@ -39512,14 +39140,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CompositeAggregation",
@@ -39692,29 +39318,27 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "value": {
-                "kind": "user_defined_value"
+      "inherits": {
+        "generics": [
+          {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
               }
+            },
+            "kind": "dictionary_of",
+            "value": {
+              "kind": "user_defined_value"
             }
-          ],
-          "type": {
-            "name": "MultiBucketAggregate",
-            "namespace": "_types.aggregations"
           }
+        ],
+        "type": {
+          "name": "MultiBucketAggregate",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CompositeBucketAggregate",
@@ -39741,14 +39365,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CompoundWordTokenFilterBase",
@@ -39926,14 +39548,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ConditionTokenFilter",
@@ -40022,14 +39642,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "PropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ConstantKeywordProperty",
@@ -40054,14 +39672,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ConstantScoreQuery",
@@ -40121,14 +39737,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ConvertProcessor",
@@ -40323,14 +39937,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "PropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CorePropertyBase",
@@ -40392,14 +40004,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CountRequest",
@@ -40600,14 +40210,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CountResponse",
@@ -40779,14 +40387,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CreateFollowIndexRequest",
@@ -40821,14 +40427,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CreateFollowIndexResponse",
@@ -40890,14 +40494,12 @@
           "namespace": "_global.create"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CreateRequest",
@@ -41022,14 +40624,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "WriteResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "WriteResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CreateResponse",
@@ -41115,14 +40715,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "CreateRollupJobRequest",
@@ -41145,14 +40743,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CreateRollupJobResponse",
@@ -41161,14 +40757,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ScheduleBase",
-            "namespace": "watcher._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ScheduleBase",
+          "namespace": "watcher._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CronExpression",
@@ -41177,14 +40771,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CsvProcessor",
@@ -41278,14 +40870,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CumulativeCardinalityAggregation",
@@ -41294,14 +40884,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "CumulativeSumAggregation",
@@ -42031,14 +41619,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DataStreamsUsage",
@@ -42189,14 +41775,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DataTiersUsage",
@@ -42764,14 +42348,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "DecayFunctionBase",
-            "namespace": "_types.query_dsl.compound.function_score.functions"
-          }
+      "inherits": {
+        "type": {
+          "name": "DecayFunctionBase",
+          "namespace": "_types.query_dsl.compound.function_score.functions"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DateDecayFunction",
@@ -42823,14 +42405,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DateHistogramAggregation",
@@ -43199,14 +42779,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DateIndexNameProcessor",
@@ -43369,14 +42947,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DateNanosProperty",
@@ -43460,14 +43036,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DateProcessor",
@@ -43535,14 +43109,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DateProperty",
@@ -43637,14 +43209,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DateRangeAggregation",
@@ -43811,14 +43381,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "RangePropertyBase",
-            "namespace": "_types.mapping.types.core.range"
-          }
+      "inherits": {
+        "type": {
+          "name": "RangePropertyBase",
+          "namespace": "_types.mapping.types.core.range"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DateRangeProperty",
@@ -43931,14 +43499,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeactivateWatchRequest",
@@ -43961,14 +43527,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeactivateWatchResponse",
@@ -44022,14 +43586,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ScoreFunctionBase",
-            "namespace": "_types.query_dsl.compound.function_score.functions"
-          }
+      "inherits": {
+        "type": {
+          "name": "ScoreFunctionBase",
+          "namespace": "_types.query_dsl.compound.function_score.functions"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DecayFunctionBase",
@@ -44226,14 +43788,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteAutoFollowPatternRequest",
@@ -44256,14 +43816,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteAutoFollowPatternResponse",
@@ -44291,14 +43849,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteAutoscalingPolicyRequest",
@@ -44332,14 +43888,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteAutoscalingPolicyResponse",
@@ -44401,14 +43955,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteByQueryRequest",
@@ -44825,14 +44377,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteByQueryResponse",
@@ -45002,14 +44552,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteByQueryRethrottleRequest",
@@ -45044,14 +44592,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ListTasksResponse",
-            "namespace": "task.list_tasks"
-          }
+      "inherits": {
+        "type": {
+          "name": "ListTasksResponse",
+          "namespace": "task.list_tasks"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteByQueryRethrottleResponse",
@@ -45079,14 +44625,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteDanglingIndexRequest",
@@ -45120,14 +44664,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteDanglingIndexResponse",
@@ -45151,14 +44693,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteEnrichPolicyRequest",
@@ -45181,14 +44721,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteEnrichPolicyResponse",
@@ -45200,14 +44738,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteLicenseRequest",
@@ -45217,14 +44753,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteLicenseResponse",
@@ -45236,14 +44770,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteLifecycleRequest",
@@ -45277,14 +44809,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteLifecycleResponse",
@@ -45296,14 +44826,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeletePipelineRequest",
@@ -45349,14 +44877,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeletePipelineResponse",
@@ -45368,14 +44894,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteRequest",
@@ -45511,14 +45035,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "WriteResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "WriteResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteResponse",
@@ -45530,14 +45052,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteRollupJobRequest",
@@ -45560,14 +45080,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteRollupJobResponse",
@@ -45594,14 +45112,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteScriptRequest",
@@ -45647,14 +45163,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteScriptResponse",
@@ -45666,14 +45180,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteSnapshotLifecycleRequest",
@@ -45696,14 +45208,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteSnapshotLifecycleResponse",
@@ -45715,14 +45225,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteTransformRequest",
@@ -45757,14 +45265,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteTransformResponse",
@@ -45776,14 +45282,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeleteWatchRequest",
@@ -45806,14 +45310,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeleteWatchResponse",
@@ -45874,14 +45376,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DelimitedPayloadTokenFilter",
@@ -45969,14 +45469,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DeprecationInfoRequest",
@@ -45999,14 +45497,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DeprecationInfoResponse",
@@ -46103,14 +45599,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DerivativeAggregation",
@@ -46321,14 +45815,12 @@
           "namespace": "_types"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DictionaryResponseBase",
@@ -46467,14 +45959,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DisMaxQuery",
@@ -46669,14 +46159,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DissectProcessor",
@@ -46744,14 +46232,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DistanceFeatureQuery",
@@ -46864,14 +46350,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DiversifiedSamplerAggregation",
@@ -47136,14 +46620,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "CorePropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CorePropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DocValuesPropertyBase",
@@ -47167,14 +46649,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "DocumentExistsRequest",
@@ -47343,14 +46823,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DocumentExistsResponse",
@@ -47496,14 +46974,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DotExpanderProcessor",
@@ -47535,14 +47011,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "RangePropertyBase",
-            "namespace": "_types.mapping.types.core.range"
-          }
+      "inherits": {
+        "type": {
+          "name": "RangePropertyBase",
+          "namespace": "_types.mapping.types.core.range"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DoubleRangeProperty",
@@ -47560,14 +47034,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "DropProcessor",
@@ -47698,14 +47170,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EdgeNGramTokenFilter",
@@ -47748,14 +47218,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EdgeNGramTokenizer",
@@ -47920,14 +47388,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ElisionTokenFilter",
@@ -48273,14 +47739,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EnrichProcessor",
@@ -48370,14 +47834,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "EnrichStatsRequest",
@@ -48387,14 +47849,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EnrichStatsResponse",
@@ -48461,14 +47921,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "EqlDeleteRequest",
@@ -48491,14 +47949,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EqlDeleteResponse",
@@ -48830,14 +48286,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "EqlGetRequest",
@@ -48891,23 +48345,21 @@
           "namespace": "eql.get"
         }
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TEvent",
-                "namespace": "eql.get"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TEvent",
+              "namespace": "eql.get"
             }
-          ],
-          "type": {
-            "name": "EqlSearchResponseBase",
-            "namespace": "eql._types"
           }
+        ],
+        "type": {
+          "name": "EqlSearchResponseBase",
+          "namespace": "eql._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EqlGetResponse",
@@ -48919,14 +48371,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "EqlGetStatusRequest",
@@ -48949,14 +48399,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EqlGetStatusResponse",
@@ -49493,14 +48941,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "EqlSearchRequest",
@@ -49605,23 +49051,21 @@
           "namespace": "eql.search"
         }
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TEvent",
-                "namespace": "eql.search"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TEvent",
+              "namespace": "eql.search"
             }
-          ],
-          "type": {
-            "name": "EqlSearchResponseBase",
-            "namespace": "eql._types"
           }
+        ],
+        "type": {
+          "name": "EqlSearchResponseBase",
+          "namespace": "eql._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EqlSearchResponse",
@@ -49637,14 +49081,12 @@
           "namespace": "eql._types"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EqlSearchResponseBase",
@@ -49735,14 +49177,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "EqlUsage",
@@ -50217,14 +49657,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ExecuteEnrichPolicyRequest",
@@ -50259,14 +49697,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExecuteEnrichPolicyResponse",
@@ -50359,14 +49795,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ExecutePainlessScriptRequest",
@@ -50382,14 +49816,12 @@
           "namespace": "_global.scripts_painless_execute"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExecutePainlessScriptResponse",
@@ -50413,14 +49845,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ExecuteRetentionRequest",
@@ -50430,14 +49860,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExecuteRetentionResponse",
@@ -50449,14 +49877,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ExecuteSnapshotLifecycleRequest",
@@ -50479,14 +49905,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExecuteSnapshotLifecycleResponse",
@@ -50909,14 +50333,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExistsQuery",
@@ -51113,14 +50535,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ExplainLifecycleRequest",
@@ -51166,14 +50586,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExplainLifecycleResponse",
@@ -51235,14 +50653,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ExplainRequest",
@@ -51451,14 +50867,12 @@
           "namespace": "_global.explain"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExplainResponse",
@@ -51670,14 +51084,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MemoryStats",
-            "namespace": "nodes.nodes_stats"
-          }
+      "inherits": {
+        "type": {
+          "name": "MemoryStats",
+          "namespace": "nodes.nodes_stats"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExtendedMemoryStats",
@@ -51709,14 +51121,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "StatsAggregate",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "StatsAggregate",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExtendedStatsAggregate",
@@ -51814,14 +51224,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExtendedStatsAggregation",
@@ -51842,14 +51250,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ExtendedStatsBucketAggregation",
@@ -51870,14 +51276,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FailProcessor",
@@ -51913,14 +51317,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "PropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FieldAliasProperty",
@@ -52222,14 +51624,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "FieldCapabilitiesRequest",
@@ -52308,14 +51708,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FieldCapabilitiesResponse",
@@ -53053,18 +52451,6 @@
               "namespace": "_types"
             }
           }
-        },
-        {
-          "name": "script_count",
-          "required": false,
-          "since": "7.13.0",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
         }
       ]
     },
@@ -53108,14 +52494,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ScoreFunctionBase",
-            "namespace": "_types.query_dsl.compound.function_score.functions"
-          }
+      "inherits": {
+        "type": {
+          "name": "ScoreFunctionBase",
+          "namespace": "_types.query_dsl.compound.function_score.functions"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FieldValueFactorScoreFunction",
@@ -53455,14 +52839,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FiltersAggregate",
@@ -53508,14 +52890,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FiltersAggregation",
@@ -54103,14 +53483,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FingerprintTokenFilter",
@@ -54142,14 +53520,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "PropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FlattenedProperty",
@@ -54266,14 +53642,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FlattenedUsage",
@@ -54294,14 +53668,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "RangePropertyBase",
-            "namespace": "_types.mapping.types.core.range"
-          }
+      "inherits": {
+        "type": {
+          "name": "RangePropertyBase",
+          "namespace": "_types.mapping.types.core.range"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FloatRangeProperty",
@@ -54901,14 +54273,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "FollowIndexStatsRequest",
@@ -54931,14 +54301,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FollowIndexStatsResponse",
@@ -54965,14 +54333,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "FollowInfoRequest",
@@ -54995,14 +54361,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FollowInfoResponse",
@@ -55105,14 +54469,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ForeachProcessor",
@@ -55207,14 +54569,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ForgetFollowerIndexRequest",
@@ -55237,14 +54597,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ForgetFollowerIndexResponse",
@@ -55265,14 +54623,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FormatMetricAggregationBase",
@@ -55293,14 +54649,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FormattableMetricAggregation",
@@ -55341,14 +54695,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FrozenIndicesUsage",
@@ -55520,14 +54872,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FunctionScoreQuery",
@@ -55643,14 +54993,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "FuzzyQuery",
@@ -55809,14 +55157,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GenericProperty",
@@ -55958,14 +55304,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoBoundingBoxQuery",
@@ -56061,14 +55405,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoBoundsAggregate",
@@ -56089,14 +55431,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoBoundsAggregation",
@@ -56117,14 +55457,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoCentroidAggregate",
@@ -56156,14 +55494,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoCentroidAggregation",
@@ -56275,14 +55611,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "DecayFunctionBase",
-            "namespace": "_types.query_dsl.compound.function_score.functions"
-          }
+      "inherits": {
+        "type": {
+          "name": "DecayFunctionBase",
+          "namespace": "_types.query_dsl.compound.function_score.functions"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoDecayFunction",
@@ -56291,14 +55625,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoDistanceAggregation",
@@ -56378,14 +55710,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoDistanceQuery",
@@ -56564,14 +55894,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoHashGridAggregation",
@@ -56650,14 +55978,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoIpProcessor",
@@ -56736,14 +56062,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoLineAggregate",
@@ -57006,14 +56330,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoPointProperty",
@@ -57064,14 +56386,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoPolygonQuery",
@@ -57126,14 +56446,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoShapeProperty",
@@ -57206,14 +56524,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoShapeQuery",
@@ -57303,14 +56619,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GeoTileGridAggregation",
@@ -57399,14 +56713,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetAutoFollowPatternRequest",
@@ -57429,14 +56741,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetAutoFollowPatternResponse",
@@ -57479,14 +56789,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetAutoscalingCapacityRequest",
@@ -57520,14 +56828,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetAutoscalingCapacityResponse",
@@ -57567,14 +56873,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetAutoscalingPolicyRequest",
@@ -57608,14 +56912,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetAutoscalingPolicyResponse",
@@ -57639,14 +56941,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetBasicLicenseStatusRequest",
@@ -57656,14 +56956,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetBasicLicenseStatusResponse",
@@ -57687,14 +56985,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetCertificatesRequest",
@@ -57724,14 +57020,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetCertificatesResponse",
@@ -57743,14 +57037,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetEnrichPolicyRequest",
@@ -57773,14 +57065,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetEnrichPolicyResponse",
@@ -57823,14 +57113,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetFeaturesRequest",
@@ -57864,14 +57152,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetFeaturesResponse",
@@ -57895,14 +57181,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetIlmStatusRequest",
@@ -57912,14 +57196,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetIlmStatusResponse",
@@ -57943,14 +57225,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetLicenseRequest",
@@ -57983,14 +57263,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetLicenseResponse",
@@ -58014,14 +57292,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetLifecycleRequest",
@@ -58055,30 +57331,28 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "LifecyclePolicy",
-                "namespace": "ilm.get_lifecycle"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "LifecyclePolicy",
+              "namespace": "ilm.get_lifecycle"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetLifecycleResponse",
@@ -58090,14 +57364,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetPipelineRequest",
@@ -58143,30 +57415,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "Pipeline",
-                "namespace": "ingest._types"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "Pipeline",
+              "namespace": "ingest._types"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetPipelineResponse",
@@ -58178,14 +57448,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetRequest",
@@ -58231,7 +57499,6 @@
       ],
       "query": [
         {
-          "description": "Specifies the node or shard the operation should be performed on. Random by default.",
           "name": "preference",
           "required": false,
           "type": {
@@ -58243,11 +57510,8 @@
           }
         },
         {
-          "description": " Boolean) If true, the request is real-time as opposed to near-real-time.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#realtime",
           "name": "realtime",
           "required": false,
-          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -58257,10 +57521,8 @@
           }
         },
         {
-          "description": " If true, Elasticsearch refreshes the affected shards to make this operation visible to search. If false, do nothing with refreshes.",
           "name": "refresh",
           "required": false,
-          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -58270,8 +57532,6 @@
           }
         },
         {
-          "description": "Target the specified primary shard.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#get-routing",
           "name": "routing",
           "required": false,
           "type": {
@@ -58294,7 +57554,6 @@
           }
         },
         {
-          "description": "A comma-separated list of source fields to exclude in the response.",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -58306,7 +57565,6 @@
           }
         },
         {
-          "description": "A comma-separated list of source fields to include in the response.",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -58329,7 +57587,6 @@
           }
         },
         {
-          "description": "Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.",
           "name": "version",
           "required": false,
           "type": {
@@ -58341,7 +57598,6 @@
           }
         },
         {
-          "description": "Specific version type: internal, external, external_gte.",
           "name": "version_type",
           "required": false,
           "type": {
@@ -58353,7 +57609,6 @@
           }
         },
         {
-          "description": "True or false to return the _source field or not, or a list of fields to return.",
           "name": "_source",
           "required": false,
           "type": {
@@ -58385,14 +57640,12 @@
           "namespace": "_global.get"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetResponse",
@@ -58494,9 +57747,8 @@
           }
         },
         {
-          "description": "deprecated since 7.0.0",
           "name": "_type",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -58522,14 +57774,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetRollupCapabilitiesRequest",
@@ -58552,30 +57802,28 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "RollupCapabilities",
-                "namespace": "rollup.get_rollup_capabilities"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "RollupCapabilities",
+              "namespace": "rollup.get_rollup_capabilities"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetRollupCapabilitiesResponse",
@@ -58587,14 +57835,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetRollupIndexCapabilitiesRequest",
@@ -58617,30 +57863,28 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "RollupIndexCapabilities",
-                "namespace": "rollup.get_rollup_index_capabilities"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "RollupIndexCapabilities",
+              "namespace": "rollup.get_rollup_index_capabilities"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetRollupIndexCapabilitiesResponse",
@@ -58652,14 +57896,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetRollupJobRequest",
@@ -58682,14 +57924,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetRollupJobResponse",
@@ -58732,14 +57972,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetScriptContextRequest",
@@ -58773,14 +58011,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetScriptContextResponse",
@@ -58820,14 +58056,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetScriptLanguagesRequest",
@@ -58861,14 +58095,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetScriptLanguagesResponse",
@@ -58892,14 +58124,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetScriptRequest",
@@ -58934,14 +58164,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetScriptResponse",
@@ -58987,14 +58215,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetSnapshotLifecycleManagementStatusRequest",
@@ -59004,14 +58230,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetSnapshotLifecycleManagementStatusResponse",
@@ -59035,14 +58259,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetSnapshotLifecycleRequest",
@@ -59065,30 +58287,28 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "Id",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "SnapshotLifecyclePolicyMetadata",
-                "namespace": "slm._types"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "SnapshotLifecyclePolicyMetadata",
+              "namespace": "slm._types"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetSnapshotLifecycleResponse",
@@ -59100,14 +58320,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetSnapshotLifecycleStatsRequest",
@@ -59117,14 +58335,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetSnapshotLifecycleStatsResponse",
@@ -59369,14 +58585,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetTaskRequest",
@@ -59422,14 +58636,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetTaskResponse",
@@ -59486,14 +58698,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetTransformRequest",
@@ -59561,14 +58771,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetTransformResponse",
@@ -59606,14 +58814,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetTransformStatsRequest",
@@ -59670,14 +58876,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetTransformStatsResponse",
@@ -59715,14 +58919,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetTrialLicenseStatusRequest",
@@ -59732,14 +58934,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetTrialLicenseStatusResponse",
@@ -59763,14 +58963,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GetWatchRequest",
@@ -59793,14 +58991,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GetWatchResponse",
@@ -59887,14 +59083,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GlobalAggregation",
@@ -60104,14 +59298,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GraphExploreRequest",
@@ -60169,14 +59361,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GraphExploreResponse",
@@ -60415,14 +59605,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GrokProcessor",
@@ -60503,14 +59691,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "GrokProcessorPatternsRequest",
@@ -60520,14 +59706,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GrokProcessorPatternsResponse",
@@ -60576,14 +59760,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "GsubProcessor",
@@ -60648,14 +59830,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "HasChildQuery",
@@ -60742,14 +59922,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "HasParentQuery",
@@ -60865,14 +60043,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "HdrPercentilesAggregate",
@@ -61504,14 +60680,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "HistogramAggregation",
@@ -61680,14 +60854,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "PropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "HistogramProperty",
@@ -62342,14 +61514,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "CharFilterBase",
-            "namespace": "_types.analysis.char_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "CharFilterBase",
+          "namespace": "_types.analysis.char_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "HtmlStripCharFilter",
@@ -62731,14 +61901,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "HttpInputRequestDefinition",
-            "namespace": "watcher._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "HttpInputRequestDefinition",
+          "namespace": "watcher._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "HttpInputRequestResult",
@@ -62820,14 +61988,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "HunspellTokenFilter",
@@ -62881,14 +62047,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "CompoundWordTokenFilterBase",
-            "namespace": "_types.analysis.token_filters.compound_word"
-          }
+      "inherits": {
+        "type": {
+          "name": "CompoundWordTokenFilterBase",
+          "namespace": "_types.analysis.token_filters.compound_word"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "HyphenationDecompounderTokenFilter",
@@ -62940,14 +62104,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IdsQuery",
@@ -63070,14 +62232,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ImportDanglingIndexRequest",
@@ -63111,14 +62271,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ImportDanglingIndexResponse",
@@ -63608,14 +62766,12 @@
           "namespace": "_global.index"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndexRequest",
@@ -63784,14 +62940,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "WriteResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "WriteResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndexResponse",
@@ -64873,14 +64027,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "IndexSettings",
-            "namespace": "_types.index"
-          }
+      "inherits": {
+        "type": {
+          "name": "IndexSettings",
+          "namespace": "_types.index"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndexSettingsRequest",
@@ -65201,14 +64353,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ScriptBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ScriptBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndexedScript",
@@ -65458,14 +64608,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesAddBlockRequest",
@@ -65556,14 +64704,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesAddBlockResponse",
@@ -65750,14 +64896,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesAnalyzeRequest",
@@ -65780,14 +64924,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesAnalyzeResponse",
@@ -65877,14 +65019,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesClearCacheRequest",
@@ -65985,14 +65125,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ShardsOperationResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ShardsOperationResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesClearCacheResponse",
@@ -66047,14 +65185,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesCloneRequest",
@@ -66123,14 +65259,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesCloneResponse",
@@ -66165,14 +65299,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesCloseRequest",
@@ -66262,14 +65394,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesCloseResponse",
@@ -66314,14 +65444,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesCreateDataStreamRequest",
@@ -66344,14 +65472,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesCreateDataStreamResponse",
@@ -66439,14 +65565,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesCreateRequest",
@@ -66514,14 +65638,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesCreateResponse",
@@ -66556,14 +65678,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesDataStreamsStatsRequest",
@@ -66609,14 +65729,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesDataStreamsStatsResponse",
@@ -66698,14 +65816,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesDeleteAliasRequest",
@@ -66763,14 +65879,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesDeleteAliasResponse",
@@ -66782,14 +65896,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesDeleteDataStreamRequest",
@@ -66812,14 +65924,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesDeleteDataStreamResponse",
@@ -66831,14 +65941,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesDeleteRequest",
@@ -66917,14 +66025,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "IndicesResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "IndicesResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesDeleteResponse",
@@ -66936,14 +66042,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesDeleteTemplateRequest",
@@ -66989,14 +66093,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesDeleteTemplateResponse",
@@ -67008,14 +66110,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesExistsAliasRequest",
@@ -67106,14 +66206,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesExistsAliasResponse",
@@ -67125,14 +66223,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesExistsRequest",
@@ -67233,14 +66329,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesExistsResponse",
@@ -67252,14 +66346,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesExistsTemplateRequest",
@@ -67327,14 +66419,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesExistsTemplateResponse",
@@ -67346,14 +66436,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesExistsTypeRequest",
@@ -67444,14 +66532,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesExistsTypeResponse",
@@ -67463,14 +66549,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesFlushRequest",
@@ -67549,14 +66633,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ShardsOperationResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ShardsOperationResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesFlushResponse",
@@ -67568,14 +66650,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesFlushSyncedRequest",
@@ -67632,30 +66712,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "ShardStatistics",
-                "namespace": "_types"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "ShardStatistics",
+              "namespace": "_types"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesFlushSyncedResponse",
@@ -67679,14 +66757,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesForceMergeRequest",
@@ -67776,14 +66852,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ShardsOperationResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ShardsOperationResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesForceMergeResponse",
@@ -67795,14 +66869,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesFreezeRequest",
@@ -67892,14 +66964,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesFreezeResponse",
@@ -67923,14 +66993,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesGetAliasRequest",
@@ -68010,30 +67078,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexAliases",
-                "namespace": "indices.get_alias"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexAliases",
+              "namespace": "indices.get_alias"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesGetAliasResponse",
@@ -68109,18 +67175,6 @@
         {
           "name": "hidden",
           "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "system",
-          "required": false,
-          "since": "7.10.0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -68219,14 +67273,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesGetDataStreamRequest",
@@ -68261,14 +67313,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesGetDataStreamResponse",
@@ -68295,14 +67345,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesGetFieldMappingRequest",
@@ -68416,30 +67464,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TypeFieldMappings",
-                "namespace": "indices.get_field_mapping"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TypeFieldMappings",
+              "namespace": "indices.get_field_mapping"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesGetFieldMappingResponse",
@@ -68451,14 +67497,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesGetMappingRequest",
@@ -68560,30 +67604,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexMappingRecord",
-                "namespace": "indices.get_mapping"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexMappingRecord",
+              "namespace": "indices.get_mapping"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesGetMappingResponse",
@@ -68595,14 +67637,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesGetRequest",
@@ -68714,30 +67754,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexState",
-                "namespace": "_types.index"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexState",
+              "namespace": "_types.index"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesGetResponse",
@@ -68749,14 +67787,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesGetSettingsRequest",
@@ -68869,30 +67905,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexState",
-                "namespace": "_types.index"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexState",
+              "namespace": "_types.index"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesGetSettingsResponse",
@@ -68904,14 +67938,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesGetTemplateRequest",
@@ -68979,30 +68011,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TemplateMapping",
-                "namespace": "indices._types"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TemplateMapping",
+              "namespace": "indices._types"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesGetTemplateResponse",
@@ -69014,14 +68044,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesMigrateToDataStreamRequest",
@@ -69044,14 +68072,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesMigrateToDataStreamResponse",
@@ -69063,14 +68089,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesOpenRequest",
@@ -69160,14 +68184,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesOpenResponse",
@@ -69323,14 +68345,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesPromoteDataStreamRequest",
@@ -69353,14 +68373,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesPromoteDataStreamResponse",
@@ -69444,14 +68462,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesPutAliasRequest",
@@ -69509,14 +68525,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesPutAliasResponse",
@@ -69753,14 +68767,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesPutMappingRequest",
@@ -69873,14 +68885,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "IndicesResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "IndicesResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesPutMappingResponse",
@@ -69902,14 +68912,12 @@
           }
         }
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesPutSettingsRequest",
@@ -70010,14 +69018,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesPutSettingsResponse",
@@ -70131,14 +69137,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesPutTemplateRequest",
@@ -70217,14 +69221,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesPutTemplateResponse",
@@ -70236,14 +69238,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesRecoveryRequest",
@@ -70289,30 +69289,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "RecoveryStatus",
-                "namespace": "indices.recovery"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "RecoveryStatus",
+              "namespace": "indices.recovery"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesRecoveryResponse",
@@ -70324,14 +69322,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesRefreshRequest",
@@ -70388,14 +69384,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ShardsOperationResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ShardsOperationResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesRefreshResponse",
@@ -70404,14 +69398,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesResponseBase",
@@ -70575,14 +69567,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesRolloverRequest",
@@ -70673,14 +69663,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesRolloverResponse",
@@ -70769,14 +69757,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesSegmentsRequest",
@@ -70844,14 +69830,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesSegmentsResponse",
@@ -70926,14 +69910,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesShardStoresRequest",
@@ -71016,14 +69998,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesShardStoresResponse",
@@ -71100,14 +70080,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesShrinkRequest",
@@ -71176,14 +70154,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesShrinkResponse",
@@ -71261,14 +70237,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesSplitRequest",
@@ -71337,14 +70311,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesSplitResponse",
@@ -71445,14 +70417,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesStatsRequest",
@@ -71613,14 +70583,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesStatsResponse",
@@ -71676,14 +70644,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesUnfreezeRequest",
@@ -71773,14 +70739,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesUnfreezeResponse",
@@ -71831,14 +70795,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesUpdateAliasBulkRequest",
@@ -71871,14 +70833,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesUpdateAliasBulkResponse",
@@ -71906,14 +70866,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesUpgradeRequest",
@@ -71947,14 +70905,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesUpgradeResponse",
@@ -71994,14 +70950,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IndicesValidateQueryRequest",
@@ -72180,14 +71134,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IndicesValidateQueryResponse",
@@ -72350,14 +71302,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "InferenceAggregation",
@@ -72420,14 +71370,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "InferenceProcessor",
@@ -72611,14 +71559,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "IngestGeoIpStatsRequest",
@@ -72652,14 +71598,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IngestGeoIpStatsResponse",
@@ -72885,14 +71829,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ScriptBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ScriptBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "InlineScript",
@@ -73270,14 +72212,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "RangePropertyBase",
-            "namespace": "_types.mapping.types.core.range"
-          }
+      "inherits": {
+        "type": {
+          "name": "RangePropertyBase",
+          "namespace": "_types.mapping.types.core.range"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IntegerRangeProperty",
@@ -73763,14 +72703,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IntervalsQuery",
@@ -73964,14 +72902,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IpProperty",
@@ -74022,14 +72958,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IpRangeAggregation",
@@ -74141,14 +73075,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "RangePropertyBase",
-            "namespace": "_types.mapping.types.core.range"
-          }
+      "inherits": {
+        "type": {
+          "name": "RangePropertyBase",
+          "namespace": "_types.mapping.types.core.range"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "IpRangeProperty",
@@ -74756,14 +73688,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "JoinProcessor",
@@ -74806,14 +73736,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "PropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "JoinProperty",
@@ -74867,14 +73795,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "JsonProcessor",
@@ -74959,14 +73885,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "KStemTokenFilter",
@@ -74990,14 +73914,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "KeepTypesTokenFilter",
@@ -75032,14 +73954,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "KeepWordsTokenFilter",
@@ -75085,14 +74005,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "KeyValueProcessor",
@@ -75335,14 +74253,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ValueAggregate",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "ValueAggregate",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "KeyedValueAggregate",
@@ -75366,14 +74282,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "KeywordMarkerTokenFilter",
@@ -75430,14 +74344,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "KeywordProperty",
@@ -75543,14 +74455,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "KeywordTokenizer",
@@ -75571,14 +74481,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BaseUrlConfig",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "BaseUrlConfig",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "KibanaUrlConfig",
@@ -75650,14 +74558,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LengthTokenFilter",
@@ -75689,14 +74595,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LetterTokenizer",
@@ -76558,14 +75462,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LimitTokenCountTokenFilter",
@@ -76723,14 +75625,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ListDanglingIndicesRequest",
@@ -76764,14 +75664,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ListDanglingIndicesResponse",
@@ -76795,14 +75693,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ListTasksRequest",
@@ -76908,14 +75804,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ListTasksResponse",
@@ -77066,14 +75960,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "LogstashDeletePipelineRequest",
@@ -77107,14 +75999,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LogstashDeletePipelineResponse",
@@ -77154,14 +76044,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "LogstashGetPipelineRequest",
@@ -77195,14 +76083,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LogstashGetPipelineResponse",
@@ -77242,14 +76128,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "LogstashPutPipelineRequest",
@@ -77283,14 +76167,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LogstashPutPipelineResponse",
@@ -77311,14 +76193,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "RangePropertyBase",
-            "namespace": "_types.mapping.types.core.range"
-          }
+      "inherits": {
+        "type": {
+          "name": "RangePropertyBase",
+          "namespace": "_types.mapping.types.core.range"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LongRangeProperty",
@@ -77336,14 +76216,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LowercaseProcessor",
@@ -77386,14 +76264,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LowercaseTokenFilter",
@@ -77414,14 +76290,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "LowercaseTokenizer",
@@ -77430,14 +76304,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MachineLearningUsage",
@@ -77522,14 +76394,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ErrorCause",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ErrorCause",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MainError",
@@ -77597,14 +76467,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "CharFilterBase",
-            "namespace": "_types.analysis.char_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "CharFilterBase",
+          "namespace": "_types.analysis.char_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MappingCharFilter",
@@ -77639,14 +76507,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MatchAllQuery",
@@ -77667,14 +76533,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MatchBoolPrefixQuery",
@@ -77783,14 +76647,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MatchNoneQuery",
@@ -77799,14 +76661,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MatchPhrasePrefixQuery",
@@ -77871,14 +76731,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MatchPhraseQuery",
@@ -77921,14 +76779,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MatchQuery",
@@ -78115,14 +76971,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "Aggregation",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "Aggregation",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MatrixAggregation",
@@ -78164,14 +77018,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MatrixStatsAggregate",
@@ -78289,14 +77141,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MatrixAggregation",
-            "namespace": "_types.aggregations.matrix"
-          }
+      "inherits": {
+        "type": {
+          "name": "MatrixAggregation",
+          "namespace": "_types.aggregations.matrix"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MatrixStatsAggregation",
@@ -78341,14 +77191,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MaxAggregation",
@@ -78357,14 +77205,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MaxBucketAggregation",
@@ -78373,14 +77219,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MedianAbsoluteDeviationAggregation",
@@ -78860,14 +77704,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MinAggregation",
@@ -78876,14 +77718,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MinBucketAggregation",
@@ -79051,14 +77891,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MissingAggregation",
@@ -79093,14 +77931,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlCloseJobRequest",
@@ -79158,14 +77994,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlCloseJobResponse",
@@ -79271,14 +78105,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteCalendarEventRequest",
@@ -79313,14 +78145,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteCalendarEventResponse",
@@ -79332,14 +78162,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteCalendarJobRequest",
@@ -79374,14 +78202,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteCalendarJobResponse",
@@ -79427,14 +78253,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteCalendarRequest",
@@ -79457,14 +78281,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteCalendarResponse",
@@ -79476,14 +78298,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteDataFrameAnalyticsRequest",
@@ -79531,14 +78351,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteDataFrameAnalyticsResponse",
@@ -79550,14 +78368,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteDatafeedRequest",
@@ -79592,14 +78408,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteDatafeedResponse",
@@ -79639,14 +78453,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteExpiredDataRequest",
@@ -79692,14 +78504,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteExpiredDataResponse",
@@ -79723,14 +78533,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteFilterRequest",
@@ -79753,14 +78561,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteFilterResponse",
@@ -79772,14 +78578,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteForecastRequest",
@@ -79837,14 +78641,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteForecastResponse",
@@ -79856,14 +78658,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteJobRequest",
@@ -79909,14 +78709,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteJobResponse",
@@ -79928,14 +78726,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteModelSnapshotRequest",
@@ -79970,14 +78766,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteModelSnapshotResponse",
@@ -79989,14 +78783,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteTrainedModelAliasRequest",
@@ -80031,14 +78823,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteTrainedModelAliasResponse",
@@ -80050,14 +78840,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlDeleteTrainedModelRequest",
@@ -80080,14 +78868,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlDeleteTrainedModelResponse",
@@ -80157,14 +78943,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlEstimateModelMemoryRequest",
@@ -80174,14 +78958,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlEstimateModelMemoryResponse",
@@ -80221,14 +79003,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlEvaluateDataFrameRequest",
@@ -80262,14 +79042,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlEvaluateDataFrameResponse",
@@ -80309,14 +79087,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlExplainDataFrameAnalyticsRequest",
@@ -80350,14 +79126,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlExplainDataFrameAnalyticsResponse",
@@ -80430,14 +79204,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlFlushJobRequest",
@@ -80472,14 +79244,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlFlushJobResponse",
@@ -80541,14 +79311,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlForecastJobRequest",
@@ -80571,14 +79339,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlForecastJobResponse",
@@ -80686,14 +79452,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetAnomalyRecordsRequest",
@@ -80773,14 +79537,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetAnomalyRecordsResponse",
@@ -80911,14 +79673,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetBucketsRequest",
@@ -81031,14 +79791,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetBucketsResponse",
@@ -81125,14 +79883,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetCalendarEventsRequest",
@@ -81211,14 +79967,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetCalendarEventsResponse",
@@ -81272,14 +80026,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetCalendarsRequest",
@@ -81302,14 +80054,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetCalendarsResponse",
@@ -81363,14 +80113,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetCategoriesRequest",
@@ -81405,14 +80153,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetCategoriesResponse",
@@ -81466,14 +80212,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetDataFrameAnalyticsRequest",
@@ -81507,14 +80251,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetDataFrameAnalyticsResponse",
@@ -81554,14 +80296,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetDataFrameAnalyticsStatsRequest",
@@ -81595,14 +80335,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetDataFrameAnalyticsStatsResponse",
@@ -81626,14 +80364,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetDatafeedStatsRequest",
@@ -81668,14 +80404,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetDatafeedStatsResponse",
@@ -81713,14 +80447,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetDatafeedsRequest",
@@ -81766,14 +80498,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetDatafeedsResponse",
@@ -81811,14 +80541,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetFiltersRequest",
@@ -81864,14 +80592,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetFiltersResponse",
@@ -81991,14 +80717,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetInfluencersRequest",
@@ -82021,14 +80745,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetInfluencersResponse",
@@ -82066,14 +80788,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetJobStatsRequest",
@@ -82108,14 +80828,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetJobStatsResponse",
@@ -82153,14 +80871,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetJobsRequest",
@@ -82220,14 +80936,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetJobsResponse",
@@ -82325,14 +81039,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetModelSnapshotsRequest",
@@ -82367,14 +81079,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetModelSnapshotsResponse",
@@ -82494,14 +81204,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetOverallBucketsRequest",
@@ -82524,14 +81232,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetOverallBucketsResponse",
@@ -82585,14 +81291,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetTrainedModelRequest",
@@ -82626,14 +81330,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetTrainedModelResponse",
@@ -82673,14 +81375,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlGetTrainedModelStatsRequest",
@@ -82714,14 +81414,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlGetTrainedModelStatsResponse",
@@ -82998,14 +81696,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlInfoRequest",
@@ -83015,14 +81711,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlInfoResponse",
@@ -83126,14 +81820,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlOpenJobRequest",
@@ -83156,14 +81848,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlOpenJobResponse",
@@ -83206,14 +81896,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPostCalendarEventsRequest",
@@ -83236,14 +81924,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPostCalendarEventsResponse",
@@ -83285,14 +81971,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPostJobDataRequest",
@@ -83338,14 +82022,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPostJobDataResponse",
@@ -83539,14 +82221,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPreviewDataFrameAnalyticsRequest",
@@ -83580,14 +82260,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPreviewDataFrameAnalyticsResponse",
@@ -83611,14 +82289,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPreviewDatafeedRequest",
@@ -83647,14 +82323,12 @@
           "namespace": "ml.preview_datafeed"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPreviewDatafeedResponse",
@@ -83681,14 +82355,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPutCalendarJobRequest",
@@ -83723,14 +82395,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPutCalendarJobResponse",
@@ -83795,14 +82465,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPutCalendarRequest",
@@ -83825,14 +82493,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPutCalendarResponse",
@@ -83897,14 +82563,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPutDataFrameAnalyticsRequest",
@@ -83938,14 +82602,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPutDataFrameAnalyticsResponse",
@@ -84118,14 +82780,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPutDatafeedRequest",
@@ -84193,14 +82853,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPutDatafeedResponse",
@@ -84384,14 +83042,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPutFilterRequest",
@@ -84414,14 +83070,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPutFilterResponse",
@@ -84563,14 +83217,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPutJobRequest",
@@ -84593,14 +83245,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPutJobResponse",
@@ -84794,14 +83444,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPutTrainedModelAliasRequest",
@@ -84835,14 +83483,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPutTrainedModelAliasResponse",
@@ -84882,14 +83528,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlPutTrainedModelRequest",
@@ -84923,14 +83567,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlPutTrainedModelResponse",
@@ -84970,14 +83612,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlRevertModelSnapshotRequest",
@@ -85012,14 +83652,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlRevertModelSnapshotResponse",
@@ -85043,14 +83681,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlSetUpgradeModeRequest",
@@ -85083,14 +83719,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlSetUpgradeModeResponse",
@@ -85140,14 +83774,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlStartDatafeedRequest",
@@ -85182,14 +83814,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlStartDatafeedResponse",
@@ -85224,14 +83854,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlStopDataFrameAnalyticsRequest",
@@ -85293,14 +83921,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlStopDataFrameAnalyticsResponse",
@@ -85351,14 +83977,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlStopDatafeedRequest",
@@ -85404,14 +84028,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlStopDatafeedResponse",
@@ -85603,14 +84225,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlUpdateDatafeedRequest",
@@ -85678,14 +84298,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlUpdateDatafeedResponse",
@@ -85905,14 +84523,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlUpdateFilterRequest",
@@ -85935,14 +84551,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlUpdateFilterResponse",
@@ -86179,14 +84793,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlUpdateJobRequest",
@@ -86209,14 +84821,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlUpdateJobResponse",
@@ -86267,14 +84877,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlUpdateModelSnapshotRequest",
@@ -86309,14 +84917,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlUpdateModelSnapshotResponse",
@@ -86370,14 +84976,12 @@
           }
         }
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlValidateDetectorRequest",
@@ -86387,14 +84991,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlValidateDetectorResponse",
@@ -86499,14 +85101,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MlValidateJobRequest",
@@ -86516,14 +85116,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MlValidateJobResponse",
@@ -87014,14 +85612,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MonitoringUsage",
@@ -87108,14 +85704,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MoreLikeThisQuery",
@@ -87393,14 +85987,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MoveToStepRequest",
@@ -87423,14 +86015,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MoveToStepResponse",
@@ -87439,14 +86029,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MovingAverageAggregation",
@@ -87568,14 +86156,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MovingFunctionAggregation",
@@ -87618,14 +86204,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MovingPercentilesAggregation",
@@ -87663,14 +86247,12 @@
           "namespace": "_types.aggregations"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MultiBucketAggregate",
@@ -88014,14 +86596,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MultiGetRequest",
@@ -88163,14 +86743,12 @@
           "namespace": "_global.mget"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MultiGetResponse",
@@ -88203,14 +86781,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MultiMatchQuery",
@@ -88694,14 +87270,12 @@
           }
         }
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MultiSearchRequest",
@@ -88820,14 +87394,12 @@
           "namespace": "_global.msearch"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MultiSearchResponse",
@@ -88889,23 +87461,21 @@
           "namespace": "_global.msearch"
         }
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TDocument",
-                "namespace": "_global.msearch"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "_global.msearch"
             }
-          ],
-          "type": {
-            "name": "SearchResponse",
-            "namespace": "_global.search"
           }
+        ],
+        "type": {
+          "name": "SearchResponse",
+          "namespace": "_global.search"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MultiSearchResult",
@@ -88955,14 +87525,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MultiSearchTemplateRequest",
@@ -89053,14 +87621,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MultiSearchTemplateResponse",
@@ -89322,14 +87888,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "MultiTermVectorsRequest",
@@ -89486,14 +88050,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MultiTermVectorsResponse",
@@ -89517,14 +88079,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MultiTermsAggregation",
@@ -89569,14 +88129,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "MultiplexerTokenFilter",
@@ -89611,14 +88169,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "Murmur3HashProperty",
@@ -89667,14 +88223,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NGramTokenFilter",
@@ -89706,14 +88260,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NGramTokenizer",
@@ -89784,14 +88336,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "EnrichPolicy",
-            "namespace": "enrich._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "EnrichPolicy",
+          "namespace": "enrich._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NamedPolicy",
@@ -90030,14 +88580,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NestedAggregation",
@@ -90100,14 +88648,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "CorePropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CorePropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NestedProperty",
@@ -90202,14 +88748,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NestedQuery",
@@ -90619,8 +89163,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "Name",
-              "namespace": "_types"
+              "name": "string",
+              "namespace": "internal"
             }
           }
         },
@@ -92080,6 +90624,17 @@
       },
       "properties": [
         {
+          "name": "failed",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "name": "failures",
           "required": false,
           "type": {
@@ -92094,19 +90649,6 @@
           }
         },
         {
-          "description": "Total number of nodes selected by the request.",
-          "name": "total",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Number of nodes that responded successfully to the request.",
           "name": "successful",
           "required": true,
           "type": {
@@ -92118,8 +90660,7 @@
           }
         },
         {
-          "description": "Number of nodes that rejected the request or failed to respond. If this value is not 0, a reason for the rejection or failure is included in the response.",
-          "name": "failed",
+          "name": "total",
           "required": true,
           "type": {
             "kind": "instance_of",
@@ -92522,14 +91063,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "NodesHotThreadsRequest",
@@ -92619,14 +91158,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NodesHotThreadsResponse",
@@ -92653,14 +91190,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "NodesInfoRequest",
@@ -92718,14 +91253,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "NodesResponseBase",
-            "namespace": "nodes._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "NodesResponseBase",
+          "namespace": "nodes._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NodesInfoResponse",
@@ -92767,14 +91300,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NodesResponseBase",
@@ -92782,8 +91313,6 @@
       },
       "properties": [
         {
-          "description": "Contains statistics about the number of nodes selected by the request’s node filters.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes",
           "name": "_nodes",
           "required": true,
           "type": {
@@ -92800,14 +91329,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "NodesStatsRequest",
@@ -92946,14 +91473,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "NodesResponseBase",
-            "namespace": "nodes._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "NodesResponseBase",
+          "namespace": "nodes._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NodesStatsResponse",
@@ -92998,14 +91523,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "NodesUsageRequest",
@@ -93052,14 +91575,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "NodesResponseBase",
-            "namespace": "nodes._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "NodesResponseBase",
+          "namespace": "nodes._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NodesUsageResponse",
@@ -93119,14 +91640,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NoriPartOfSpeechTokenFilter",
@@ -93150,14 +91669,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NoriTokenizer",
@@ -93214,14 +91731,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NormalizeAggregation",
@@ -93269,14 +91784,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NumberProperty",
@@ -93453,14 +91966,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "DecayFunctionBase",
-            "namespace": "_types.query_dsl.compound.function_score.functions"
-          }
+      "inherits": {
+        "type": {
+          "name": "DecayFunctionBase",
+          "namespace": "_types.query_dsl.compound.function_score.functions"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "NumericDecayFunction",
@@ -93504,14 +92015,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "CorePropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CorePropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ObjectProperty",
@@ -93602,14 +92111,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "OpenPointInTimeRequest",
@@ -93644,14 +92151,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "OpenPointInTimeResponse",
@@ -94279,14 +92784,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ParentAggregation",
@@ -94307,14 +92810,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ParentIdQuery",
@@ -94435,14 +92936,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PathHierarchyTokenizer",
@@ -94507,14 +93006,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PatternCaptureTokenFilter",
@@ -94549,14 +93046,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PatternReplaceTokenFilter",
@@ -94602,14 +93097,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PauseAutoFollowPatternRequest",
@@ -94632,14 +93125,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PauseAutoFollowPatternResponse",
@@ -94651,14 +93142,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PauseFollowIndexRequest",
@@ -94681,14 +93170,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PauseFollowIndexResponse",
@@ -94859,14 +93346,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PercentileRanksAggregation",
@@ -94923,14 +93408,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PercentilesAggregate",
@@ -94954,14 +93437,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PercentilesAggregation",
@@ -95018,14 +93499,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PercentilesBucketAggregation",
@@ -95049,14 +93528,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PercolateQuery",
@@ -95149,14 +93626,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "PropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PercolatorProperty",
@@ -95435,14 +93910,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "SuggesterBase",
-            "namespace": "_global.search.suggesters"
-          }
+      "inherits": {
+        "type": {
+          "name": "SuggesterBase",
+          "namespace": "_global.search.suggesters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PhraseSuggester",
@@ -95601,14 +94074,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PingRequest",
@@ -95629,14 +94100,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PingResponse",
@@ -95645,14 +94114,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PinnedQuery",
@@ -95761,14 +94228,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "Aggregation",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "Aggregation",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PipelineAggregationBase",
@@ -95870,14 +94335,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PipelineProcessor",
@@ -96118,14 +94581,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PointProperty",
@@ -96207,14 +94668,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PorterStemTokenFilter",
@@ -96256,14 +94715,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PostLicenseRequest",
@@ -96285,14 +94742,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PostLicenseResponse",
@@ -96335,14 +94790,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PredicateTokenFilter",
@@ -96363,14 +94816,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PrefixQuery",
@@ -96476,14 +94927,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PreviewTransformRequest",
@@ -96499,14 +94948,12 @@
           "namespace": "transform.preview_transform"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PreviewTransformResponse",
@@ -97540,14 +95987,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PutAutoFollowPatternRequest",
@@ -97570,14 +96015,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PutAutoFollowPatternResponse",
@@ -97605,14 +96048,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PutAutoscalingPolicyRequest",
@@ -97646,14 +96087,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PutAutoscalingPolicyResponse",
@@ -97704,14 +96143,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PutEnrichPolicyRequest",
@@ -97734,14 +96171,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PutEnrichPolicyResponse",
@@ -97769,14 +96204,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PutLifecycleRequest",
@@ -97810,14 +96243,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PutLifecycleResponse",
@@ -97884,14 +96315,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PutPipelineRequest",
@@ -97937,14 +96366,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PutPipelineResponse",
@@ -98032,14 +96459,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PutScriptRequest",
@@ -98097,14 +96522,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PutScriptResponse",
@@ -98176,14 +96599,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PutSnapshotLifecycleRequest",
@@ -98206,14 +96627,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PutSnapshotLifecycleResponse",
@@ -98296,14 +96715,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "PutTransformRequest",
@@ -98338,14 +96755,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "PutTransformResponse",
@@ -99976,14 +98391,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "QuerySqlRequest",
@@ -100006,14 +98419,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "QuerySqlResponse",
@@ -100062,14 +98473,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "QueryStringQuery",
@@ -100447,14 +98856,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ScoreFunctionBase",
-            "namespace": "_types.query_dsl.compound.function_score.functions"
-          }
+      "inherits": {
+        "type": {
+          "name": "ScoreFunctionBase",
+          "namespace": "_types.query_dsl.compound.function_score.functions"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RandomScoreFunction",
@@ -100498,14 +98905,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RangeAggregation",
@@ -100640,14 +99045,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RangePropertyBase",
@@ -100690,14 +99093,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RangeQuery",
@@ -101136,14 +99537,12 @@
     {
       "description": "Discounted cumulative gain (DCG)",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_discounted_cumulative_gain_dcg",
-      "inherits": [
-        {
-          "type": {
-            "name": "RankEvalMetricBase",
-            "namespace": "_global.rank_eval"
-          }
+      "inherits": {
+        "type": {
+          "name": "RankEvalMetricBase",
+          "namespace": "_global.rank_eval"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankEvalMetricDiscountedCumulativeGain",
@@ -101169,14 +99568,12 @@
     {
       "description": "Expected Reciprocal Rank (ERR)",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_expected_reciprocal_rank_err",
-      "inherits": [
-        {
-          "type": {
-            "name": "RankEvalMetricBase",
-            "namespace": "_global.rank_eval"
-          }
+      "inherits": {
+        "type": {
+          "name": "RankEvalMetricBase",
+          "namespace": "_global.rank_eval"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankEvalMetricExpectedReciprocalRank",
@@ -101200,14 +99597,12 @@
     {
       "description": "Mean Reciprocal Rank",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_mean_reciprocal_rank",
-      "inherits": [
-        {
-          "type": {
-            "name": "RankEvalMetricRatingTreshold",
-            "namespace": "_global.rank_eval"
-          }
+      "inherits": {
+        "type": {
+          "name": "RankEvalMetricRatingTreshold",
+          "namespace": "_global.rank_eval"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankEvalMetricMeanReciprocalRank",
@@ -101218,14 +99613,12 @@
     {
       "description": "Precision at K (P@k)",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#k-precision",
-      "inherits": [
-        {
-          "type": {
-            "name": "RankEvalMetricRatingTreshold",
-            "namespace": "_global.rank_eval"
-          }
+      "inherits": {
+        "type": {
+          "name": "RankEvalMetricRatingTreshold",
+          "namespace": "_global.rank_eval"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankEvalMetricPrecision",
@@ -101248,14 +99641,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "RankEvalMetricBase",
-            "namespace": "_global.rank_eval"
-          }
+      "inherits": {
+        "type": {
+          "name": "RankEvalMetricBase",
+          "namespace": "_global.rank_eval"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankEvalMetricRatingTreshold",
@@ -101280,14 +99671,12 @@
     {
       "description": "Recall at K (R@k)",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#k-recall",
-      "inherits": [
-        {
-          "type": {
-            "name": "RankEvalMetricRatingTreshold",
-            "namespace": "_global.rank_eval"
-          }
+      "inherits": {
+        "type": {
+          "name": "RankEvalMetricRatingTreshold",
+          "namespace": "_global.rank_eval"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankEvalMetricRecall",
@@ -101363,14 +99752,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "RankEvalRequest",
@@ -101520,14 +99907,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankEvalResponse",
@@ -101596,14 +99981,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "PropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankFeatureProperty",
@@ -101632,14 +100015,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankFeatureQuery",
@@ -101660,14 +100041,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "PropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RankFeaturesProperty",
@@ -101685,14 +100064,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RareTermsAggregation",
@@ -101857,14 +100234,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RateAggregation",
@@ -101962,14 +100337,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RealmUsage",
@@ -102883,14 +101256,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RegexpQuery",
@@ -103028,14 +101399,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BaseNode",
-            "namespace": "_spec_utils"
-          }
+      "inherits": {
+        "type": {
+          "name": "BaseNode",
+          "namespace": "_spec_utils"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ReindexNode",
@@ -103140,14 +101509,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ReindexRequest",
@@ -103246,14 +101613,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ReindexResponse",
@@ -103445,14 +101810,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ReindexRethrottleRequest",
@@ -103487,14 +101850,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ReindexRethrottleResponse",
@@ -103933,14 +102294,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ReloadSearchAnalyzersRequest",
@@ -103997,14 +102356,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ReloadSearchAnalyzersResponse",
@@ -104058,14 +102415,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ReloadSecureSettingsRequest",
@@ -104100,14 +102455,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "NodesResponseBase",
-            "namespace": "nodes._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "NodesResponseBase",
+          "namespace": "nodes._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ReloadSecureSettingsResponse",
@@ -104225,14 +102578,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RemoveDuplicatesTokenFilter",
@@ -104244,14 +102595,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "RemovePolicyRequest",
@@ -104274,14 +102623,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RemovePolicyResponse",
@@ -104316,14 +102663,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RemoveProcessor",
@@ -104355,14 +102700,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RenameProcessor",
@@ -104452,14 +102795,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "RenderSearchTemplateRequest",
@@ -104469,14 +102810,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RenderSearchTemplateResponse",
@@ -104683,8 +103022,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "Id",
-              "namespace": "_types"
+              "name": "string",
+              "namespace": "internal"
             }
           }
         },
@@ -104862,14 +103201,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ResolveIndexRequest",
@@ -104904,14 +103241,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ResolveIndexResponse",
@@ -105179,14 +103514,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ResumeAutoFollowPatternRequest",
@@ -105209,14 +103542,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ResumeAutoFollowPatternResponse",
@@ -105343,14 +103674,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ResumeFollowIndexRequest",
@@ -105373,14 +103702,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ResumeFollowIndexResponse",
@@ -105423,14 +103750,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "RetryIlmRequest",
@@ -105453,14 +103778,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RetryIlmResponse",
@@ -105469,14 +103792,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ReverseNestedAggregation",
@@ -105497,14 +103818,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ReverseTokenFilter",
@@ -106357,14 +104676,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "RollupRequest",
@@ -106398,14 +104715,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RollupResponse",
@@ -106477,14 +104792,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "RollupSearchRequest",
@@ -106548,14 +104861,12 @@
           "namespace": "rollup.rollup_search"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RollupSearchResponse",
@@ -106567,14 +104878,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "RootNodeInfoRequest",
@@ -106584,14 +104893,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RootNodeInfoResponse",
@@ -107202,14 +105509,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "RuntimeFieldsUsage",
@@ -107264,14 +105569,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SamplerAggregation",
@@ -107759,14 +106062,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ScriptProcessor",
@@ -107826,14 +106127,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ScriptQuery",
@@ -107854,14 +106153,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ScoreFunctionBase",
-            "namespace": "_types.query_dsl.compound.function_score.functions"
-          }
+      "inherits": {
+        "type": {
+          "name": "ScoreFunctionBase",
+          "namespace": "_types.query_dsl.compound.function_score.functions"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ScriptScoreFunction",
@@ -107882,14 +106179,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ScriptScoreQuery",
@@ -108051,14 +106346,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ScriptedMetricAggregate",
@@ -108075,14 +106368,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ScriptedMetricAggregation",
@@ -108174,11 +106465,8 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "Period to retain the search context for scrolling.",
-            "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results",
             "name": "scroll",
             "required": false,
-            "serverDefault": "1d",
             "type": {
               "kind": "instance_of",
               "type": {
@@ -108188,9 +106476,8 @@
             }
           },
           {
-            "description": "Scroll ID of the search.",
             "name": "scroll_id",
-            "required": true,
+            "required": false,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -108200,10 +106487,8 @@
             }
           },
           {
-            "description": "If true, the API response’s hit.total property is returned as an integer. If false, the API response’s hit.total property is returned as an object.",
             "name": "rest_total_hits_as_int",
             "required": false,
-            "serverDefault": false,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -108214,14 +106499,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ScrollRequest",
@@ -108243,11 +106526,8 @@
       ],
       "query": [
         {
-          "description": "Period to retain the search context for scrolling.",
-          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results",
           "name": "scroll",
           "required": false,
-          "serverDefault": "1d",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -108257,7 +106537,6 @@
           }
         },
         {
-          "description": "Deprecated with 7.0.0",
           "name": "scroll_id",
           "required": false,
           "type": {
@@ -108269,10 +106548,8 @@
           }
         },
         {
-          "description": "If true, the API response’s hit.total property is returned as an integer. If false, the API response’s hit.total property is returned as an object.",
           "name": "rest_total_hits_as_int",
           "required": false,
-          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -108301,39 +106578,112 @@
           "namespace": "_global.scroll"
         }
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TDocument",
-                "namespace": "_global.scroll"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "_global.scroll"
             }
-          ],
-          "type": {
-            "name": "SearchResponse",
-            "namespace": "_global.search"
           }
+        ],
+        "type": {
+          "name": "SearchResponse",
+          "namespace": "_global.search"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ScrollResponse",
         "namespace": "_global.scroll"
       },
-      "properties": []
-    },
-    {
-      "inherits": [
+      "properties": [
         {
+          "name": "failed_shards",
+          "required": false,
           "type": {
-            "name": "CorePropertyBase",
-            "namespace": "_types.mapping.types"
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "ScrollResponseFailedShard",
+                "namespace": "_global.scroll"
+              }
+            }
           }
         }
-      ],
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "ScrollResponseErrorReason",
+        "namespace": "_global.scroll"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "reason",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "ScrollResponseFailedShard",
+        "namespace": "_global.scroll"
+      },
+      "properties": [
+        {
+          "name": "shard",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "reason",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ScrollResponseErrorReason",
+              "namespace": "_global.scroll"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "CorePropertyBase",
+          "namespace": "_types.mapping.types"
+        }
+      },
       "kind": "interface",
       "name": {
         "name": "SearchAsYouTypeProperty",
@@ -109150,14 +107500,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SearchRequest",
@@ -109714,14 +108062,12 @@
           "namespace": "_global.search"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SearchResponse",
@@ -109949,14 +108295,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SearchShardsRequest",
@@ -110046,14 +108390,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SearchShardsResponse",
@@ -110342,14 +108684,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SearchTemplateRequest",
@@ -110544,14 +108884,12 @@
           "namespace": "_global.search_template"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SearchTemplateResponse",
@@ -110679,14 +109017,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SearchableSnapshotsClearCacheRequest",
@@ -110720,14 +109056,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SearchableSnapshotsClearCacheResponse",
@@ -110809,14 +109143,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SearchableSnapshotsMountRequest",
@@ -110885,14 +109217,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SearchableSnapshotsMountResponse",
@@ -110974,14 +109304,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SearchableSnapshotsRepositoryStatsRequest",
@@ -111015,14 +109343,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SearchableSnapshotsRepositoryStatsResponse",
@@ -111062,14 +109388,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SearchableSnapshotsStatsRequest",
@@ -111103,14 +109427,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SearchableSnapshotsStatsResponse",
@@ -111131,14 +109453,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SearchableSnapshotsUsage",
@@ -111200,14 +109520,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityAuthenticateRequest",
@@ -111217,14 +109535,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityAuthenticateResponse",
@@ -111361,14 +109677,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityChangePasswordRequest",
@@ -111403,14 +109717,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityChangePasswordResponse",
@@ -111422,14 +109734,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityClearApiKeyCacheRequest",
@@ -111452,14 +109762,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityClearApiKeyCacheResponse",
@@ -111515,14 +109823,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityClearCachedPrivilegesRequest",
@@ -111545,14 +109851,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityClearCachedPrivilegesResponse",
@@ -111608,14 +109912,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityClearCachedRealmsRequest",
@@ -111653,14 +109955,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityClearCachedRealmsResponse",
@@ -111716,14 +110016,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityClearCachedRolesRequest",
@@ -111746,14 +110044,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityClearCachedRolesResponse",
@@ -111857,14 +110153,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityCreateApiKeyRequest",
@@ -111886,14 +110180,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityCreateApiKeyResponse",
@@ -111950,14 +110242,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityDeletePrivilegesRequest",
@@ -112004,40 +110294,38 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "key": {
               "kind": "instance_of",
               "type": {
                 "name": "string",
                 "namespace": "internal"
               }
             },
-            {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "FoundUserPrivilege",
-                  "namespace": "security.delete_privileges"
-                }
+            "kind": "dictionary_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "FoundUserPrivilege",
+                "namespace": "security.delete_privileges"
               }
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityDeletePrivilegesResponse",
@@ -112049,14 +110337,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityDeleteRoleMappingRequest",
@@ -112091,14 +110377,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityDeleteRoleMappingResponse",
@@ -112122,14 +110406,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityDeleteRoleRequest",
@@ -112164,14 +110446,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityDeleteRoleResponse",
@@ -112195,14 +110475,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityDeleteUserRequest",
@@ -112237,14 +110515,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityDeleteUserResponse",
@@ -112268,14 +110544,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityDisableUserRequest",
@@ -112310,14 +110584,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityDisableUserResponse",
@@ -112341,14 +110613,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityEnableUserRequest",
@@ -112383,14 +110653,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityEnableUserResponse",
@@ -112434,14 +110702,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityGetApiKeyRequest",
@@ -112507,14 +110773,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityGetApiKeyResponse",
@@ -112541,14 +110805,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityGetBuiltinPrivilegesRequest",
@@ -112570,14 +110832,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityGetBuiltinPrivilegesResponse",
@@ -112615,14 +110875,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityGetPrivilegesRequest",
@@ -112657,40 +110915,38 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "key": {
               "kind": "instance_of",
               "type": {
                 "name": "string",
                 "namespace": "internal"
               }
             },
-            {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "PrivilegesActions",
-                  "namespace": "security.put_privileges"
-                }
+            "kind": "dictionary_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "PrivilegesActions",
+                "namespace": "security.put_privileges"
               }
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityGetPrivilegesResponse",
@@ -112702,14 +110958,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityGetRoleMappingRequest",
@@ -112732,30 +110986,28 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "XPackRoleMapping",
-                "namespace": "security._types"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "XPackRoleMapping",
+              "namespace": "security._types"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityGetRoleMappingResponse",
@@ -112767,14 +111019,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityGetRoleRequest",
@@ -112797,30 +111047,28 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "XPackRole",
-                "namespace": "security._types"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "XPackRole",
+              "namespace": "security._types"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityGetRoleResponse",
@@ -112903,14 +111151,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityGetTokenRequest",
@@ -112920,14 +111166,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityGetTokenResponse",
@@ -113017,14 +111261,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityGetUserPrivilegesRequest",
@@ -113046,14 +111288,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityGetUserPrivilegesResponse",
@@ -113136,14 +111376,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityGetUserRequest",
@@ -113169,30 +111407,28 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "XPackUser",
-                "namespace": "security._types"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "XPackUser",
+              "namespace": "security._types"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityGetUserResponse",
@@ -113264,14 +111500,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityGrantApiKeyRequest",
@@ -113281,14 +111515,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityGrantApiKeyResponse",
@@ -113392,14 +111624,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityHasPrivilegesRequest",
@@ -113422,14 +111652,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityHasPrivilegesResponse",
@@ -113591,14 +111819,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityInvalidateApiKeyRequest",
@@ -113608,14 +111834,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityInvalidateApiKeyResponse",
@@ -113730,14 +111954,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityInvalidateTokenRequest",
@@ -113747,14 +111969,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityInvalidateTokenResponse",
@@ -113864,14 +112084,12 @@
           }
         }
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityPutPrivilegesRequest",
@@ -113893,40 +112111,38 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "key": {
               "kind": "instance_of",
               "type": {
                 "name": "string",
                 "namespace": "internal"
               }
             },
-            {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "PutPrivilegesStatus",
-                  "namespace": "security.put_privileges"
-                }
+            "kind": "dictionary_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "PutPrivilegesStatus",
+                "namespace": "security.put_privileges"
               }
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityPutPrivilegesResponse",
@@ -114010,14 +112226,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityPutRoleMappingRequest",
@@ -114052,14 +112266,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityPutRoleMappingResponse",
@@ -114200,14 +112412,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityPutRoleRequest",
@@ -114242,14 +112452,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityPutRoleResponse",
@@ -114399,14 +112607,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SecurityPutUserRequest",
@@ -114441,14 +112647,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityPutUserResponse",
@@ -114657,14 +112861,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SecurityUsage",
@@ -115252,14 +113454,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SerialDifferencingAggregation",
@@ -115280,14 +113480,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SetProcessor",
@@ -115326,14 +113524,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SetSecurityUserProcessor",
@@ -115395,14 +113591,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ShapeProperty",
@@ -115464,14 +113658,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ShapeQuery",
@@ -115633,8 +113825,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "IndexName",
-              "namespace": "_types"
+              "name": "string",
+              "namespace": "internal"
             }
           }
         },
@@ -116935,14 +115127,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ShardsOperationResponseBase",
@@ -117026,14 +115216,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ShingleTokenFilter",
@@ -117128,14 +115316,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ShutdownDeleteNodeRequest",
@@ -117145,14 +115331,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ShutdownDeleteNodeResponse",
@@ -117192,14 +115376,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ShutdownGetNodeRequest",
@@ -117209,14 +115391,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ShutdownGetNodeResponse",
@@ -117256,14 +115436,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "ShutdownPutNodeRequest",
@@ -117273,14 +115451,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ShutdownPutNodeResponse",
@@ -117307,23 +115483,21 @@
           "namespace": "_types.aggregations"
         }
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TKey",
-                "namespace": "_types.aggregations"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TKey",
+              "namespace": "_types.aggregations"
             }
-          ],
-          "type": {
-            "name": "MultiBucketAggregate",
-            "namespace": "_types.aggregations"
           }
+        ],
+        "type": {
+          "name": "MultiBucketAggregate",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SignificantTermsAggregate",
@@ -117355,14 +115529,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SignificantTermsAggregation",
@@ -117597,14 +115769,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SignificantTextAggregation",
@@ -117868,14 +116038,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SimpleQueryStringQuery",
@@ -118111,14 +116279,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SimulatePipelineRequest",
@@ -118153,14 +116319,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SimulatePipelineResponse",
@@ -118256,14 +116420,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SingleBucketAggregate",
@@ -118766,14 +116928,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SlmUsage",
@@ -118869,14 +117029,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotCloneRequest",
@@ -118946,14 +117104,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotCloneResponse",
@@ -119003,14 +117159,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotCreateRepositoryRequest",
@@ -119067,14 +117221,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotCreateRepositoryResponse",
@@ -119152,14 +117304,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotCreateRequest",
@@ -119217,14 +117367,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotCreateResponse",
@@ -119259,14 +117407,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotDeleteRepositoryRequest",
@@ -119312,14 +117458,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotDeleteRepositoryResponse",
@@ -119331,14 +117475,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotDeleteRequest",
@@ -119385,14 +117527,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotDeleteResponse",
@@ -119404,14 +117544,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotGetRepositoryRequest",
@@ -119457,30 +117595,28 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "SnapshotRepository",
-                "namespace": "snapshot._types"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "SnapshotRepository",
+              "namespace": "snapshot._types"
+            }
           }
+        ],
+        "type": {
+          "name": "DictionaryResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotGetRepositoryResponse",
@@ -119492,14 +117628,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotGetRequest",
@@ -119568,14 +117702,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotGetResponse",
@@ -120706,14 +118838,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotRestoreRequest",
@@ -120771,14 +118901,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotRestoreResponse",
@@ -121287,14 +119415,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotStatusRequest",
@@ -121352,14 +119478,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotStatusResponse",
@@ -121386,14 +119510,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SnapshotVerifyRepositoryRequest",
@@ -121439,14 +119561,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnapshotVerifyRepositoryResponse",
@@ -121552,14 +119672,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SnowballTokenFilter",
@@ -121777,14 +119895,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SortProcessor",
@@ -121873,14 +119989,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SourceExistsRequest",
@@ -122038,14 +120152,12 @@
           }
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SourceExistsResponse",
@@ -122180,21 +120292,156 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "GetRequest",
-            "namespace": "_global.get"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "SourceRequest",
         "namespace": "_global.get_source"
       },
-      "path": [],
-      "query": []
+      "path": [
+        {
+          "description": "The document ID",
+          "name": "id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The name of the index",
+          "name": "index",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The type of the document; deprecated and optional starting with 7.0",
+          "name": "type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Type",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "name": "preference",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "realtime",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "refresh",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "routing",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Routing",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "source_enabled",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "_source_excludes",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "_source_includes",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionNumber",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "version_type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionType",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
     },
     {
       "generics": [
@@ -122203,42 +120450,38 @@
           "namespace": "_global.get_source"
         }
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "user_defined_value"
-            }
-          ],
-          "type": {
-            "name": "DictionaryResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SourceResponse",
         "namespace": "_global.get_source"
       },
-      "properties": []
-    },
-    {
-      "inherits": [
+      "properties": [
         {
+          "name": "body",
+          "required": true,
           "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "_global.get_source"
+            }
           }
         }
-      ],
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
+        }
+      },
       "kind": "interface",
       "name": {
         "name": "SpanContainingQuery",
@@ -122270,14 +120513,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanFieldMaskingQuery",
@@ -122309,14 +120550,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanFirstQuery",
@@ -122348,14 +120587,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanGapQuery",
@@ -122387,14 +120624,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanMultiTermQuery",
@@ -122415,14 +120650,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanNearQuery",
@@ -122468,14 +120701,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanNotQuery",
@@ -122540,14 +120771,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanOrQuery",
@@ -122571,14 +120800,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanQuery",
@@ -122887,14 +121114,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanTermQuery",
@@ -122915,14 +121140,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SpanWithinQuery",
@@ -122954,14 +121177,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SplitProcessor",
@@ -123071,14 +121292,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SqlUsage",
@@ -123236,14 +121455,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StandardTokenizer",
@@ -123267,14 +121484,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StartBasicLicenseRequest",
@@ -123296,14 +121511,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StartBasicLicenseResponse",
@@ -123390,14 +121603,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StartIlmRequest",
@@ -123407,14 +121618,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StartIlmResponse",
@@ -123426,14 +121635,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StartRollupJobRequest",
@@ -123456,14 +121663,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StartRollupJobResponse",
@@ -123487,14 +121692,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StartSnapshotLifecycleManagementRequest",
@@ -123504,14 +121707,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StartSnapshotLifecycleManagementResponse",
@@ -123523,14 +121724,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StartTransformRequest",
@@ -123565,14 +121764,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StartTransformResponse",
@@ -123584,14 +121781,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StartTrialLicenseRequest",
@@ -123624,14 +121819,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StartTrialLicenseResponse",
@@ -123685,14 +121878,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StatsAggregate",
@@ -123757,14 +121948,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StatsAggregation",
@@ -123773,14 +121962,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StatsBucketAggregation",
@@ -123810,14 +121997,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StemmerOverrideTokenFilter",
@@ -123852,14 +122037,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StemmerTokenFilter",
@@ -123941,14 +122124,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StopIlmRequest",
@@ -123958,14 +122139,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StopIlmResponse",
@@ -123977,14 +122156,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StopRollupJobRequest",
@@ -124030,14 +122207,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StopRollupJobResponse",
@@ -124061,14 +122236,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StopSnapshotLifecycleManagementRequest",
@@ -124078,14 +122251,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StopSnapshotLifecycleManagementResponse",
@@ -124094,14 +122265,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StopTokenFilter",
@@ -124158,14 +122327,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "StopTransformRequest",
@@ -124244,14 +122411,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StopTransformResponse",
@@ -124506,14 +122671,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StringStatsAggregate",
@@ -124599,14 +122762,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "StringStatsAggregation",
@@ -125145,14 +123306,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormatMetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormatMetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SumAggregation",
@@ -125161,14 +123320,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "PipelineAggregationBase",
-            "namespace": "_types.aggregations.pipeline"
-          }
+      "inherits": {
+        "type": {
+          "name": "PipelineAggregationBase",
+          "namespace": "_types.aggregations.pipeline"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SumBucketAggregation",
@@ -125192,14 +123349,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SynonymGraphTokenFilter",
@@ -125289,14 +123444,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "SynonymTokenFilter",
@@ -125406,14 +123559,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TDigestPercentilesAggregate",
@@ -125444,14 +123595,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "Aggregation",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "Aggregation",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TTestAggregation",
@@ -125512,14 +123661,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BaseNode",
-            "namespace": "_spec_utils"
-          }
+      "inherits": {
+        "type": {
+          "name": "BaseNode",
+          "namespace": "_spec_utils"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TaskExecutingNode",
@@ -126174,14 +124321,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TermQuery",
@@ -126263,14 +124408,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "SuggesterBase",
-            "namespace": "_global.search.suggesters"
-          }
+      "inherits": {
+        "type": {
+          "name": "SuggesterBase",
+          "namespace": "_global.search.suggesters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TermSuggester",
@@ -126710,14 +124853,12 @@
           "namespace": "_global.termvectors"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "TermVectorsRequest",
@@ -126886,14 +125027,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TermVectorsResponse",
@@ -127081,23 +125220,21 @@
           "namespace": "_types.aggregations"
         }
       ],
-      "inherits": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TKey",
-                "namespace": "_types.aggregations"
-              }
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TKey",
+              "namespace": "_types.aggregations"
             }
-          ],
-          "type": {
-            "name": "MultiBucketAggregate",
-            "namespace": "_types.aggregations"
           }
+        ],
+        "type": {
+          "name": "MultiBucketAggregate",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TermsAggregate",
@@ -127129,14 +125266,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BucketAggregationBase",
-            "namespace": "_types.aggregations.bucket"
-          }
+      "inherits": {
+        "type": {
+          "name": "BucketAggregationBase",
+          "namespace": "_types.aggregations.bucket"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TermsAggregation",
@@ -127460,14 +125595,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TermsQuery",
@@ -127555,14 +125688,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TermsSetQuery",
@@ -127681,14 +125812,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "CorePropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "CorePropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TextProperty",
@@ -128508,14 +126637,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TokenCountProperty",
@@ -129151,14 +127278,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TopHitsAggregate",
@@ -129194,14 +127319,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TopHitsAggregation",
@@ -129454,14 +127577,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TopMetricsAggregate",
@@ -129485,14 +127606,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "MetricAggregationBase",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "MetricAggregationBase",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TopMetricsAggregation",
@@ -130448,14 +128567,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "TranslateSqlRequest",
@@ -130465,14 +128582,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TranslateSqlResponse",
@@ -130832,14 +128947,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TrimProcessor",
@@ -130882,14 +128995,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TrimTokenFilter",
@@ -130898,14 +129009,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TruncateTokenFilter",
@@ -131234,14 +129343,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "TypeQuery",
@@ -131291,14 +129398,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UaxEmailUrlTokenizer",
@@ -131462,14 +129567,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "UnfollowIndexRequest",
@@ -131492,14 +129595,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UnfollowIndexResponse",
@@ -131508,14 +129609,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UniqueTokenFilter",
@@ -131630,14 +129729,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "UpdateByQueryRequest",
@@ -132053,14 +130150,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UpdateByQueryResponse",
@@ -132227,14 +130322,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "BaseNode",
-            "namespace": "_spec_utils"
-          }
+      "inherits": {
+        "type": {
+          "name": "BaseNode",
+          "namespace": "_spec_utils"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UpdateByQueryRethrottleNode",
@@ -132268,14 +130361,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "UpdateByQueryRethrottleRequest",
@@ -132310,14 +130401,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UpdateByQueryRethrottleResponse",
@@ -132455,14 +130544,12 @@
           "namespace": "_global.update"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "UpdateRequest",
@@ -132671,14 +130758,12 @@
           "namespace": "_global.update"
         }
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "WriteResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "WriteResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UpdateResponse",
@@ -132771,14 +130856,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "UpdateTransformRequest",
@@ -132813,14 +130896,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UpdateTransformResponse",
@@ -132940,14 +131021,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UppercaseProcessor",
@@ -132990,14 +131069,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UppercaseTokenFilter",
@@ -133032,14 +131109,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UrlDecodeProcessor",
@@ -133113,14 +131188,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ProcessorBase",
-            "namespace": "ingest._types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ProcessorBase",
+          "namespace": "ingest._types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "UserAgentProcessor",
@@ -133356,14 +131429,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AggregateBase",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "AggregateBase",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ValueAggregate",
@@ -133395,14 +131466,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "FormattableMetricAggregation",
-            "namespace": "_types.aggregations.metric"
-          }
+      "inherits": {
+        "type": {
+          "name": "FormattableMetricAggregation",
+          "namespace": "_types.aggregations.metric"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "ValueCountAggregation",
@@ -133503,14 +131572,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "VectorUsage",
@@ -133567,14 +131634,12 @@
       }
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "VersionProperty",
@@ -134066,14 +132131,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "WatchRecordQueuedStats",
-            "namespace": "watcher.stats"
-          }
+      "inherits": {
+        "type": {
+          "name": "WatchRecordQueuedStats",
+          "namespace": "watcher.stats"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatchRecordStats",
@@ -134229,14 +132292,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "WatcherAckWatchRequest",
@@ -134271,14 +132332,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherAckWatchResponse",
@@ -134363,14 +132422,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "WatcherActivateWatchRequest",
@@ -134393,14 +132450,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherActivateWatchResponse",
@@ -134522,14 +132577,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "WatcherExecuteWatchRequest",
@@ -134564,14 +132617,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherExecuteWatchResponse",
@@ -134806,14 +132857,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "WatcherPutWatchRequest",
@@ -134881,14 +132930,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherPutWatchResponse",
@@ -134972,14 +133019,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "WatcherQueryWatchesRequest",
@@ -135013,14 +133058,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherQueryWatchesResponse",
@@ -135060,14 +133103,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "WatcherStartRequest",
@@ -135077,14 +133118,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherStartResponse",
@@ -135117,14 +133156,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "WatcherStatsRequest",
@@ -135200,14 +133237,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherStatsResponse",
@@ -135283,14 +133318,12 @@
           }
         ]
       },
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "WatcherStopRequest",
@@ -135300,14 +133333,12 @@
       "query": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "AcknowledgedResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherStopResponse",
@@ -135316,14 +133347,12 @@
       "properties": []
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "XPackUsage",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "XPackUsage",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherUsage",
@@ -135366,14 +133395,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "UsageCount",
-            "namespace": "xpack.usage"
-          }
+      "inherits": {
+        "type": {
+          "name": "UsageCount",
+          "namespace": "xpack.usage"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WatcherWatchTriggerScheduleUsage",
@@ -135550,14 +133577,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "Aggregation",
-            "namespace": "_types.aggregations"
-          }
+      "inherits": {
+        "type": {
+          "name": "Aggregation",
+          "namespace": "_types.aggregations"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WeightedAverageAggregation",
@@ -135653,14 +133678,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenizerBase",
-            "namespace": "_types.analysis.tokenizers"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis.tokenizers"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WhitespaceTokenizer",
@@ -135681,14 +133704,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "DocValuesPropertyBase",
-            "namespace": "_types.mapping.types"
-          }
+      "inherits": {
+        "type": {
+          "name": "DocValuesPropertyBase",
+          "namespace": "_types.mapping.types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WildcardProperty",
@@ -135706,14 +133727,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "QueryBase",
-            "namespace": "_types.query_dsl.abstractions.query"
-          }
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl.abstractions.query"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WildcardQuery",
@@ -135745,14 +133764,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WordDelimiterGraphTokenFilter",
@@ -135922,14 +133939,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "TokenFilterBase",
-            "namespace": "_types.analysis.token_filters"
-          }
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis.token_filters"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WordDelimiterTokenFilter",
@@ -136088,14 +134103,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "WriteResponseBase",
@@ -136608,14 +134621,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "XPackInfoRequest",
@@ -136640,14 +134651,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "XPackInfoResponse",
@@ -136904,14 +134913,12 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "inherits": [
-        {
-          "type": {
-            "name": "RequestBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "request",
       "name": {
         "name": "XPackUsageRequest",
@@ -136933,14 +134940,12 @@
       ]
     },
     {
-      "inherits": [
-        {
-          "type": {
-            "name": "ResponseBase",
-            "namespace": "_types"
-          }
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
         }
-      ],
+      },
       "kind": "interface",
       "name": {
         "name": "XPackUsageResponse",

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -125,7 +125,7 @@ function buildGenerics (types: M.ValueOf[] | M.TypeName[] | undefined, openGener
 }
 
 function buildInherits (type: M.Interface | M.Request, openGenerics?: string[]): string {
-  const inherits = (type.inherits ?? []).filter(type => !skipBehaviors.includes(type.type.name))
+  const inherits = (type.inherits != null ? [type.inherits] : []).filter(type => !skipBehaviors.includes(type.type.name))
   const interfaces = (type.implements ?? []).filter(type => !skipBehaviors.includes(type.type.name))
   const behaviors = (type.behaviors ?? []).filter(type => !skipBehaviors.includes(type.type.name))
   const extendAll = inherits.concat(interfaces).concat(behaviors)
@@ -185,7 +185,7 @@ function buildBehaviorInterface (type: M.Interface): string {
       let generic = behavior.generics?.[0]
       assert(generic?.kind === 'instance_of')
       if (generic.type.name === 'TCatRecord') {
-        const g = type.inherits?.[0].generics?.[0]
+        const g = type.inherits?.generics?.[0]
         assert(g?.kind === 'instance_of')
         generic = g
       }
@@ -250,7 +250,7 @@ function lookupBehavior (type: M.Interface, name: string): M.Inherits | null {
     if (behavior != null) return behavior
   }
   if (type.inherits == null) return null
-  const parentType = model.types.find(t => t.name.name === type.inherits?.[0].type.name)
+  const parentType = model.types.find(t => t.name.name === type.inherits?.type.name)
   if (parentType == null) return null
   if (parentType.kind === 'interface') {
     return lookupBehavior(parentType, name)


### PR DESCRIPTION
This updates the metamodel to have a single optional inherits clause instead of an array.

This has no impact on the spec as TypeScript doesn't allow extending more than one class, and we had a model validation ensuring that `inherits` had zero or one parent class.
