### PR TITLE
Add a key parameter to SingleKeyDictionary

### DIFF
--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -49,7 +49,7 @@ export class TypeName {
 /**
  * Type of a value. Used both for property types and nested type definitions.
  */
-export type ValueOf = InstanceOf | ArrayOf | UnionOf | DictionaryOf | NamedValueOf | UserDefinedValue | LiteralValue
+export type ValueOf = InstanceOf | ArrayOf | UnionOf | DictionaryOf | UserDefinedValue | LiteralValue
 
 /**
  * A single value
@@ -78,21 +78,16 @@ export class UnionOf {
 }
 
 /**
- * A dictionary (or map)
+ * A dictionary (or map).  The key is a string or a number (or a union thereof), possibly through an alias.
+ *
+ * If `singleKey` is true, then this dictionary can only have a single key. This is a common pattern in ES APIs,
+ * used to associate a value to a field name or some other identifier.
  */
 export class DictionaryOf {
   kind: 'dictionary_of'
   key: ValueOf
   value: ValueOf
-}
-
-/**
- * A named value. This is a common pattern in ES APIs that deserves its own representation. It's often used to
- * associate some value to a field name, e.g. the "sort" field in search.
- */
-export class NamedValueOf {
-  kind: 'named_value_of'
-  value: ValueOf
+  singleKey: boolean
 }
 
 /**

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -213,17 +213,20 @@ export function modelType (node: Node): model.ValueOf {
           const type: model.DictionaryOf = {
             kind: 'dictionary_of',
             key,
-            value
+            value,
+            singleKey: false
           }
           return type
         }
 
         case 'SingleKeyDictionary': {
-          assert(node, node.getTypeArguments().length === 1, 'A SingleKeyDictionary must have one argument')
-          const [value] = node.getTypeArguments().map(node => modelType(node))
-          const type: model.NamedValueOf = {
-            kind: 'named_value_of',
-            value
+          assert(node, node.getTypeArguments().length === 2, 'A SingleKeyDictionary must have two arguments')
+          const [key, value] = node.getTypeArguments().map(node => modelType(node))
+          const type: model.DictionaryOf = {
+            kind: 'dictionary_of',
+            key,
+            value,
+            singleKey: true
           }
           return type
         }

--- a/compiler/steps/validate-model.ts
+++ b/compiler/steps/validate-model.ts
@@ -686,10 +686,6 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
         validateValueOf(valueOf.value, openGenerics)
         break
 
-      case 'named_value_of':
-        validateValueOf(valueOf.value, openGenerics)
-        break
-
       case 'user_defined_value':
         // Nothing to validate
         break
@@ -841,11 +837,6 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
         context.push('value')
         validateValueOfJsonEvents(valueOf.value)
         context.pop()
-        break
-
-      case 'named_value_of':
-        validateEvent(events, JsonEvent.object)
-        validateValueOfJsonEvents(valueOf.value)
         break
 
       case 'union_of':

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -12492,6 +12492,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -12636,6 +12637,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -12774,6 +12776,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -12815,6 +12818,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -12994,6 +12998,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -13016,6 +13021,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -13044,6 +13050,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -15420,6 +15427,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -15672,6 +15680,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -15905,6 +15914,7 @@
           }
         },
         "kind": "dictionary_of",
+        "singleKey": false,
         "value": {
           "kind": "instance_of",
           "type": {
@@ -16046,6 +16056,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -16078,6 +16089,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -16181,6 +16193,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -16580,6 +16593,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -16768,6 +16782,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -16947,6 +16962,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -17070,6 +17086,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -17678,6 +17695,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -17891,6 +17909,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -18598,6 +18617,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -18696,6 +18716,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -19718,6 +19739,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "user_defined_value"
                 }
@@ -20302,6 +20324,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -32808,6 +32831,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -33826,6 +33850,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -33843,6 +33868,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -33860,6 +33886,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -34123,6 +34150,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -34520,6 +34548,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -34541,6 +34570,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -34562,6 +34592,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -34583,6 +34614,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -34638,6 +34670,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -34841,6 +34874,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -34862,6 +34896,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -35069,6 +35104,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -35711,6 +35747,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -35851,6 +35888,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -35868,6 +35906,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -35961,6 +36000,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -35978,6 +36018,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -36795,6 +36836,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -36816,6 +36858,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -36848,6 +36891,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -37069,6 +37113,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -37090,6 +37135,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -37114,6 +37160,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -37135,6 +37182,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -37156,6 +37204,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -37177,6 +37226,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -37214,6 +37264,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "key": {
                 "kind": "instance_of",
@@ -37223,6 +37274,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -37277,6 +37329,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -37534,6 +37587,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -37588,6 +37642,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -37609,6 +37664,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -37626,6 +37682,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -37990,6 +38047,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -38011,6 +38069,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -38088,6 +38147,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -38789,6 +38849,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -38836,6 +38897,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -38860,6 +38922,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -38969,6 +39032,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "items": [
                 {
@@ -39170,6 +39234,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -39202,6 +39267,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -39238,6 +39304,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "items": [
                 {
@@ -39291,6 +39358,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -39403,6 +39471,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -39431,6 +39500,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -41012,6 +41082,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -41089,6 +41160,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -41937,6 +42009,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -41958,6 +42031,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -42081,6 +42155,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -42702,6 +42777,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -45609,6 +45685,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -45733,6 +45810,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -46102,6 +46180,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -47029,6 +47108,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -48696,6 +48776,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -49286,6 +49367,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -50315,6 +50397,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -50686,6 +50769,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -51465,6 +51549,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -51817,6 +51902,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "key": {
                 "kind": "instance_of",
@@ -51826,6 +51912,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -52732,6 +52819,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -52961,6 +53049,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -53002,6 +53091,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -53358,6 +53448,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -55231,6 +55322,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -57774,6 +57866,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -59751,6 +59844,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -59830,6 +59924,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -60211,6 +60306,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -61098,6 +61194,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -61115,6 +61212,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -61139,6 +61237,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -61642,6 +61741,7 @@
           }
         },
         "kind": "dictionary_of",
+        "singleKey": false,
         "value": {
           "items": [
             {
@@ -61880,6 +61980,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -61923,6 +62024,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -62524,6 +62626,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -62658,6 +62761,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -62738,6 +62842,7 @@
           }
         },
         "kind": "dictionary_of",
+        "singleKey": false,
         "value": {
           "kind": "user_defined_value"
         }
@@ -63258,6 +63363,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "items": [
                 {
@@ -64095,6 +64201,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -64171,6 +64278,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -64664,6 +64772,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -65257,6 +65366,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -65278,6 +65388,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -65518,6 +65629,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -65604,6 +65716,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -65627,6 +65740,7 @@
                     }
                   },
                   "kind": "dictionary_of",
+                  "singleKey": false,
                   "value": {
                     "kind": "instance_of",
                     "type": {
@@ -65658,6 +65772,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -68730,6 +68845,7 @@
                     }
                   },
                   "kind": "dictionary_of",
+                  "singleKey": false,
                   "value": {
                     "kind": "instance_of",
                     "type": {
@@ -68749,6 +68865,7 @@
                       }
                     },
                     "kind": "dictionary_of",
+                    "singleKey": false,
                     "value": {
                       "kind": "instance_of",
                       "type": {
@@ -68796,6 +68913,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -68824,6 +68942,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -69162,6 +69281,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -69231,6 +69351,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -69607,6 +69728,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -69641,6 +69763,7 @@
                     }
                   },
                   "kind": "dictionary_of",
+                  "singleKey": false,
                   "value": {
                     "kind": "instance_of",
                     "type": {
@@ -69672,6 +69795,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -69799,6 +69923,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -69966,6 +70091,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -70007,6 +70133,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -70134,6 +70261,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -70164,6 +70292,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -70185,6 +70314,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -70321,6 +70451,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -70342,6 +70473,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -70489,6 +70621,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -70719,6 +70852,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -71528,6 +71662,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -71827,6 +71962,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -72073,6 +72209,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -72197,6 +72334,7 @@
                     }
                   },
                   "kind": "dictionary_of",
+                  "singleKey": false,
                   "value": {
                     "kind": "user_defined_value"
                   }
@@ -72295,6 +72433,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -73570,6 +73709,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -73872,6 +74012,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "items": [
                 {
@@ -75259,6 +75400,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -75551,6 +75693,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -75954,6 +76097,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -75977,6 +76121,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -76440,6 +76585,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -76461,6 +76607,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -76530,6 +76677,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -77118,6 +77266,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -77154,6 +77303,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -77175,6 +77325,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -79023,6 +79174,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -79044,6 +79196,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -81782,6 +81935,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -82758,6 +82912,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -82870,6 +83025,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -82989,6 +83145,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -83098,6 +83255,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -84184,6 +84342,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -84315,6 +84474,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -84434,6 +84594,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -84543,6 +84704,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -84769,6 +84931,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -85759,6 +85922,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -85987,6 +86151,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -86423,6 +86588,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -87124,6 +87290,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -87145,6 +87312,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -87242,6 +87410,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -87626,6 +87795,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -88818,6 +88988,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -89036,6 +89207,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -89132,6 +89304,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -89351,6 +89524,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -89535,6 +89709,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -90019,6 +90194,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -90174,6 +90350,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -90685,6 +90862,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -90706,6 +90884,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -90806,6 +90985,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -90827,6 +91007,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -90986,6 +91167,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -91124,6 +91306,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -91167,6 +91350,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -91403,6 +91587,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -91625,6 +91810,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -91727,6 +91913,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -92190,6 +92377,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -93786,6 +93974,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -93893,6 +94082,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -95119,6 +95309,7 @@
           }
         },
         "kind": "dictionary_of",
+        "singleKey": false,
         "value": {
           "kind": "instance_of",
           "type": {
@@ -95183,6 +95374,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -95806,6 +95998,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -95823,6 +96016,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -95855,6 +96049,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -95910,6 +96105,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -95998,6 +96194,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -97268,7 +97465,15 @@
           "name": "common",
           "required": false,
           "type": {
-            "kind": "named_value_of",
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
             "value": {
               "items": [
                 {
@@ -97318,7 +97523,15 @@
           "type": {
             "items": [
               {
-                "kind": "named_value_of",
+                "key": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "Field",
+                    "namespace": "_types"
+                  }
+                },
+                "kind": "dictionary_of",
+                "singleKey": true,
                 "value": {
                   "items": [
                     {
@@ -97376,7 +97589,15 @@
           "name": "fuzzy",
           "required": false,
           "type": {
-            "kind": "named_value_of",
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
             "value": {
               "items": [
                 {
@@ -99634,6 +99855,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "key": {
                 "kind": "instance_of",
@@ -99643,6 +99865,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -100016,6 +100239,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -100061,6 +100285,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -100082,6 +100307,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -101540,6 +101766,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -101991,6 +102218,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -102607,6 +102835,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "items": [
                 {
@@ -102894,6 +103123,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -102951,6 +103181,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -103429,6 +103660,7 @@
           }
         },
         "kind": "dictionary_of",
+        "singleKey": false,
         "value": {
           "kind": "instance_of",
           "type": {
@@ -104077,6 +104309,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "key": {
                 "kind": "instance_of",
@@ -104086,6 +104319,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -104245,6 +104479,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -104636,6 +104871,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -104876,6 +105112,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -105450,6 +105687,7 @@
           }
         },
         "kind": "dictionary_of",
+        "singleKey": false,
         "value": {
           "kind": "instance_of",
           "type": {
@@ -106103,6 +106341,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -106140,6 +106379,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -106225,6 +106465,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -106435,6 +106676,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -106542,6 +106784,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -107050,6 +107293,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -107071,6 +107315,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -107161,6 +107406,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -107291,6 +107537,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -107436,6 +107683,7 @@
                     }
                   },
                   "kind": "dictionary_of",
+                  "singleKey": false,
                   "value": {
                     "kind": "instance_of",
                     "type": {
@@ -108191,6 +108439,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -108237,6 +108486,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -108309,6 +108559,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "array_of",
               "value": {
@@ -108466,6 +108717,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -108504,6 +108756,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -108677,6 +108930,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -108718,6 +108972,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -109174,6 +109429,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -109655,6 +109911,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -109860,6 +110117,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -109949,6 +110207,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -110042,6 +110301,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -110131,6 +110391,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -110194,6 +110455,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -110364,6 +110626,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -110985,6 +111248,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -111739,6 +112003,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -111771,6 +112036,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -112117,6 +112383,7 @@
             }
           },
           "kind": "dictionary_of",
+          "singleKey": false,
           "value": {
             "key": {
               "kind": "instance_of",
@@ -112126,6 +112393,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -112181,6 +112449,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -112232,6 +112501,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -112401,6 +112671,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -112432,6 +112703,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -112605,6 +112877,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -112992,6 +113265,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -113013,6 +113287,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -113098,6 +113373,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -113260,6 +113536,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -113853,6 +114130,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -115010,6 +115288,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -115256,6 +115535,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -117338,6 +117618,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -117891,6 +118172,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -118041,6 +118323,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -118062,6 +118345,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -119495,6 +119779,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -119746,6 +120031,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -121340,6 +121626,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -121361,6 +121648,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -121559,6 +121847,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "items": [
                 {
@@ -122774,6 +123063,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -123607,6 +123897,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -123709,6 +124000,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -124269,6 +124561,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -124326,6 +124619,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -124628,6 +124922,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -124860,6 +125155,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -125108,6 +125404,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -125204,6 +125501,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -125555,6 +125853,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -125574,6 +125873,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -127328,6 +127628,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "user_defined_value"
                 }
@@ -127411,6 +127712,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -127570,6 +127872,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "items": [
                 {
@@ -128251,6 +128554,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -128272,6 +128576,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -128673,6 +128978,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -129122,6 +129428,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -129213,6 +129520,7 @@
                   }
                 },
                 "kind": "dictionary_of",
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -129232,6 +129540,7 @@
                     }
                   },
                   "kind": "dictionary_of",
+                  "singleKey": false,
                   "value": {
                     "kind": "instance_of",
                     "type": {
@@ -129301,6 +129610,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -129355,6 +129665,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -130370,6 +130681,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -130449,6 +130761,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -131901,6 +132214,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -131944,6 +132258,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -132061,6 +132376,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -132246,6 +132562,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -132431,6 +132748,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -132518,6 +132836,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -132539,6 +132858,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -132798,6 +133118,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "instance_of",
                 "type": {
@@ -132841,6 +133162,7 @@
                 }
               },
               "kind": "dictionary_of",
+              "singleKey": false,
               "value": {
                 "kind": "user_defined_value"
               }
@@ -133505,6 +133827,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -133526,6 +133849,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -133547,6 +133871,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -134780,6 +135105,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -134870,6 +135196,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }
@@ -135316,6 +135643,7 @@
               }
             },
             "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "user_defined_value"
             }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10167,13 +10167,13 @@ export interface QueryCacheStats {
 export interface QueryDslAbstractionsContainerQueryContainer {
   bool?: QueryDslCompoundBoolBoolQuery
   boosting?: QueryDslCompoundBoostingBoostingQuery
-  common?: Record<string, QueryDslFullTextCommonTermsCommonTermsQuery | string>
+  common?: Record<Field, QueryDslFullTextCommonTermsCommonTermsQuery | string>
   constant_score?: QueryDslCompoundConstantScoreConstantScoreQuery
   dis_max?: QueryDslCompoundDismaxDisMaxQuery
-  distance_feature?: Record<string, QueryDslSpecializedDistanceFeatureDistanceFeatureQuery | string> | QueryDslSpecializedDistanceFeatureDistanceFeatureQuery
+  distance_feature?: Record<Field, QueryDslSpecializedDistanceFeatureDistanceFeatureQuery | string> | QueryDslSpecializedDistanceFeatureDistanceFeatureQuery
   exists?: QueryDslTermLevelExistsExistsQuery
   function_score?: QueryDslCompoundFunctionScoreFunctionScoreQuery
-  fuzzy?: Record<string, QueryDslTermLevelFuzzyFuzzyQuery | string>
+  fuzzy?: Record<Field, QueryDslTermLevelFuzzyFuzzyQuery | string>
   geo_bounding_box?: QueryDslAbstractionsQueryNamedQuery<QueryDslGeoBoundingBoxGeoBoundingBoxQuery | string>
   geo_distance?: QueryDslAbstractionsQueryNamedQuery<QueryDslGeoDistanceGeoDistanceQuery | string>
   geo_polygon?: QueryDslAbstractionsQueryNamedQuery<QueryDslGeoPolygonGeoPolygonQuery | string>

--- a/specification/_spec_utils/Dictionary.ts
+++ b/specification/_spec_utils/Dictionary.ts
@@ -19,4 +19,4 @@
 
 export class Dictionary<TKey, TValue> {}
 
-export class SingleKeyDictionary<TValue> {}
+export class SingleKeyDictionary<TKey, TValue> {}

--- a/specification/_types/query_dsl/abstractions/container/QueryContainer.ts
+++ b/specification/_types/query_dsl/abstractions/container/QueryContainer.ts
@@ -73,6 +73,7 @@ import { TypeQuery } from '@_types/query_dsl/term_level/type/TypeQuery'
 import { WildcardQuery } from '@_types/query_dsl/term_level/wildcard/WildcardQuery'
 import { NamedQuery } from '../query/Query'
 import { QueryTemplate } from './QueryTemplate'
+import {Field} from "@_types/common";
 
 /**
  * @variants container
@@ -80,17 +81,17 @@ import { QueryTemplate } from './QueryTemplate'
 export class QueryContainer {
   bool?: BoolQuery
   boosting?: BoostingQuery
-  common?: SingleKeyDictionary<CommonTermsQuery | string>
+  common?: SingleKeyDictionary<Field, CommonTermsQuery | string>
   constant_score?: ConstantScoreQuery
   dis_max?: DisMaxQuery
   // TODO?: can be both { __field__ ?: { options } } and { field?: "" ...options }
   // very lenient parser on the server, never documented as such but used in yamltests as such
   distance_feature?:
-    | SingleKeyDictionary<DistanceFeatureQuery | string>
+    | SingleKeyDictionary<Field, DistanceFeatureQuery | string>
     | DistanceFeatureQuery
   exists?: ExistsQuery
   function_score?: FunctionScoreQuery
-  fuzzy?: SingleKeyDictionary<FuzzyQuery | string>
+  fuzzy?: SingleKeyDictionary<Field, FuzzyQuery | string>
   geo_bounding_box?: NamedQuery<GeoBoundingBoxQuery | string>
   geo_distance?: NamedQuery<GeoDistanceQuery | string>
   geo_polygon?: NamedQuery<GeoPolygonQuery | string>

--- a/specification/_types/query_dsl/abstractions/container/QueryContainer.ts
+++ b/specification/_types/query_dsl/abstractions/container/QueryContainer.ts
@@ -73,7 +73,7 @@ import { TypeQuery } from '@_types/query_dsl/term_level/type/TypeQuery'
 import { WildcardQuery } from '@_types/query_dsl/term_level/wildcard/WildcardQuery'
 import { NamedQuery } from '../query/Query'
 import { QueryTemplate } from './QueryTemplate'
-import {Field} from "@_types/common";
+import { Field } from '@_types/common'
 
 /**
  * @variants container

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -94,8 +94,6 @@ function buildValue (type: M.ValueOf, openGenerics?: string[]): string | number 
       return type.items.map(t => buildValue(t, openGenerics)).join(' | ')
     case 'dictionary_of':
       return `Record<${buildValue(type.key, openGenerics)}, ${buildValue(type.value, openGenerics)}>`
-    case 'named_value_of':
-      return `Record<string, ${buildValue(type.value, openGenerics)}>`
     case 'user_defined_value':
       return 'any'
     case 'literal_value':


### PR DESCRIPTION
Semantic typing of strings is important to precisely capture the nature of fields, which is useful for very strongly typed languages and tools like editors where types can drive autocompletion and validation.

The `SingleKeyDictionary` behavior assumes that its keys are `strings` and doesn't allow expressing the real nature of these keys.

This PR changes `SingleKeyDictionary` to have a `Key` generic parameter, just like `Dictionary`, and updates the specification accordingly (using `Field` in `QueryContainer`, for example).

With `SingleKeyDictionary` also having a `key`, there's no real point for it to be a dedicated abstration in the metamodel. It is now represented as a `isSingleKey` boolean value on the `Dictionary` model class. This simplifies the model, and also code generators for languages that can't make a difference between single and multiple key dictionaries (see changes in the TS generator).