### PR TITLE
Support import alias

### DIFF
--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -240,11 +240,37 @@ export function modelType (node: Node): model.ValueOf {
 
         default: {
           const generics = node.getTypeArguments().map(node => modelType(node))
+          const identifier = node.getTypeName()
+          assert(node, Node.isIdentifier(identifier), 'Not an identifier')
+
+          const declaration = identifier.getDefinitions()[0].getDeclarationNode()
+          // We are looking at a generic parameter
+          if (declaration == null) {
+            const type: model.InstanceOf = {
+              kind: 'instance_of',
+              ...(generics.length > 0 && { generics }),
+              type: {
+                name,
+                namespace: getNameSpace(node)
+              }
+            }
+            return type
+          }
+
+          assert(
+            node,
+            Node.isClassDeclaration(declaration) ||
+            Node.isInterfaceDeclaration(declaration) ||
+            Node.isEnumDeclaration(declaration) ||
+            Node.isTypeAliasDeclaration(declaration) ||
+            Node.isTypeParameterDeclaration(declaration),
+            'It should be a class, interface, enum, type alias, or type parameter declaration'
+          )
           const type: model.InstanceOf = {
             kind: 'instance_of',
             ...(generics.length > 0 && { generics }),
             type: {
-              name,
+              name: declaration.getName() as string,
               namespace: getNameSpace(node)
             }
           }


### PR DESCRIPTION
This change will allow us to fully (🤞) support import aliases.


For example:
```ts
// ns/foo.ts
export type Hello = string


// ns/bar.ts
import { Hello as Greeting } from './foo'

export class Bar {
  greeting: Greeting
}
``` 

In the schema, the `greeting` property of `Bar` will be:
```json
{
  "name": "Hello",
  "namespace": "ns"
}
```