### PR TITLE
Fix security.create_api_key Request + Metadata

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -30324,17 +30324,10 @@
         "namespace": "_types"
       },
       "type": {
-        "key": {
-          "kind": "instance_of",
-          "type": {
-            "name": "string",
-            "namespace": "internal"
-          }
-        },
-        "kind": "dictionary_of",
-        "singleKey": false,
-        "value": {
-          "kind": "user_defined_value"
+        "kind": "instance_of",
+        "type": {
+          "name": "Metadata",
+          "namespace": "_types"
         }
       }
     },
@@ -30962,6 +30955,27 @@
           }
         }
       ]
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "Metadata",
+        "namespace": "_types"
+      },
+      "type": {
+        "key": {
+          "kind": "instance_of",
+          "type": {
+            "name": "string",
+            "namespace": "internal"
+          }
+        },
+        "kind": "dictionary_of",
+        "singleKey": false,
+        "value": {
+          "kind": "user_defined_value"
+        }
+      }
     },
     {
       "kind": "type_alias",
@@ -47251,17 +47265,10 @@
           "name": "local_metadata",
           "required": false,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
             }
           }
         },
@@ -120724,17 +120731,10 @@
           "name": "metadata",
           "required": true,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
             }
           }
         },
@@ -120815,17 +120815,10 @@
           "name": "metadata",
           "required": true,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
             }
           }
         },
@@ -120889,17 +120882,10 @@
           "name": "metadata",
           "required": true,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
             }
           }
         },
@@ -121011,17 +120997,10 @@
             "name": "metadata",
             "required": true,
             "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "user_defined_value"
+              "kind": "instance_of",
+              "type": {
+                "name": "Metadata",
+                "namespace": "_types"
               }
             }
           },
@@ -121717,6 +121696,7 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "Expiration time for the API key. By default, API keys never expire.",
             "name": "expiration",
             "required": false,
             "type": {
@@ -121728,6 +121708,7 @@
             }
           },
           {
+            "description": "Specifies the name for this API key.",
             "name": "name",
             "required": false,
             "type": {
@@ -121739,6 +121720,8 @@
             }
           },
           {
+            "description": " An array of role descriptors for this API key. This parameter is optional. When it is not specified or is an empty array, then the API key will have a point in time snapshot of permissions of the authenticated user. If you supply role descriptors then the resultant permissions would be an intersection of API keys permissions and authenticated user’s permissions thereby limiting the access scope for API keys. The structure of role descriptor is the same as the request for create role API. For more details, see create or update roles API.",
+            "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html",
             "name": "role_descriptors",
             "required": false,
             "type": {
@@ -121757,6 +121740,19 @@
                   "name": "ApiKeyRole",
                   "namespace": "security.create_api_key"
                 }
+              }
+            }
+          },
+          {
+            "description": "Arbitrary metadata that you want to associate with the API key. It supports nested data structure. Within the metadata object, keys beginning with _ are reserved for system usage.",
+            "name": "metadata",
+            "required": false,
+            "since": "7.13.0",
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Metadata",
+                "namespace": "_types"
               }
             }
           }
@@ -122337,18 +122333,12 @@
         {
           "name": "metadata",
           "required": false,
+          "since": "7.13.0",
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
             }
           }
         }
@@ -124313,8 +124303,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "Name",
+              "namespace": "_types"
             }
           }
         },
@@ -124322,17 +124312,10 @@
           "name": "metadata",
           "required": false,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
             }
           }
         }
@@ -124678,17 +124661,10 @@
             "name": "metadata",
             "required": false,
             "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "user_defined_value"
+              "kind": "instance_of",
+              "type": {
+                "name": "Metadata",
+                "namespace": "_types"
               }
             }
           },
@@ -124802,17 +124778,10 @@
             "name": "metadata",
             "required": false,
             "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "user_defined_value"
+              "kind": "instance_of",
+              "type": {
+                "name": "Metadata",
+                "namespace": "_types"
               }
             }
           },
@@ -125005,17 +124974,10 @@
             "name": "metadata",
             "required": false,
             "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "user_defined_value"
+              "kind": "instance_of",
+              "type": {
+                "name": "Metadata",
+                "namespace": "_types"
               }
             }
           },
@@ -126454,17 +126416,10 @@
           "name": "metadata",
           "required": false,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
             }
           }
         },
@@ -127458,17 +127413,10 @@
             "name": "metadata",
             "required": false,
             "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "user_defined_value"
+              "kind": "instance_of",
+              "type": {
+                "name": "Metadata",
+                "namespace": "_types"
               }
             }
           },
@@ -135375,17 +135323,10 @@
           "name": "metadata",
           "required": false,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
             }
           }
         },
@@ -136631,17 +136572,10 @@
           "name": "metadata",
           "required": true,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
             }
           }
         },
@@ -136887,17 +136821,10 @@
             "name": "metadata",
             "required": false,
             "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "user_defined_value"
+              "kind": "instance_of",
+              "type": {
+                "name": "Metadata",
+                "namespace": "_types"
               }
             }
           },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1947,7 +1947,7 @@ export type Ids = Id | Id[]
 
 export type IndexAlias = string
 
-export type IndexMetaData = Record<string, any>
+export type IndexMetaData = Metadata
 
 export type IndexName = string
 
@@ -2018,6 +2018,8 @@ export interface MergesStats {
   total_time?: string
   total_time_in_millis: long
 }
+
+export type Metadata = Record<string, any>
 
 export type Metrics = string | string[]
 
@@ -3802,7 +3804,7 @@ export type MappingTypesFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 
 export type MappingTypesProperty = MappingTypesComplexFlattenedFlattenedProperty | MappingTypesCoreJoinJoinProperty | MappingTypesCorePercolatorPercolatorProperty | MappingTypesCoreRankFeatureRankFeatureProperty | MappingTypesCoreRankFeaturesRankFeaturesProperty | MappingTypesSpecializedConstantKeywordConstantKeywordProperty | MappingTypesSpecializedFieldAliasFieldAliasProperty | MappingTypesSpecializedHistogramHistogramProperty | MappingTypesCoreProperty
 
 export interface MappingTypesPropertyBase {
-  local_metadata?: Record<string, any>
+  local_metadata?: Metadata
   meta?: Record<string, string>
   name?: PropertyName
   properties?: Record<PropertyName, MappingTypesProperty>
@@ -12594,7 +12596,7 @@ export interface SecurityTransientMetadata {
 export interface SecurityXPackRole {
   cluster: string[]
   indices: SecurityPutRoleIndicesPrivileges[]
-  metadata: Record<string, any>
+  metadata: Metadata
   run_as: string[]
   transient_metadata: SecurityTransientMetadata
   applications: SecurityPutRoleApplicationPrivileges[]
@@ -12603,7 +12605,7 @@ export interface SecurityXPackRole {
 
 export interface SecurityXPackRoleMapping {
   enabled: boolean
-  metadata: Record<string, any>
+  metadata: Metadata
   roles: string[]
   rules: SecurityPutRoleMappingRoleMappingRuleBase
 }
@@ -12611,7 +12613,7 @@ export interface SecurityXPackRoleMapping {
 export interface SecurityXPackUser {
   email?: string
   full_name?: Name
-  metadata: Record<string, any>
+  metadata: Metadata
   roles: string[]
   username: Username
   enabled: boolean
@@ -12625,7 +12627,7 @@ export interface SecurityAuthenticateResponse {
   email?: string
   full_name?: Name
   lookup_realm: SecurityRealmInfo
-  metadata: Record<string, any>
+  metadata: Metadata
   roles: string[]
   username: Username
   enabled: boolean
@@ -12719,6 +12721,7 @@ export interface SecurityCreateApiKeyRequest extends RequestBase {
     expiration?: Time
     name?: Name
     role_descriptors?: Record<string, SecurityCreateApiKeyApiKeyRole>
+    metadata?: Metadata
   }
 }
 
@@ -12790,7 +12793,7 @@ export interface SecurityGetApiKeyApiKeys {
   name: Name
   realm: string
   username: Username
-  metadata?: Record<string, any>
+  metadata?: Metadata
 }
 
 export interface SecurityGetApiKeyRequest extends RequestBase {
@@ -13024,8 +13027,8 @@ export interface SecurityInvalidateTokenResponse {
 export interface SecurityPutPrivilegesPrivilegesActions {
   actions: string[]
   application?: string
-  name?: string
-  metadata?: Record<string, any>
+  name?: Name
+  metadata?: Metadata
 }
 
 export interface SecurityPutPrivilegesPutPrivilegesStatus {
@@ -13065,7 +13068,7 @@ export interface SecurityPutRoleRequest extends RequestBase {
     cluster?: string[]
     global?: Record<string, any>
     indices?: SecurityPutRoleIndicesPrivileges[]
-    metadata?: Record<string, any>
+    metadata?: Metadata
     run_as?: string[]
     transient_metadata?: SecurityTransientMetadata
   }
@@ -13080,7 +13083,7 @@ export interface SecurityPutRoleMappingRequest extends RequestBase {
   refresh?: Refresh
   body?: {
     enabled?: boolean
-    metadata?: Record<string, any>
+    metadata?: Metadata
     roles?: string[]
     rules?: SecurityPutRoleMappingRoleMappingRuleBase
     run_as?: string[]
@@ -13102,7 +13105,7 @@ export interface SecurityPutUserRequest extends RequestBase {
     username?: Username
     email?: string | null
     full_name?: string | null
-    metadata?: Record<string, any>
+    metadata?: Metadata
     password?: Password
     password_hash?: string
     roles?: string[]
@@ -13288,7 +13291,7 @@ export interface SnapshotSnapshotInfo {
   include_global_state?: boolean
   indices: IndexName[]
   index_details?: Record<IndexName, SnapshotSnapshotIndexDetails>
-  metadata?: Record<string, any>
+  metadata?: Metadata
   reason?: string
   snapshot: Name
   shards?: ShardStatistics
@@ -13412,7 +13415,7 @@ export interface SnapshotCreateRequest extends RequestBase {
     ignore_unavailable?: boolean
     include_global_state?: boolean
     indices?: Indices
-    metadata?: Record<string, any>
+    metadata?: Metadata
     partial?: boolean
   }
 }
@@ -14340,7 +14343,7 @@ export interface WatcherWatch {
   actions: Record<IndexName, WatcherAction>
   condition: WatcherConditionContainer
   input: WatcherInputContainer
-  metadata?: Record<string, any>
+  metadata?: Metadata
   status?: WatcherAckWatchWatchStatus
   throttle_period?: string
   transform?: WatcherTransformContainer
@@ -14496,7 +14499,7 @@ export interface WatcherExecuteWatchWatchRecord {
   condition: WatcherConditionContainer
   input: WatcherInputContainer
   messages: string[]
-  metadata: Record<string, any>
+  metadata: Metadata
   node: string
   result: WatcherExecuteWatchExecutionResult
   state: WatcherExecuteWatchActionExecutionState
@@ -14529,7 +14532,7 @@ export interface WatcherPutWatchRequest extends RequestBase {
     actions?: Record<string, WatcherAction>
     condition?: WatcherConditionContainer
     input?: WatcherInputContainer
-    metadata?: Record<string, any>
+    metadata?: Metadata
     throttle_period?: string
     transform?: WatcherTransformContainer
     trigger?: WatcherTriggerContainer

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -70,8 +70,9 @@ export type DataStreamName = string
 /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#byte-units */
 export type ByteSize = long | string
 
+export type Metadata = Dictionary<string, UserDefinedValue>
 /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
-export type IndexMetaData = Dictionary<string, UserDefinedValue>
+export type IndexMetaData = Metadata
 
 // Versioning Numbers & Strings
 export type VersionNumber = long

--- a/specification/_types/mapping/types/Property.ts
+++ b/specification/_types/mapping/types/Property.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { PropertyName } from '@_types/common'
+import { Metadata, PropertyName } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { DynamicMapping } from '../DynamicMapping'
 import { FlattenedProperty } from './complex/flattened/FlattenedProperty'
@@ -33,7 +33,7 @@ import { FieldAliasProperty } from './specialized/field_alias/FieldAliasProperty
 import { HistogramProperty } from './specialized/histogram/HistogramProperty'
 
 export class PropertyBase {
-  local_metadata?: Dictionary<string, UserDefinedValue>
+  local_metadata?: Metadata
   meta?: Dictionary<string, string>
   name?: PropertyName
   properties?: Dictionary<PropertyName, Property>

--- a/specification/security/_types/XPackRole.ts
+++ b/specification/security/_types/XPackRole.ts
@@ -21,11 +21,12 @@ import { ApplicationPrivileges } from '@security/put_role/ApplicationPrivileges'
 import { IndicesPrivileges } from '@security/put_role/IndicesPrivileges'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { Metadata } from '@_types/common'
 
 export class XPackRole {
   cluster: string[]
   indices: IndicesPrivileges[]
-  metadata: Dictionary<string, UserDefinedValue>
+  metadata: Metadata
   run_as: string[]
   transient_metadata: TransientMetadata
   applications: ApplicationPrivileges[]

--- a/specification/security/_types/XPackRoleMapping.ts
+++ b/specification/security/_types/XPackRoleMapping.ts
@@ -20,10 +20,11 @@
 import { RoleMappingRuleBase } from '@security/put_role_mapping/SecurityPutRoleMappingRequest'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { Metadata } from '@_types/common'
 
 export class XPackRoleMapping {
   enabled: boolean
-  metadata: Dictionary<string, UserDefinedValue>
+  metadata: Metadata
   roles: string[]
   rules: RoleMappingRuleBase
 }

--- a/specification/security/_types/XPackUser.ts
+++ b/specification/security/_types/XPackUser.ts
@@ -19,12 +19,12 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { Name, Username } from '@_types/common'
+import { Metadata, Name, Username } from '@_types/common'
 
 export class XPackUser {
   email?: string
   full_name?: Name
-  metadata: Dictionary<string, UserDefinedValue>
+  metadata: Metadata
   roles: string[]
   username: Username
   enabled: boolean

--- a/specification/security/authenticate/SecurityAuthenticateResponse.ts
+++ b/specification/security/authenticate/SecurityAuthenticateResponse.ts
@@ -20,7 +20,7 @@
 import { RealmInfo } from '@security/_types/RealmInfo'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { Name, Username } from '@_types/common'
+import { Metadata, Name, Username } from '@_types/common'
 
 export class Response {
   body: {
@@ -28,7 +28,7 @@ export class Response {
     email?: string
     full_name?: Name
     lookup_realm: RealmInfo
-    metadata: Dictionary<string, UserDefinedValue>
+    metadata: Metadata
     roles: string[]
     username: Username
     enabled: boolean

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { RequestBase } from '@_types/Base'
-import { IndexMetaData, Metadata, Name, Refresh } from '@_types/common'
+import { Metadata, Name, Refresh } from '@_types/common'
 import { Time } from '@_types/Time'
 import { ApiKeyRole } from './ApiKeyRole'
 

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { RequestBase } from '@_types/Base'
-import { Name, Refresh } from '@_types/common'
+import { IndexMetaData, Metadata, Name, Refresh } from '@_types/common'
 import { Time } from '@_types/Time'
 import { ApiKeyRole } from './ApiKeyRole'
 
@@ -33,8 +33,19 @@ export interface Request extends RequestBase {
     refresh?: Refresh
   }
   body?: {
+    /** Expiration time for the API key. By default, API keys never expire. */
     expiration?: Time
+    /** Specifies the name for this API key. */
     name?: Name
+    /**
+     *  An array of role descriptors for this API key. This parameter is optional. When it is not specified or is an empty array, then the API key will have a point in time snapshot of permissions of the authenticated user. If you supply role descriptors then the resultant permissions would be an intersection of API keys permissions and authenticated user’s permissions thereby limiting the access scope for API keys. The structure of role descriptor is the same as the request for create role API. For more details, see create or update roles API.
+     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html
+     */
     role_descriptors?: Dictionary<string, ApiKeyRole>
+    /**
+     * Arbitrary metadata that you want to associate with the API key. It supports nested data structure. Within the metadata object, keys beginning with _ are reserved for system usage.
+     * @since 7.13.0
+     */
+    metadata?: Metadata
   }
 }

--- a/specification/security/get_api_key/ApiKeys.ts
+++ b/specification/security/get_api_key/ApiKeys.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { Id, Name, Username } from '@_types/common'
+import { Id, Metadata, Name, Username } from '@_types/common'
 import { long } from '@_types/Numeric'
 
 export class ApiKeys {
@@ -30,5 +30,6 @@ export class ApiKeys {
   name: Name
   realm: string
   username: Username
-  metadata?: Dictionary<string, UserDefinedValue> // version: 7.13
+  /** @since 7.13.0 */
+  metadata?: Metadata
 }

--- a/specification/security/put_privileges/PrivilegesActions.ts
+++ b/specification/security/put_privileges/PrivilegesActions.ts
@@ -19,10 +19,11 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { Metadata, Name } from '@_types/common'
 
 export class PrivilegesActions {
   actions: string[]
   application?: string
-  name?: string
-  metadata?: Dictionary<string, UserDefinedValue>
+  name?: Name
+  metadata?: Metadata
 }

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -21,7 +21,7 @@ import { TransientMetadata } from '@security/_types/XPackRole'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
-import { Name, Refresh } from '@_types/common'
+import { Metadata, Name, Refresh } from '@_types/common'
 import { ApplicationPrivileges } from './ApplicationPrivileges'
 import { IndicesPrivileges } from './IndicesPrivileges'
 
@@ -42,7 +42,7 @@ export interface Request extends RequestBase {
     cluster?: string[]
     global?: Dictionary<string, UserDefinedValue>
     indices?: IndicesPrivileges[]
-    metadata?: Dictionary<string, UserDefinedValue>
+    metadata?: Metadata
     run_as?: string[]
     transient_metadata?: TransientMetadata
   }

--- a/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
+++ b/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
@@ -20,7 +20,7 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
-import { Name, Refresh } from '@_types/common'
+import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
  * @rest_spec_name security.put_role_mapping
@@ -36,7 +36,7 @@ export interface Request extends RequestBase {
   }
   body?: {
     enabled?: boolean
-    metadata?: Dictionary<string, UserDefinedValue>
+    metadata?: Metadata
     roles?: string[]
     rules?: RoleMappingRuleBase
     run_as?: string[]

--- a/specification/security/put_user/SecurityPutUserRequest.ts
+++ b/specification/security/put_user/SecurityPutUserRequest.ts
@@ -20,7 +20,7 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
-import { Password, Refresh, Username } from '@_types/common'
+import { Metadata, Password, Refresh, Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.put_user
@@ -38,7 +38,7 @@ export interface Request extends RequestBase {
     username?: Username
     email?: string | null
     full_name?: string | null
-    metadata?: Dictionary<string, UserDefinedValue>
+    metadata?: Metadata
     password?: Password
     password_hash?: string
     roles?: string[]

--- a/specification/snapshot/_types/SnapshotInfo.ts
+++ b/specification/snapshot/_types/SnapshotInfo.ts
@@ -21,6 +21,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import {
   IndexName,
+  Metadata,
   Name,
   Uuid,
   VersionNumber,
@@ -43,7 +44,7 @@ export class SnapshotInfo {
   indices: IndexName[]
   /** @since 7.13.0 */
   index_details?: Dictionary<IndexName, SnapshotIndexDetails>
-  metadata?: Dictionary<string, UserDefinedValue>
+  metadata?: Metadata
   reason?: string
   snapshot: Name
   shards?: ShardStatistics

--- a/specification/snapshot/create/SnapshotCreateRequest.ts
+++ b/specification/snapshot/create/SnapshotCreateRequest.ts
@@ -20,7 +20,7 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
-import { Indices, Name } from '@_types/common'
+import { Indices, Metadata, Name } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
@@ -40,9 +40,8 @@ export interface Request extends RequestBase {
   body?: {
     ignore_unavailable?: boolean
     include_global_state?: boolean
-    /** @prop_serializer IndicesMultiSyntaxFormatter */
     indices?: Indices
-    metadata?: Dictionary<string, UserDefinedValue>
+    metadata?: Metadata
     partial?: boolean
   }
 }

--- a/specification/watcher/_types/Watch.ts
+++ b/specification/watcher/_types/Watch.ts
@@ -20,7 +20,7 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { WatchStatus } from '@watcher/ack_watch/WatchStatus'
-import { IndexName } from '@_types/common'
+import { IndexName, Metadata } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Action } from './Action'
 import { ConditionContainer } from './Conditions'
@@ -32,7 +32,7 @@ export class Watch {
   actions: Dictionary<IndexName, Action>
   condition: ConditionContainer
   input: InputContainer
-  metadata?: Dictionary<string, UserDefinedValue>
+  metadata?: Metadata
   status?: WatchStatus
   throttle_period?: string
   transform?: TransformContainer

--- a/specification/watcher/execute_watch/WatchRecord.ts
+++ b/specification/watcher/execute_watch/WatchRecord.ts
@@ -21,7 +21,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { ConditionContainer } from '@watcher/_types/Conditions'
 import { InputContainer } from '@watcher/_types/Input'
-import { Id } from '@_types/common'
+import { Id, Metadata } from '@_types/common'
 import { ActionExecutionState } from './ActionExecutionState'
 import { ExecutionResult } from './ExecutionResult'
 import { TriggerEventResult } from './TriggerEventResult'
@@ -30,7 +30,7 @@ export class WatchRecord {
   condition: ConditionContainer
   input: InputContainer
   messages: string[]
-  metadata: Dictionary<string, UserDefinedValue>
+  metadata: Metadata
   node: string
   result: ExecutionResult
   state: ActionExecutionState

--- a/specification/watcher/put_watch/WatcherPutWatchRequest.ts
+++ b/specification/watcher/put_watch/WatcherPutWatchRequest.ts
@@ -25,7 +25,7 @@ import { InputContainer } from '@watcher/_types/Input'
 import { TransformContainer } from '@watcher/_types/Transform'
 import { TriggerContainer } from '@watcher/_types/Trigger'
 import { RequestBase } from '@_types/Base'
-import { Id, VersionNumber } from '@_types/common'
+import { Id, Metadata, VersionNumber } from '@_types/common'
 import { long } from '@_types/Numeric'
 
 /**
@@ -47,7 +47,7 @@ export interface Request extends RequestBase {
     actions?: Dictionary<string, Action>
     condition?: ConditionContainer
     input?: InputContainer
-    metadata?: Dictionary<string, UserDefinedValue>
+    metadata?: Metadata
     throttle_period?: string
     transform?: TransformContainer
     trigger?: TriggerContainer


### PR DESCRIPTION
validated `security.create_api_key` Request and introduced alongside the type `Metadata` for (surprise 😄 ) metadata.