### PR TITLE
Validate indices.put_index_template

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -4752,10 +4752,17 @@
       "description": "Creates or updates an index template.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "name": "indices.put_index_template",
-      "request": null,
+      "request": {
+        "name": "Request",
+        "namespace": "indices.put_index_template"
+      },
       "requestBodyRequired": true,
-      "response": null,
-      "stability": "stable",
+      "response": {
+        "name": "Response",
+        "namespace": "indices.put_index_template"
+      },
+      "since": "7.9.0",
+      "stability": "TODO",
       "urls": [
         {
           "methods": [
@@ -87320,6 +87327,189 @@
       "name": {
         "name": "Response",
         "namespace": "indices.put_alias"
+      },
+      "properties": []
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "IndexTemplateMapping",
+        "namespace": "indices.put_index_template"
+      },
+      "properties": [
+        {
+          "name": "aliases",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "IndexName",
+                "namespace": "_types"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Alias",
+                "namespace": "indices._types"
+              }
+            }
+          }
+        },
+        {
+          "name": "mappings",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TypeMapping",
+              "namespace": "_types.mapping"
+            }
+          }
+        },
+        {
+          "name": "settings",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexSettings",
+              "namespace": "_types.index"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "index_patterns",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Indices",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "composed_of",
+            "required": false,
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Name",
+                  "namespace": "_types"
+                }
+              }
+            }
+          },
+          {
+            "name": "template",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "IndexTemplateMapping",
+                "namespace": "indices.put_index_template"
+              }
+            }
+          },
+          {
+            "name": "data_stream",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "EmptyObject",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "priority",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "version",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "VersionNumber",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "_meta",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "IndexMetaData",
+                "namespace": "_types"
+              }
+            }
+          }
+        ]
+      },
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "indices.put_index_template"
+      },
+      "path": [
+        {
+          "description": "Index or template name",
+          "name": "name",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Name",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": []
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "Response",
+        "namespace": "indices.put_index_template"
       },
       "properties": []
     },

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -440,7 +440,7 @@
     },
     "indices.put_index_template": {
       "request": [
-        "Missing request & response"
+        "Endpoint has \"@stability: TODO"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8705,6 +8705,28 @@ export interface IndicesPutAliasRequest extends RequestBase {
 export interface IndicesPutAliasResponse extends ResponseBase {
 }
 
+export interface IndicesPutIndexTemplateIndexTemplateMapping {
+  aliases?: Record<IndexName, IndicesAlias>
+  mappings?: MappingTypeMapping
+  settings?: IndexIndexSettings
+}
+
+export interface IndicesPutIndexTemplateRequest extends RequestBase {
+  name: Name
+  body?: {
+    index_patterns?: Indices
+    composed_of?: Name[]
+    template?: IndicesPutIndexTemplateIndexTemplateMapping
+    data_stream?: EmptyObject
+    priority?: integer
+    version?: VersionNumber
+    _meta?: IndexMetaData
+  }
+}
+
+export interface IndicesPutIndexTemplateResponse extends AcknowledgedResponseBase {
+}
+
 export interface IndicesPutMappingRequest extends RequestBase {
   index?: Indices
   type?: Type

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -20,7 +20,14 @@
 import { Alias } from '@indices/_types/Alias'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { RequestBase } from '@_types/Base'
-import { EmptyObject, IndexMetaData, IndexName, Indices, Name, VersionNumber } from '@_types/common'
+import {
+  EmptyObject,
+  IndexMetaData,
+  IndexName,
+  Indices,
+  Name,
+  VersionNumber
+} from '@_types/common'
 import { IndexSettings } from '@_types/index/IndexSettings'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { integer } from '@_types/Numeric'

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Alias } from '@indices/_types/Alias'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { RequestBase } from '@_types/Base'
+import { EmptyObject, IndexMetaData, IndexName, Indices, Name, VersionNumber } from '@_types/common'
+import { IndexSettings } from '@_types/index/IndexSettings'
+import { TypeMapping } from '@_types/mapping/TypeMapping'
+import { integer } from '@_types/Numeric'
+
+/**
+ * @rest_spec_name indices.put_index_template
+ * @since 7.9.0
+ * @stability TODO
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /** Index or template name */
+    name: Name
+  }
+  body?: {
+    index_patterns?: Indices
+    composed_of?: Name[]
+    template?: IndexTemplateMapping
+    data_stream?: EmptyObject
+    priority?: integer
+    version?: VersionNumber
+    _meta?: IndexMetaData
+  }
+}
+
+export class IndexTemplateMapping {
+  aliases?: Dictionary<IndexName, Alias>
+  mappings?: TypeMapping
+  settings?: IndexSettings
+}

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateResponse.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateResponse.ts
@@ -19,6 +19,4 @@
 
 import { AcknowledgedResponseBase } from '@_types/Base'
 
-// TODO must be changed to HttpStatusCodeResponse once
-// https://github.com/elastic/elastic-client-generator/pull/373 is merged.
 export class Response extends AcknowledgedResponseBase {}

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateResponse.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+// TODO must be changed to HttpStatusCodeResponse once
+// https://github.com/elastic/elastic-client-generator/pull/373 is merged.
+export class Response extends AcknowledgedResponseBase {}


### PR DESCRIPTION
The request is validated but 2 more tests are failing because of flattening. E.g. in xpack-Verify_data_stream_resolvability_in_ILM_remove_policy_API_1_request.json.test-d.ts:
```
"settings": {
  "index.lifecycle.name": "my_moveable_timeseries_lifecycle"
}
```
 Response is validated.