### PR TITLE
Update inherits resolver

### DIFF
--- a/compiler/model/build-model.ts
+++ b/compiler/model/build-model.ts
@@ -234,9 +234,11 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
     }
 
     for (const inherit of declaration.getHeritageClauses()) {
-      const extended = modelInherits(inherit)
-      assert(inherit, extended.length <= 1, '??? TypeScript only allows to extend a single class')
-      type.inherits = extended[0]
+      const extended = inherit.getTypeNodes()
+        .map(t => t.getExpression())
+        .map(t => t.getType().getSymbol()?.getDeclarations()[0])[0]
+      assert(inherit, Node.isClassDeclaration(extended) || Node.isInterfaceDeclaration(extended), 'Should extend from a class or interface')
+      type.inherits = modelInherits(extended, inherit)
     }
 
     for (const typeParameter of declaration.getTypeParameters()) {
@@ -300,9 +302,11 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
 
     for (const inherit of declaration.getHeritageClauses()) {
       if (inherit.getToken() === ts.SyntaxKind.ExtendsKeyword) {
-        const extended = modelInherits(inherit)
-        assert(inherit, extended.length <= 1, '??? TypeScript only allows to extend a single class')
-        type.inherits = extended[0]
+        const extended = inherit.getTypeNodes()
+          .map(t => t.getExpression())
+          .map(t => t.getType().getSymbol()?.getDeclarations()[0])[0]
+        assert(inherit, Node.isClassDeclaration(extended) || Node.isInterfaceDeclaration(extended), 'Should extend from a class or interface')
+        type.inherits = modelInherits(extended, inherit)
       }
     }
 

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -268,22 +268,20 @@ export function isApi (declaration: InterfaceDeclaration): boolean {
 }
 
 /**
- * Given a HeritageClause node returns an Inherits structure.
- * A class could extend from multiple classes, which are
- * defined inside the node typeArguments.
+ * Given the extended class or interface definition and the HeritageClause node
+ * returns an Inherits structure.
  */
-export function modelInherits (node: HeritageClause): model.Inherits[] {
-  return node.getTypeNodes().map(node => {
-    assert(node, Node.isExpressionWithTypeArguments(node), 'The node should be a expression with type arguments')
-    const generics = node.getTypeArguments().map(node => modelType(node))
-    return {
-      type: {
-        name: node.getExpression().getText(),
-        namespace: getNameSpace(node)
-      },
-      ...(generics.length > 0 && { generics })
-    }
-  })
+export function modelInherits (node: InterfaceDeclaration | ClassDeclaration, inherit: HeritageClause): model.Inherits {
+  const generics = inherit.getTypeNodes()
+    .flatMap(node => node.getTypeArguments())
+    .map(node => modelType(node))
+  return {
+    type: {
+      name: node.getName() as string,
+      namespace: getNameSpace(node)
+    },
+    ...(generics.length > 0 && { generics })
+  }
 }
 
 /**


### PR DESCRIPTION
This pr improves the inherit resolving, now we can also import an alias, and the generated schema will use the original declaration with the correct namespace.