### PR TITLE
Fix ml.close_job Request

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -103053,6 +103053,16 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "value",
+        "value": {
+          "kind": "instance_of",
+          "type": {
+            "name": "EmptyObject",
+            "namespace": "_types"
+          }
+        }
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -103090,6 +103100,7 @@
           }
         },
         {
+          "description": "Use to close a failed job, or to forcefully close a job which has not responded to its initial close request.",
           "name": "force",
           "required": false,
           "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10495,6 +10495,7 @@ export interface MlCloseJobRequest extends RequestBase {
   allow_no_jobs?: boolean
   force?: boolean
   timeout?: Time
+  body?: EmptyObject
 }
 
 export interface MlCloseJobResponse extends ResponseBase {

--- a/specification/ml/close_job/MlCloseJobRequest.ts
+++ b/specification/ml/close_job/MlCloseJobRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { EmptyObject, Id } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
@@ -32,9 +32,10 @@ export interface Request extends RequestBase {
   }
   query_parameters?: {
     allow_no_jobs?: boolean
+    /** Use to close a failed job, or to forcefully close a job which has not responded to its initial close request. */
     force?: boolean
     /** @server_default 30s */
-    timeout?: Time // default: 30s
+    timeout?: Time
   }
-  body?: {}
+  body?: EmptyObject
 }


### PR DESCRIPTION
as titled.

Needed assign `EmptyObject` to `body` as the tests were failing with the following condition:
```
expectAssignable<T.MlCloseJobRequest>({
  "body": {},
  "job_id": "nest-fluent-e6be8050"
})
```