### PR TITLE
Remove stubbing of security.*_user response

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -121700,22 +121700,6 @@
       ]
     },
     {
-      "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "stub",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "_types"
-              }
-            }
-          }
-        ]
-      },
       "kind": "response",
       "name": {
         "name": "Response",
@@ -121765,22 +121749,6 @@
       ]
     },
     {
-      "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "stub",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "_types"
-              }
-            }
-          }
-        ]
-      },
       "kind": "response",
       "name": {
         "name": "Response",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12713,18 +12713,14 @@ export interface SecurityDisableUserRequest extends RequestBase {
   refresh?: Refresh
 }
 
-export interface SecurityDisableUserResponse {
-  stub: integer
-}
+export interface SecurityDisableUserResponse {}
 
 export interface SecurityEnableUserRequest extends RequestBase {
   username: Username
   refresh?: Refresh
 }
 
-export interface SecurityEnableUserResponse {
-  stub: integer
-}
+export interface SecurityEnableUserResponse {}
 
 export interface SecurityGetApiKeyApiKeys {
   creation: long

--- a/specification/security/disable_user/SecurityDisableUserResponse.ts
+++ b/specification/security/disable_user/SecurityDisableUserResponse.ts
@@ -20,5 +20,5 @@
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  body: { stub: integer }
+  body: {}
 }

--- a/specification/security/enable_user/SecurityEnableUserResponse.ts
+++ b/specification/security/enable_user/SecurityEnableUserResponse.ts
@@ -20,5 +20,5 @@
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  body: { stub: integer }
+  body: {}
 }


### PR DESCRIPTION
removing the stub that was in place for status code only responses because https://github.com/elastic/elastic-client-generator/pull/391 allows to build upon.