### PR TITLE
Validate searchable_snapshots.clear_cache fix

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -109308,22 +109308,6 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
-      "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "stub_c",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "_types"
-              }
-            }
-          }
-        ]
-      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109337,12 +109321,13 @@
       },
       "path": [
         {
-          "name": "stub_a",
-          "required": true,
+          "description": "A comma-separated list of index names",
+          "name": "index",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "Indices",
               "namespace": "_types"
             }
           }
@@ -109350,13 +109335,57 @@
       ],
       "query": [
         {
-          "name": "stub_b",
-          "required": true,
+          "name": "expand_wildcards",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "ExpandWildcards",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "allow_no_indices",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "ignore_unavailable",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "pretty",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "human",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11427,11 +11427,12 @@ export interface WatcherSearchTransform {
 export type SearchType = 'query_then_fetch' | 'dfs_query_then_fetch'
 
 export interface SearchableSnapshotsClearCacheSearchableSnapshotsClearCacheRequest extends RequestBase {
-  stub_a: integer
-  stub_b: integer
-  body?: {
-    stub_c: integer
-  }
+  index?: Indices
+  expand_wildcards?: ExpandWildcards
+  allow_no_indices?: boolean
+  ignore_unavailable?: boolean
+  pretty?: boolean
+  human?: boolean
 }
 
 export interface SearchableSnapshotsClearCacheSearchableSnapshotsClearCacheResponse extends ResponseBase {

--- a/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
+++ b/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { integer } from '@_types/Numeric'
+import { ExpandWildcards, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name searchable_snapshots.clear_cache
@@ -27,12 +27,13 @@ import { integer } from '@_types/Numeric'
  */
 export interface SearchableSnapshotsClearCacheRequest extends RequestBase {
   path_parts?: {
-    stub_a: integer
+    index?: Indices
   }
   query_parameters?: {
-    stub_b: integer
-  }
-  body?: {
-    stub_c: integer
+    expand_wildcards?: ExpandWildcards
+    allow_no_indices?: boolean
+    ignore_unavailable?: boolean
+    pretty?: boolean
+    human?: boolean
   }
 }


### PR DESCRIPTION
as titled, but has no upstream tests.

added `human` and `pretty` based on https://github.com/elastic/support-diagnostics/pull/482/files