### PR TITLE
Introduce HttpStatusCode Response type

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -62190,6 +62190,32 @@
       ]
     },
     {
+      "attachedBehaviors": [
+        "EmptyResponseBase"
+      ],
+      "behaviors": [
+        {
+          "type": {
+            "name": "EmptyResponseBase",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
+      "description": "Empty Response body, with the result defined by the HTTP status code",
+      "inherits": {
+        "type": {
+          "name": "ResponseBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "HttpStatusCodeResponseBase",
+        "namespace": "_types"
+      },
+      "properties": []
+    },
+    {
       "inherits": {
         "type": {
           "name": "TokenFilterBase",
@@ -94399,17 +94425,9 @@
       "attachedBehaviors": [
         "EmptyResponseBase"
       ],
-      "behaviors": [
-        {
-          "type": {
-            "name": "EmptyResponseBase",
-            "namespace": "_spec_utils"
-          }
-        }
-      ],
       "inherits": {
         "type": {
-          "name": "ResponseBase",
+          "name": "HttpStatusCodeResponseBase",
           "namespace": "_types"
         }
       },
@@ -110899,9 +110917,12 @@
       ]
     },
     {
+      "attachedBehaviors": [
+        "EmptyResponseBase"
+      ],
       "inherits": {
         "type": {
-          "name": "ResponseBase",
+          "name": "HttpStatusCodeResponseBase",
           "namespace": "_types"
         }
       },
@@ -110910,19 +110931,7 @@
         "name": "SecurityDisableUserResponse",
         "namespace": "security.disable_user"
       },
-      "properties": [
-        {
-          "name": "stub",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
+      "properties": []
     },
     {
       "attachedBehaviors": [
@@ -110968,9 +110977,12 @@
       ]
     },
     {
+      "attachedBehaviors": [
+        "EmptyResponseBase"
+      ],
       "inherits": {
         "type": {
-          "name": "ResponseBase",
+          "name": "HttpStatusCodeResponseBase",
           "namespace": "_types"
         }
       },
@@ -110979,19 +110991,7 @@
         "name": "SecurityEnableUserResponse",
         "namespace": "security.enable_user"
       },
-      "properties": [
-        {
-          "name": "stub",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
+      "properties": []
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6106,6 +6106,9 @@ export interface NodesNodesStatsHttpStats {
   total_opened: long
 }
 
+export interface HttpStatusCodeResponseBase extends ResponseBase {
+}
+
 export interface AnalysisTokenFiltersHunspellTokenFilter extends AnalysisTokenFiltersTokenFilterBase {
   dedup: boolean
   dictionary: string
@@ -11619,18 +11622,14 @@ export interface SecurityDisableUserSecurityDisableUserRequest extends RequestBa
   refresh?: Refresh
 }
 
-export interface SecurityDisableUserSecurityDisableUserResponse extends ResponseBase {
-  stub: integer
-}
+export type SecurityDisableUserSecurityDisableUserResponse = boolean
 
 export interface SecurityEnableUserSecurityEnableUserRequest extends RequestBase {
   username: Username
   refresh?: Refresh
 }
 
-export interface SecurityEnableUserSecurityEnableUserResponse extends ResponseBase {
-  stub: integer
-}
+export type SecurityEnableUserSecurityEnableUserResponse = boolean
 
 export interface XpackUsageSecurityFeatureToggle {
   enabled: boolean

--- a/specification/_global/ping/PingResponse.ts
+++ b/specification/_global/ping/PingResponse.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { EmptyResponseBase } from '@spec_utils/behaviors'
-import { ResponseBase } from '@_types/Base'
+import { HttpStatusCodeResponseBase } from '@_types/Base'
 
-export class PingResponse extends ResponseBase implements EmptyResponseBase {}
+export class PingResponse extends HttpStatusCodeResponseBase {}

--- a/specification/_types/Base.ts
+++ b/specification/_types/Base.ts
@@ -18,6 +18,7 @@
  */
 
 import { CommonQueryParameters } from '@spec_utils/behaviors'
+import { EmptyResponseBase } from '_spec_utils/behaviors'
 import {
   Id,
   IndexName,
@@ -58,6 +59,13 @@ export class AcknowledgedResponseBase extends ResponseBase {
 export class DictionaryResponseBase<TKey, TValue> extends ResponseBase {}
 
 export class DynamicResponseBase extends ResponseBase {}
+
+/**
+ * Empty Response body, with the result defined by the HTTP status code
+ */
+export class HttpStatusCodeResponseBase
+  extends ResponseBase
+  implements EmptyResponseBase {}
 
 export class ElasticsearchVersionInfo {
   build_date: DateString

--- a/specification/security/disable_user/SecurityDisableUserResponse.ts
+++ b/specification/security/disable_user/SecurityDisableUserResponse.ts
@@ -17,9 +17,6 @@
  * under the License.
  */
 
-import { ResponseBase } from '@_types/Base'
-import { integer } from '@_types/Numeric'
+import { HttpStatusCodeResponseBase } from '@_types/Base'
 
-export class SecurityDisableUserResponse extends ResponseBase {
-  stub: integer
-}
+export class SecurityDisableUserResponse extends HttpStatusCodeResponseBase {}

--- a/specification/security/enable_user/SecurityEnableUserResponse.ts
+++ b/specification/security/enable_user/SecurityEnableUserResponse.ts
@@ -17,9 +17,6 @@
  * under the License.
  */
 
-import { ResponseBase } from '@_types/Base'
-import { integer } from '@_types/Numeric'
+import { HttpStatusCodeResponseBase } from '@_types/Base'
 
-export class SecurityEnableUserResponse extends ResponseBase {
-  stub: integer
-}
+export class SecurityEnableUserResponse extends HttpStatusCodeResponseBase {}


### PR DESCRIPTION
Several API's respond with only a status code, this PR introduces a dedicated identification for these API's.

Furthermore, does this PR validate the endpoints: `security.enable_user` and `security.disable_user`

The next phase for this action is to be able to register, `success` and `error` properties in the class that are driven by the status codes returned.