### PR TITLE
Fix search Request

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -49996,6 +49996,18 @@
           }
         },
         {
+          "name": "combined_fields",
+          "required": false,
+          "since": "7.13.0",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "CombinedFieldsQuery",
+              "namespace": "_types.query_dsl.abstractions.query"
+            }
+          }
+        },
+        {
           "name": "constant_score",
           "required": false,
           "type": {
@@ -51108,6 +51120,51 @@
             "type": {
               "name": "Routing",
               "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "CombinedFieldsQuery",
+        "namespace": "_types.query_dsl.abstractions.query"
+      },
+      "properties": [
+        {
+          "name": "query",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "fields",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
+            }
+          }
+        },
+        {
+          "name": "operator",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
           }
         }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -50167,31 +50167,10 @@
           "name": "geo_distance",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "GeoDistanceQuery",
-                      "namespace": "_types.query_dsl.geo.distance"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl.abstractions.query"
+              "name": "GeoDistanceQuery",
+              "namespace": "_types.query_dsl.geo.distance"
             }
           }
         },
@@ -54444,6 +54423,33 @@
       }
     },
     {
+      "attachedBehaviors": [
+        "AdditionalProperties"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "GeoLocation",
+                "namespace": "_types.query_dsl.geo"
+              }
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperties",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
       "inherits": {
         "type": {
           "name": "QueryBase",
@@ -54475,17 +54481,6 @@
             "type": {
               "name": "GeoDistanceType",
               "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "location",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "GeoLocation",
-              "namespace": "_types.query_dsl.geo"
             }
           }
         },

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -24174,7 +24174,7 @@
       "properties": [
         {
           "name": "filter",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1290,7 +1290,7 @@ export type SearchSortGeoDistanceSort = SearchSortGeoDistanceSortKeys |
     { [property: string]: QueryDslGeoGeoLocation | QueryDslGeoGeoLocation[] }
 
 export interface SearchSortNestedSortValue {
-  filter: QueryDslAbstractionsContainerQueryContainer
+  filter?: QueryDslAbstractionsContainerQueryContainer
   max_children?: integer
   path: Field
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4103,6 +4103,7 @@ export interface QueryDslAbstractionsContainerQueryContainer {
   bool?: QueryDslCompoundBoolBoolQuery
   boosting?: QueryDslCompoundBoostingBoostingQuery
   common?: Record<Field, QueryDslFullTextCommonTermsCommonTermsQuery | string>
+  combined_fields?: QueryDslAbstractionsQueryCombinedFieldsQuery
   constant_score?: QueryDslCompoundConstantScoreConstantScoreQuery
   dis_max?: QueryDslCompoundDismaxDisMaxQuery
   distance_feature?: Record<Field, QueryDslSpecializedDistanceFeatureDistanceFeatureQuery | string> | QueryDslSpecializedDistanceFeatureDistanceFeatureQuery
@@ -4164,6 +4165,12 @@ export interface QueryDslAbstractionsFieldLookupFieldLookup {
   index?: IndexName
   path?: Field
   routing?: Routing
+}
+
+export interface QueryDslAbstractionsQueryCombinedFieldsQuery {
+  query: string
+  fields: Field[]
+  operator?: string
 }
 
 export interface QueryDslAbstractionsQueryNamedQueryKeys<TQuery = unknown> {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4111,7 +4111,7 @@ export interface QueryDslAbstractionsContainerQueryContainer {
   function_score?: QueryDslCompoundFunctionScoreFunctionScoreQuery
   fuzzy?: Record<Field, QueryDslTermLevelFuzzyFuzzyQuery | string>
   geo_bounding_box?: QueryDslAbstractionsQueryNamedQuery<QueryDslGeoBoundingBoxGeoBoundingBoxQuery | string>
-  geo_distance?: QueryDslAbstractionsQueryNamedQuery<QueryDslGeoDistanceGeoDistanceQuery | string>
+  geo_distance?: QueryDslGeoDistanceGeoDistanceQuery
   geo_polygon?: QueryDslAbstractionsQueryNamedQuery<QueryDslGeoPolygonGeoPolygonQuery | string>
   geo_shape?: QueryDslAbstractionsQueryNamedQuery<QueryDslGeoShapeGeoShapeQuery | string>
   has_child?: QueryDslJoiningHasChildHasChildQuery
@@ -4516,12 +4516,13 @@ export interface QueryDslGeoBoundingBoxGeoBoundingBoxQuery extends QueryDslAbstr
 
 export type QueryDslGeoBoundingBoxGeoExecution = 'memory' | 'indexed'
 
-export interface QueryDslGeoDistanceGeoDistanceQuery extends QueryDslAbstractionsQueryQueryBase {
+export interface QueryDslGeoDistanceGeoDistanceQueryKeys extends QueryDslAbstractionsQueryQueryBase {
   distance?: Distance
   distance_type?: GeoDistanceType
-  location?: QueryDslGeoGeoLocation
   validation_method?: QueryDslGeoGeoValidationMethod
 }
+export type QueryDslGeoDistanceGeoDistanceQuery = QueryDslGeoDistanceGeoDistanceQueryKeys |
+    { [property: string]: QueryDslGeoGeoLocation }
 
 export interface QueryDslGeoPolygonGeoPolygonQuery extends QueryDslAbstractionsQueryQueryBase {
   points?: QueryDslGeoGeoLocation[]

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -110,7 +110,6 @@ export interface Request extends RequestBase {
     from?: integer
     highlight?: Highlight
     track_total_hits?: boolean | integer
-    /** @prop_serializer IndicesBoostFormatter */
     indices_boost?: Array<Dictionary<IndexName, double>>
     docvalue_fields?: DocValueField | Array<Field | DocValueField>
     min_score?: double

--- a/specification/_global/search/sort/NestedSort.ts
+++ b/specification/_global/search/sort/NestedSort.ts
@@ -22,10 +22,10 @@ import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions/container/QueryContainer'
 
 export class NestedSortValue {
-  filter: QueryContainer
+  filter?: QueryContainer
   max_children?: integer
   path: Field
-  //nested: NestedSortValue
+  // nested: NestedSortValue
 }
 
 // export type NestedSort = Dictionary<Field, NestedSortKey>

--- a/specification/_types/query_dsl/abstractions/container/QueryContainer.ts
+++ b/specification/_types/query_dsl/abstractions/container/QueryContainer.ts
@@ -71,7 +71,7 @@ import { TermsQuery } from '@_types/query_dsl/term_level/terms/TermsQuery'
 import { TermsSetQuery } from '@_types/query_dsl/term_level/terms_set/TermsSetQuery'
 import { TypeQuery } from '@_types/query_dsl/term_level/type/TypeQuery'
 import { WildcardQuery } from '@_types/query_dsl/term_level/wildcard/WildcardQuery'
-import { NamedQuery } from '../query/Query'
+import { CombinedFieldsQuery, NamedQuery } from '../query/Query'
 import { QueryTemplate } from './QueryTemplate'
 import { Field } from '@_types/common'
 
@@ -82,6 +82,8 @@ export class QueryContainer {
   bool?: BoolQuery
   boosting?: BoostingQuery
   common?: SingleKeyDictionary<Field, CommonTermsQuery | string>
+  /** @since 7.13.0 */
+  combined_fields?: CombinedFieldsQuery
   constant_score?: ConstantScoreQuery
   dis_max?: DisMaxQuery
   // TODO?: can be both { __field__ ?: { options } } and { field?: "" ...options }

--- a/specification/_types/query_dsl/abstractions/container/QueryContainer.ts
+++ b/specification/_types/query_dsl/abstractions/container/QueryContainer.ts
@@ -95,7 +95,7 @@ export class QueryContainer {
   function_score?: FunctionScoreQuery
   fuzzy?: SingleKeyDictionary<Field, FuzzyQuery | string>
   geo_bounding_box?: NamedQuery<GeoBoundingBoxQuery | string>
-  geo_distance?: NamedQuery<GeoDistanceQuery | string>
+  geo_distance?: GeoDistanceQuery
   geo_polygon?: NamedQuery<GeoPolygonQuery | string>
   geo_shape?: NamedQuery<GeoShapeQuery | string>
   has_child?: HasChildQuery

--- a/specification/_types/query_dsl/abstractions/query/Query.ts
+++ b/specification/_types/query_dsl/abstractions/query/Query.ts
@@ -18,6 +18,7 @@
  */
 
 import { AdditionalProperties } from '@spec_utils/behaviors'
+import { Field } from '@_types/common'
 import { float } from '@_types/Numeric'
 
 export class QueryBase {
@@ -37,4 +38,10 @@ export class NamedQuery<TQuery>
   boost?: float
   _name?: string
   ignore_unmapped?: boolean
+}
+
+export class CombinedFieldsQuery {
+  query: string
+  fields: Field[]
+  operator?: string
 }

--- a/specification/_types/query_dsl/geo/distance/GeoDistanceQuery.ts
+++ b/specification/_types/query_dsl/geo/distance/GeoDistanceQuery.ts
@@ -17,14 +17,16 @@
  * under the License.
  */
 
+import { AdditionalProperties } from '@spec_utils/behaviors'
 import { Distance, GeoDistanceType } from '@_types/Geo'
 import { QueryBase } from '@_types/query_dsl/abstractions/query/Query'
 import { GeoLocation } from '../GeoLocation'
 import { GeoValidationMethod } from '../GeoValidationMethod'
 
-export class GeoDistanceQuery extends QueryBase {
+export class GeoDistanceQuery
+  extends QueryBase
+  implements AdditionalProperties<string, GeoLocation> {
   distance?: Distance
   distance_type?: GeoDistanceType
-  location?: GeoLocation
   validation_method?: GeoValidationMethod
 }


### PR DESCRIPTION
@delvedor - the compiler is unable to resolve lat & lon from `GeoLocation` with the failing test
```
"location": {
  "lat": 0,
  "lon": 0
}
```

```
export type GeoLocation = string | double[] | TwoDimensionalPoint
```