### PR TITLE
Changes "void_value" into "no_body" for req/responses with no body

### DIFF
--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -49,7 +49,7 @@ export class TypeName {
 /**
  * Type of a value. Used both for property types and nested type definitions.
  */
-export type ValueOf = InstanceOf | ArrayOf | UnionOf | DictionaryOf | UserDefinedValue | LiteralValue | VoidValue
+export type ValueOf = InstanceOf | ArrayOf | UnionOf | DictionaryOf | UserDefinedValue | LiteralValue
 
 /**
  * A single value
@@ -114,13 +114,6 @@ export class UserDefinedValue {
 export class LiteralValue {
   kind: 'literal_value'
   value: string | number | boolean
-}
-
-/**
- * The absence of any type. This is commonly used in APIs that returns an empty body.
- */
-export class VoidValue {
-  kind: 'void_value'
 }
 
 /**
@@ -225,6 +218,7 @@ export class Request extends BaseType {
   // Note: does not extend Interface as properties are split across path, query and body
   kind: 'request'
   generics?: TypeName[]
+  /** The parent defines additional body properties that are added to the body, that has to be a PropertyBody */
   inherits?: Inherits
   implements?: Inherits[]
   /** URL path properties */
@@ -239,10 +233,11 @@ export class Request extends BaseType {
   // We can also pull path parameter descriptions on body properties they replace
 
   /**
-   * Body type. In most cases this is just a list of properties, except for a few specific cases like bulk requests
-   * (an array of bulk operations) or create requests (a user provided document type).
+   * Body type. Most often a list of properties (that can extend those of the inherited class, see above), except for a
+   * few specific cases that use other types such as bulk (array) or create (generic parameter). Or NoBody for requests
+   * that don't have a body.
    */
-  body?: ValueBody | PropertiesBody
+  body: Body
   behaviors?: Inherits[]
   attachedBehaviors?: string[]
 }
@@ -255,10 +250,12 @@ export class Response extends BaseType {
   generics?: TypeName[]
   inherits?: Inherits
   implements?: Inherits[]
-  body?: ValueBody | PropertiesBody
+  body: Body
   behaviors?: Inherits[]
   attachedBehaviors?: string[]
 }
+
+export type Body = ValueBody | PropertiesBody | NoBody
 
 export class ValueBody {
   kind: 'value'
@@ -268,6 +265,10 @@ export class ValueBody {
 export class PropertiesBody {
   kind: 'properties'
   properties: Property[]
+}
+
+export class NoBody {
+  kind: 'no_body'
 }
 
 /**

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -247,13 +247,6 @@ export function modelType (node: Node): model.ValueOf {
           return type
         }
 
-        case 'Void': {
-          const type: model.VoidValue = {
-            kind: 'void_value'
-          }
-          return type
-        }
-
         default: {
           const generics = node.getTypeArguments().map(node => modelType(node))
           const identifier = node.getTypeName()

--- a/compiler/steps/validate-model.ts
+++ b/compiler/steps/validate-model.ts
@@ -392,22 +392,28 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     validateProperties(typeDef.query, openGenerics)
     context.pop()
 
-    if (typeDef.body != null) {
-      context.push('body')
-      switch (typeDef.body.kind) {
-        case 'properties':
-          validateProperties(typeDef.body.properties, openGenerics)
-          break
-        case 'value':
-          validateValueOf(typeDef.body.value, openGenerics)
-          break
-        default:
-          // @ts-expect-error
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          throw new Error(`Unknown kind: ${typeDef.body.kind}`)
+    context.push('body')
+    if (typeDef.inherits != null && typeDef.body.kind !== 'properties') {
+      if (fqn(typeDef.inherits.type) !== '_types:RequestBase') {
+        modelError('A request with inherited properties must have a PropertyBody')
       }
-      context.pop()
     }
+    switch (typeDef.body.kind) {
+      case 'properties':
+        validateProperties(typeDef.body.properties, openGenerics)
+        break
+      case 'value':
+        validateValueOf(typeDef.body.value, openGenerics)
+        break
+      case 'no_body':
+        // Nothing to validate
+        break
+      default:
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        throw new Error(`Unknown kind: ${typeDef.body.kind}`)
+    }
+    context.pop()
   }
 
   function validateResponse (typeDef: model.Response): void {
@@ -421,22 +427,28 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     // valid overlaps, with some parameters that can also be represented as body properties.
     // Client generators will have to take care of this.
 
-    if (typeDef.body != null) {
-      context.push('body')
-      switch (typeDef.body.kind) {
-        case 'properties':
-          validateProperties(typeDef.body.properties, openGenerics)
-          break
-        case 'value':
-          validateValueOf(typeDef.body.value, openGenerics)
-          break
-        default:
-          // @ts-expect-error
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          throw new Error(`Unknown kind: ${typeDef.body.kind}`)
+    context.push('body')
+    if (typeDef.inherits != null && typeDef.body.kind !== 'properties') {
+      if (fqn(typeDef.inherits.type) !== '_types:RequestBase') {
+        modelError('A response with inherited properties must have a PropertyBody')
       }
-      context.pop()
     }
+    switch (typeDef.body.kind) {
+      case 'properties':
+        validateProperties(typeDef.body.properties, openGenerics)
+        break
+      case 'value':
+        validateValueOf(typeDef.body.value, openGenerics)
+        break
+      case 'no_body':
+        // Nothing to validate
+        break
+      default:
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        throw new Error(`Unknown kind: ${typeDef.body.kind}`)
+    }
+    context.pop()
   }
 
   function validateInterface (typeDef: model.Interface): void {
@@ -724,10 +736,6 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
         break
 
       case 'literal_value':
-        // Nothing to validate
-        break
-
-      case 'void_value':
         // Nothing to validate
         break
 

--- a/compiler/validation-errors.ts
+++ b/compiler/validation-errors.ts
@@ -68,8 +68,10 @@ export class ValidationErrors {
     let count = 0
     const logArray = function (errs: string[], prefix = ''): void {
       for (const err of errs) {
-        console.error(`${prefix}${err}`)
-        count++
+        if (err !== 'Endpoint has "@stability: TODO' && err !== 'Missing request & response') {
+          console.error(`${prefix}${err}`)
+          count++
+        }
       }
     }
 

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -16745,8 +16745,8 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Name",
+                "namespace": "_types"
               }
             }
           },
@@ -16756,8 +16756,8 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Uuid",
+                "namespace": "_types"
               }
             }
           },
@@ -16767,8 +16767,8 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Name",
+                "namespace": "_types"
               }
             }
           },

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -13588,6 +13588,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "WriteResponseBase",
@@ -13604,6 +13608,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -13742,6 +13749,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "WriteResponseBase",
@@ -14388,6 +14399,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -14427,6 +14441,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "Response",
@@ -14443,6 +14461,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -14493,6 +14514,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -14509,6 +14534,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -14670,10 +14698,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -14685,6 +14710,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -14835,10 +14863,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -15758,6 +15783,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -16095,6 +16123,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -16293,6 +16324,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -16371,6 +16405,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -16429,6 +16466,10 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "Request",
@@ -16657,6 +16698,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "WriteResponseBase",
@@ -16673,6 +16718,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -18504,6 +18552,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -18569,6 +18620,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -18585,10 +18639,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -18677,6 +18728,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -20327,6 +20382,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -20785,6 +20843,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "generics": [
         {
           "name": "TDocument",
@@ -26394,6 +26456,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -28535,6 +28600,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -56937,6 +57005,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -56964,6 +57035,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -56980,6 +57055,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -57041,6 +57119,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "generics": [
         {
           "name": "TDocument",
@@ -57072,6 +57154,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -57887,6 +57972,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "generics": [
         {
           "name": "TDocument",
@@ -58373,6 +58462,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -58582,6 +58674,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -58704,6 +58799,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -59011,6 +59109,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -59280,6 +59381,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -59433,6 +59537,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -59733,6 +59840,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -59815,6 +59925,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -61853,6 +61966,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -62954,6 +63070,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -63091,6 +63210,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -63241,6 +63363,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -64794,6 +64919,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -64937,6 +65065,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -65072,6 +65203,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -65513,6 +65647,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -65637,6 +65774,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -65915,6 +66055,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -67176,6 +67319,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -67448,6 +67594,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -67756,6 +67905,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -67931,6 +68083,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -68291,6 +68446,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -68639,6 +68797,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -69243,6 +69404,9 @@
         "CommonCatQueryParameters",
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -69958,6 +70122,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -69985,6 +70152,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -70001,6 +70172,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -70255,6 +70429,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -70444,6 +70621,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -70500,6 +70680,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -70527,6 +70710,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -70543,6 +70730,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -70570,6 +70760,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -70789,6 +70983,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -70805,6 +71003,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -70832,6 +71033,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -70990,6 +71195,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -71141,6 +71350,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -71193,6 +71405,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -71220,6 +71435,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -73531,6 +73750,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -73583,6 +73805,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -73737,6 +73963,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -73830,6 +74059,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -74078,6 +74310,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -74599,6 +74834,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -74802,6 +75040,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -74972,6 +75214,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -75169,6 +75414,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -76014,6 +76263,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -77917,6 +78169,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -78604,6 +78859,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -78631,6 +78889,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -78688,6 +78950,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -78764,6 +79029,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -78874,6 +79142,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -78985,6 +79257,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -79339,6 +79614,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -79367,6 +79645,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -79383,6 +79665,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -79436,6 +79721,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "generics": [
         {
           "name": "TEvent",
@@ -79467,6 +79756,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -79889,6 +80181,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "generics": [
         {
           "name": "TEvent",
@@ -80820,6 +81116,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -80858,6 +81157,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -81159,6 +81462,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -81300,6 +81606,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -81338,6 +81647,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -81388,6 +81701,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -81483,6 +81799,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -81595,6 +81915,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -81611,6 +81935,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -81678,6 +82005,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -81705,6 +82035,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -81752,6 +82086,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -81799,6 +82137,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -83225,6 +83567,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83965,6 +84310,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -84070,6 +84418,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "ShardsOperationResponseBase",
@@ -84311,6 +84663,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -84653,6 +85008,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -84680,6 +85038,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -84760,6 +85122,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -84894,6 +85259,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -84977,6 +85345,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "IndicesResponseBase",
@@ -84993,6 +85365,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85054,6 +85429,9 @@
       ]
     },
     {
+      "body": {
+        "kind": "no_body"
+      },
       "kind": "response",
       "name": {
         "name": "Response",
@@ -85064,6 +85442,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85091,6 +85472,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -85107,6 +85492,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85134,6 +85522,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -85150,6 +85542,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85200,6 +85595,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -85216,6 +85615,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85311,10 +85713,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -85326,6 +85725,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85410,10 +85812,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -85425,6 +85824,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85468,10 +85870,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -85483,6 +85882,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85545,10 +85947,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -85560,6 +85959,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85644,10 +86046,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -85659,6 +86058,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85742,6 +86144,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "ShardsOperationResponseBase",
@@ -85758,6 +86164,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85867,6 +86276,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85961,6 +86373,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "ShardsOperationResponseBase",
@@ -85977,6 +86393,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86103,6 +86522,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86235,6 +86657,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -86298,6 +86724,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86381,6 +86810,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -86588,6 +87021,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86656,6 +87092,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86772,6 +87211,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -87183,6 +87626,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87288,6 +87734,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -87320,6 +87770,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87436,6 +87889,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -87468,6 +87925,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87540,6 +88000,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -87572,6 +88036,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87641,6 +88108,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87668,6 +88138,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -87684,6 +88158,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87810,6 +88287,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87984,6 +88464,9 @@
       ]
     },
     {
+      "body": {
+        "kind": "no_body"
+      },
       "kind": "response",
       "name": {
         "name": "Response",
@@ -88161,6 +88644,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -88522,6 +89009,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "IndicesResponseBase",
@@ -88679,6 +89170,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -88882,6 +89377,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -89524,6 +90023,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -89574,6 +90076,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -89791,6 +90297,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -89852,6 +90361,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "ShardsOperationResponseBase",
@@ -89916,6 +90429,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -90017,6 +90533,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -90626,6 +91145,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -91013,6 +91535,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -91594,6 +92119,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -92140,6 +92669,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -93051,6 +93583,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -93242,6 +93777,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -96353,6 +96892,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -96403,6 +96945,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -96549,6 +97095,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -96614,6 +97163,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -96666,6 +97218,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -96698,6 +97254,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -96857,6 +97416,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -97376,6 +97939,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -97391,6 +97957,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -97407,6 +97977,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -97589,6 +98162,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -97653,6 +98229,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -97833,6 +98412,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -97940,6 +98522,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -98363,6 +98948,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -103920,6 +104508,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104008,6 +104599,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104035,6 +104629,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -104051,6 +104649,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104089,6 +104690,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -104105,6 +104710,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104191,6 +104799,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104243,6 +104854,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -104259,6 +104874,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104298,6 +104916,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -104419,6 +105041,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104446,6 +105071,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -104462,6 +105091,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104523,6 +105155,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -104539,6 +105175,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104589,6 +105228,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -104605,6 +105248,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104643,6 +105289,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -104659,6 +105309,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104686,6 +105339,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -104702,6 +105359,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104740,6 +105400,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -105741,6 +106405,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -107051,6 +107718,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -107808,6 +108478,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -107998,6 +108671,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -108077,6 +108753,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -108212,6 +108891,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -108485,6 +109167,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -108564,6 +109249,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109019,6 +109707,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109177,6 +109868,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109558,6 +110252,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -110241,6 +110938,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -110397,6 +111097,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111647,6 +112350,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111701,6 +112407,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -111797,6 +112507,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111835,6 +112548,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -111851,6 +112568,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -112039,6 +112759,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -113392,6 +114115,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -113523,6 +114249,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -113647,6 +114377,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -114323,6 +115057,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -116874,6 +117611,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -118389,6 +119129,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -119129,6 +119872,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -119765,6 +120511,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -119781,6 +120531,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -119927,6 +120680,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -119954,6 +120710,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -120103,6 +120863,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -120130,6 +120893,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -120295,6 +121062,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -120874,6 +121644,9 @@
       ]
     },
     {
+      "body": {
+        "kind": "no_body"
+      },
       "generics": [
         {
           "name": "TDocument",
@@ -120890,6 +121663,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -120943,6 +121719,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -121019,6 +121798,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -122051,6 +122833,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -122270,6 +123055,9 @@
       ]
     },
     {
+      "body": {
+        "kind": "no_body"
+      },
       "kind": "response",
       "name": {
         "name": "Response",
@@ -122300,6 +123088,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -122406,6 +123197,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -122492,6 +123286,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -122593,6 +123390,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -122984,6 +123784,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123034,6 +123837,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -123077,6 +123884,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123142,6 +123952,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123207,6 +124020,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123272,6 +124088,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123312,10 +124131,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -123327,6 +124143,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123367,10 +124186,7 @@
     },
     {
       "body": {
-        "kind": "value",
-        "value": {
-          "kind": "void_value"
-        }
+        "kind": "no_body"
       },
       "kind": "response",
       "name": {
@@ -123480,6 +124296,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123580,6 +124399,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123635,6 +124457,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123673,6 +124498,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -123716,6 +124545,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123743,6 +124575,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -123775,6 +124611,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123802,6 +124641,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -124133,6 +124976,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -124176,6 +125022,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -124376,6 +125226,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -125536,6 +126389,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -126880,6 +127737,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126907,6 +127767,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -126923,6 +127787,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126976,6 +127843,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126991,6 +127861,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -127007,6 +127881,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127034,6 +127911,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -127066,6 +127947,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127209,6 +128093,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127337,6 +128224,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -127353,6 +128244,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127368,6 +128262,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -127384,6 +128282,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127399,6 +128300,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -128456,6 +129361,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -128620,6 +129528,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -128893,6 +129805,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -128909,6 +129825,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -128959,6 +129878,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -128975,6 +129898,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -129025,6 +129951,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -129041,6 +129971,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -129224,6 +130157,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -129274,6 +130210,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "generics": [
           {
@@ -129545,6 +130485,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -129655,6 +130598,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130285,6 +131231,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130323,6 +131272,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130464,6 +131416,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130717,6 +131672,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132249,6 +133207,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132288,6 +133249,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -132304,6 +133269,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132555,6 +133523,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -133144,6 +134115,10 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "Request",
@@ -133185,6 +134160,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -133201,6 +134180,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -133240,6 +134222,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -133256,6 +134242,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -133339,6 +134328,10 @@
       ]
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -133355,6 +134348,10 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "Request",
@@ -137039,6 +138036,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -137103,6 +138103,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -137156,6 +138159,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -137209,6 +138215,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -137582,6 +138591,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -138017,6 +139029,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -138032,6 +139047,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -138048,6 +139067,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -138406,6 +139428,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -138421,6 +139446,10 @@
       "query": []
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "inherits": {
         "type": {
           "name": "AcknowledgedResponseBase",
@@ -138922,6 +139951,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -140896,6 +141928,9 @@
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
+      "body": {
+        "kind": "no_body"
+      },
       "inherits": {
         "type": {
           "name": "RequestBase",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1,5 +1,23 @@
 {
   "endpointErrors": {
+    "async_search.delete": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "async_search.get": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "async_search.status": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "async_search.submit": {
       "request": [
         "Endpoint has \"@stability: TODO"
@@ -180,6 +198,66 @@
       ],
       "response": []
     },
+    "ccr.delete_auto_follow_pattern": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ccr.follow_info": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ccr.follow_stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ccr.get_auto_follow_pattern": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ccr.pause_auto_follow_pattern": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ccr.pause_follow": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ccr.resume_auto_follow_pattern": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ccr.stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ccr.unfollow": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.delete_component_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "cluster.delete_voting_config_exclusions": {
       "request": [
         "Endpoint has \"@stability: TODO"
@@ -193,6 +271,24 @@
       "response": []
     },
     "cluster.get_component_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.get_settings": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.health": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.pending_tasks": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -217,6 +313,18 @@
       "response": []
     },
     "cluster.reroute": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.state": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "cluster.stats": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -294,7 +402,67 @@
       ],
       "response": []
     },
+    "delete": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "delete_by_query_rethrottle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "delete_script": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "enrich.delete_policy": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "enrich.execute_policy": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "enrich.get_policy": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "enrich.put_policy": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "enrich.stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "eql.delete": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "eql.get": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "eql.get_status": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -348,6 +516,24 @@
       ],
       "response": []
     },
+    "get_script": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "get_script_context": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "get_script_languages": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "get_source": {
       "request": [
         "Endpoint has \"@stability: TODO"
@@ -360,13 +546,37 @@
       ],
       "response": []
     },
+    "ilm.explain_lifecycle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "ilm.get_lifecycle": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
       "response": []
     },
+    "ilm.get_status": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "ilm.put_lifecycle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ilm.remove_policy": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ilm.retry": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -384,6 +594,12 @@
       ],
       "response": []
     },
+    "indices.add_block": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "indices.analyze": {
       "request": [
         "Endpoint has \"@stability: TODO"
@@ -391,6 +607,36 @@
       "response": []
     },
     "indices.clear_cache": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.close": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.create_data_stream": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.data_streams_stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.delete": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.delete_alias": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -408,7 +654,73 @@
       ],
       "response": []
     },
+    "indices.delete_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.exists": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.exists_alias": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "indices.exists_index_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.exists_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.exists_type": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.flush": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.flush_synced": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.forcemerge": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.freeze": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.get": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.get_alias": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -420,13 +732,55 @@
       ],
       "response": []
     },
+    "indices.get_field_mapping": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "indices.get_index_template": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
       "response": []
     },
+    "indices.get_mapping": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.get_settings": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.get_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "indices.get_upgrade": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.migrate_to_data_stream": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.open": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.promote_data_stream": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -445,6 +799,42 @@
       "response": []
     },
     "indices.put_template": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.recovery": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.refresh": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.reload_search_analyzers": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.resolve_index": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.segments": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.shard_stores": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -474,6 +864,18 @@
       ],
       "response": []
     },
+    "indices.stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "indices.unfreeze": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "indices.upgrade": {
       "request": [
         "Endpoint has \"@stability: TODO"
@@ -481,6 +883,66 @@
       "response": []
     },
     "indices.validate_query": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "info": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ingest.delete_pipeline": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ingest.geo_ip_stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ingest.get_pipeline": {
+      "request": [
+        "Request: should not have a body"
+      ],
+      "response": []
+    },
+    "ingest.processor_grok": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "license.delete": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "license.get": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "license.get_basic_status": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "license.get_trial_status": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "license.post_start_basic": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -510,13 +972,85 @@
       ],
       "response": []
     },
+    "migration.deprecations": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "ml.close_job": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
       "response": []
     },
+    "ml.delete_calendar": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_calendar_event": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_calendar_job": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_data_frame_analytics": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_datafeed": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "ml.delete_expired_data": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_filter": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_forecast": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_job": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_model_snapshot": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_trained_model": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.delete_trained_model_alias": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -558,6 +1092,18 @@
       ],
       "response": []
     },
+    "ml.get_data_frame_analytics": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_data_frame_analytics_stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "ml.get_datafeed_stats": {
       "request": [
         "Endpoint has \"@stability: TODO"
@@ -565,6 +1111,12 @@
       "response": []
     },
     "ml.get_datafeeds": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.get_filters": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -600,7 +1152,25 @@
       ],
       "response": []
     },
+    "ml.get_trained_models_stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.info": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "ml.open_job": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.put_calendar_job": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -612,7 +1182,19 @@
       ],
       "response": []
     },
+    "ml.put_trained_model_alias": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "ml.revert_model_snapshot": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.set_upgrade_mode": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -625,6 +1207,12 @@
       "response": []
     },
     "ml.stop_datafeed": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ml.upgrade_job_snapshot": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -688,7 +1276,19 @@
       ],
       "response": []
     },
+    "nodes.usage": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "open_point_in_time": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ping": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -706,13 +1306,55 @@
       ],
       "response": []
     },
+    "reindex_rethrottle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "render_search_template": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
       "response": []
     },
+    "rollup.delete_job": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "rollup.get_jobs": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "rollup.get_rollup_caps": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "rollup.get_rollup_index_caps": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "rollup.rollup": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "rollup.start_job": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "rollup.stop_job": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -725,6 +1367,12 @@
       "response": []
     },
     "search": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "search_shards": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -760,6 +1408,36 @@
       ],
       "response": []
     },
+    "security.authenticate": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.clear_api_key_cache": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.clear_cached_privileges": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.clear_cached_realms": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.clear_cached_roles": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "security.clear_cached_service_tokens": {
       "request": [
         "Missing request & response"
@@ -772,9 +1450,75 @@
       ],
       "response": []
     },
+    "security.delete_privileges": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.delete_role": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.delete_role_mapping": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "security.delete_service_token": {
       "request": [
         "Missing request & response"
+      ],
+      "response": []
+    },
+    "security.delete_user": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.disable_user": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.enable_user": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.get_api_key": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.get_builtin_privileges": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.get_privileges": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.get_role": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "security.get_role_mapping": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
       ],
       "response": []
     },
@@ -826,7 +1570,73 @@
       ],
       "response": []
     },
+    "slm.delete_lifecycle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "slm.execute_lifecycle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "slm.execute_retention": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "slm.get_lifecycle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "slm.get_stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "slm.get_status": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "slm.start": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "slm.stop": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "snapshot.cleanup_repository": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "snapshot.clone": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "snapshot.delete": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "snapshot.delete_repository": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -838,7 +1648,67 @@
       ],
       "response": []
     },
+    "snapshot.get_repository": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "snapshot.restore": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "snapshot.status": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "snapshot.verify_repository": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "ssl.certificates": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "tasks.cancel": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "tasks.get": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "tasks.list": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "transform.delete_transform": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "transform.get_transform": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "transform.get_transform_stats": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -851,6 +1721,18 @@
       "response": []
     },
     "transform.put_transform": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "transform.start_transform": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "transform.stop_transform": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -874,7 +1756,43 @@
       ],
       "response": []
     },
+    "update_by_query_rethrottle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.ack_watch": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.activate_watch": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.deactivate_watch": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.delete_watch": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "watcher.execute_watch": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.get_watch": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],
@@ -892,7 +1810,19 @@
       ],
       "response": []
     },
+    "watcher.start": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "watcher.stats": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
+    "watcher.stop": {
       "request": [
         "Endpoint has \"@stability: TODO"
       ],

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -511,9 +511,9 @@ export interface InfoRequest extends RequestBase {
 }
 
 export interface InfoResponse {
-  cluster_name: string
-  cluster_uuid: string
-  name: string
+  cluster_name: Name
+  cluster_uuid: Uuid
+  name: Name
   tagline: string
   version: ElasticsearchVersionInfo
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -480,8 +480,6 @@ export interface GetScriptLanguagesResponse {
 }
 
 export interface GetSourceRequest extends GetRequest {
-  body?: {
-  }
 }
 
 export type GetSourceResponse<TDocument = unknown> = TDocument
@@ -14122,8 +14120,6 @@ export interface TransformPreviewTransformResponse<TTransform = unknown> {
 export interface TransformPutTransformRequest extends TransformPreviewTransformRequest {
   transform_id: Id
   defer_validation?: boolean
-  body?: {
-  }
 }
 
 export interface TransformPutTransformResponse extends AcknowledgedResponseBase {
@@ -14150,8 +14146,6 @@ export interface TransformStopTransformResponse extends AcknowledgedResponseBase
 }
 
 export interface TransformUpdateTransformRequest extends TransformPutTransformRequest {
-  body?: {
-  }
 }
 
 export interface TransformUpdateTransformResponse {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -166,7 +166,8 @@ export interface CreateRequest<TDocument = unknown> extends RequestBase {
   body?: TDocument
 }
 
-export interface CreateResponse extends WriteResponseBase {}
+export interface CreateResponse extends WriteResponseBase {
+}
 
 export interface DeleteRequest extends RequestBase {
   id: Id
@@ -182,7 +183,8 @@ export interface DeleteRequest extends RequestBase {
   wait_for_active_shards?: WaitForActiveShards
 }
 
-export interface DeleteResponse extends WriteResponseBase {}
+export interface DeleteResponse extends WriteResponseBase {
+}
 
 export interface DeleteByQueryRequest extends RequestBase {
   index: Indices
@@ -249,7 +251,8 @@ export interface DeleteByQueryRethrottleRequest extends RequestBase {
   requests_per_second?: long
 }
 
-export interface DeleteByQueryRethrottleResponse extends TaskListTasksResponse {}
+export interface DeleteByQueryRethrottleResponse extends TaskListTasksResponse {
+}
 
 export interface DeleteScriptRequest extends RequestBase {
   id: Id
@@ -257,7 +260,8 @@ export interface DeleteScriptRequest extends RequestBase {
   timeout?: Time
 }
 
-export interface DeleteScriptResponse extends AcknowledgedResponseBase {}
+export interface DeleteScriptResponse extends AcknowledgedResponseBase {
+}
 
 export interface ExistsRequest extends RequestBase {
   id: Id
@@ -476,6 +480,8 @@ export interface GetScriptLanguagesResponse {
 }
 
 export interface GetSourceRequest extends GetRequest {
+  body?: {
+  }
 }
 
 export type GetSourceResponse<TDocument = unknown> = TDocument
@@ -498,7 +504,8 @@ export interface IndexRequest<TDocument = unknown> extends RequestBase {
   body?: TDocument
 }
 
-export interface IndexResponse extends WriteResponseBase {}
+export interface IndexResponse extends WriteResponseBase {
+}
 
 export interface InfoRequest extends RequestBase {
 }
@@ -703,7 +710,8 @@ export interface PutScriptRequest extends RequestBase {
   }
 }
 
-export interface PutScriptResponse extends AcknowledgedResponseBase {}
+export interface PutScriptResponse extends AcknowledgedResponseBase {
+}
 
 export interface RankEvalDocumentRating {
   _id: Id
@@ -952,7 +960,8 @@ export interface ScrollRequest extends RequestBase {
   }
 }
 
-export interface ScrollResponse<TDocument = unknown> extends SearchResponse<TDocument> {}
+export interface ScrollResponse<TDocument = unknown> extends SearchResponse<TDocument> {
+}
 
 export interface SearchRequest extends RequestBase {
   index?: Indices
@@ -4729,7 +4738,8 @@ export interface AsyncSearchDeleteRequest extends RequestBase {
   id: Id
 }
 
-export interface AsyncSearchDeleteResponse extends AcknowledgedResponseBase {}
+export interface AsyncSearchDeleteResponse extends AcknowledgedResponseBase {
+}
 
 export interface AsyncSearchGetRequest extends RequestBase {
   id: Id
@@ -4738,7 +4748,8 @@ export interface AsyncSearchGetRequest extends RequestBase {
   wait_for_completion_timeout?: Time
 }
 
-export interface AsyncSearchGetResponse<TDocument = unknown> extends AsyncSearchAsyncSearchDocumentResponseBase<TDocument> {}
+export interface AsyncSearchGetResponse<TDocument = unknown> extends AsyncSearchAsyncSearchDocumentResponseBase<TDocument> {
+}
 
 export interface AsyncSearchStatusRequest extends RequestBase {
   id: Id
@@ -4812,7 +4823,8 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   }
 }
 
-export interface AsyncSearchSubmitResponse<TDocument = unknown> extends AsyncSearchAsyncSearchDocumentResponseBase<TDocument> {}
+export interface AsyncSearchSubmitResponse<TDocument = unknown> extends AsyncSearchAsyncSearchDocumentResponseBase<TDocument> {
+}
 
 export interface AutoscalingCapacityGetRequest extends RequestBase {
   stub_a: string
@@ -6674,7 +6686,8 @@ export interface CcrDeleteAutoFollowPatternRequest extends RequestBase {
   name: Name
 }
 
-export interface CcrDeleteAutoFollowPatternResponse extends AcknowledgedResponseBase {}
+export interface CcrDeleteAutoFollowPatternResponse extends AcknowledgedResponseBase {
+}
 
 export interface CcrFollowIndexStatsRequest extends RequestBase {
   index: Indices
@@ -6746,13 +6759,15 @@ export interface CcrPauseAutoFollowPatternRequest extends RequestBase {
   name: Name
 }
 
-export interface CcrPauseAutoFollowPatternResponse extends AcknowledgedResponseBase {}
+export interface CcrPauseAutoFollowPatternResponse extends AcknowledgedResponseBase {
+}
 
 export interface CcrPauseFollowIndexRequest extends RequestBase {
   index: IndexName
 }
 
-export interface CcrPauseFollowIndexResponse extends AcknowledgedResponseBase {}
+export interface CcrPauseFollowIndexResponse extends AcknowledgedResponseBase {
+}
 
 export interface CcrPutAutoFollowPatternRequest extends RequestBase {
   name: Name
@@ -6774,13 +6789,15 @@ export interface CcrPutAutoFollowPatternRequest extends RequestBase {
   }
 }
 
-export interface CcrPutAutoFollowPatternResponse extends AcknowledgedResponseBase {}
+export interface CcrPutAutoFollowPatternResponse extends AcknowledgedResponseBase {
+}
 
 export interface CcrResumeAutoFollowPatternRequest extends RequestBase {
   name: Name
 }
 
-export interface CcrResumeAutoFollowPatternResponse extends AcknowledgedResponseBase {}
+export interface CcrResumeAutoFollowPatternResponse extends AcknowledgedResponseBase {
+}
 
 export interface CcrResumeFollowIndexRequest extends RequestBase {
   index: IndexName
@@ -6798,7 +6815,8 @@ export interface CcrResumeFollowIndexRequest extends RequestBase {
   }
 }
 
-export interface CcrResumeFollowIndexResponse extends AcknowledgedResponseBase {}
+export interface CcrResumeFollowIndexResponse extends AcknowledgedResponseBase {
+}
 
 export interface CcrStatsAutoFollowStats {
   auto_followed_clusters: CcrStatsAutoFollowedCluster[]
@@ -6830,7 +6848,8 @@ export interface CcrUnfollowIndexRequest extends RequestBase {
   index: IndexName
 }
 
-export interface CcrUnfollowIndexResponse extends AcknowledgedResponseBase {}
+export interface CcrUnfollowIndexResponse extends AcknowledgedResponseBase {
+}
 
 export interface ClusterClusterStateBlockIndex {
   description?: string
@@ -7086,7 +7105,8 @@ export interface ClusterClusterDeleteComponentTemplateRequest extends RequestBas
   timeout?: Time
 }
 
-export interface ClusterClusterDeleteComponentTemplateResponse extends AcknowledgedResponseBase {}
+export interface ClusterClusterDeleteComponentTemplateResponse extends AcknowledgedResponseBase {
+}
 
 export interface ClusterClusterDeleteVotingConfigExclusionsRequest extends RequestBase {
   body?: {
@@ -7220,7 +7240,8 @@ export interface ClusterClusterPutComponentTemplateRequest extends RequestBase {
   }
 }
 
-export interface ClusterClusterPutComponentTemplateResponse extends AcknowledgedResponseBase {}
+export interface ClusterClusterPutComponentTemplateResponse extends AcknowledgedResponseBase {
+}
 
 export interface ClusterClusterPutSettingsRequest extends RequestBase {
   flat_settings?: boolean
@@ -7264,7 +7285,8 @@ export interface ClusterClusterRemoteInfoRequest extends RequestBase {
   }
 }
 
-export interface ClusterClusterRemoteInfoResponse extends DictionaryResponseBase<string, ClusterClusterRemoteInfoClusterRemoteInfo> {}
+export interface ClusterClusterRemoteInfoResponse extends DictionaryResponseBase<string, ClusterClusterRemoteInfoClusterRemoteInfo> {
+}
 
 export interface ClusterClusterRerouteClusterRerouteCommand {
   cancel?: ClusterClusterRerouteClusterRerouteCommandCancelAction
@@ -7666,7 +7688,8 @@ export interface EnrichDeletePolicyRequest extends RequestBase {
   name: Name
 }
 
-export interface EnrichDeletePolicyResponse extends AcknowledgedResponseBase {}
+export interface EnrichDeletePolicyResponse extends AcknowledgedResponseBase {
+}
 
 export type EnrichExecutePolicyEnrichPolicyPhase = 'SCHEDULED' | 'RUNNING' | 'COMPLETE' | 'FAILED'
 
@@ -7700,7 +7723,8 @@ export interface EnrichPutPolicyRequest extends RequestBase {
   }
 }
 
-export interface EnrichPutPolicyResponse extends AcknowledgedResponseBase {}
+export interface EnrichPutPolicyResponse extends AcknowledgedResponseBase {
+}
 
 export interface EnrichStatsCoordinatorStats {
   executed_searches_total: long
@@ -7754,7 +7778,8 @@ export interface EqlDeleteRequest extends RequestBase {
   id: Id
 }
 
-export interface EqlDeleteResponse extends AcknowledgedResponseBase {}
+export interface EqlDeleteResponse extends AcknowledgedResponseBase {
+}
 
 export interface EqlGetRequest extends RequestBase {
   id: Id
@@ -7762,7 +7787,8 @@ export interface EqlGetRequest extends RequestBase {
   wait_for_completion_timeout?: Time
 }
 
-export interface EqlGetResponse<TEvent = unknown> extends EqlEqlSearchResponseBase<TEvent> {}
+export interface EqlGetResponse<TEvent = unknown> extends EqlEqlSearchResponseBase<TEvent> {
+}
 
 export interface EqlGetStatusRequest extends RequestBase {
   id: Id
@@ -7802,7 +7828,8 @@ export interface EqlSearchRequest extends RequestBase {
   }
 }
 
-export interface EqlSearchResponse<TEvent = unknown> extends EqlEqlSearchResponseBase<TEvent> {}
+export interface EqlSearchResponse<TEvent = unknown> extends EqlEqlSearchResponseBase<TEvent> {
+}
 
 export type EqlSearchResultPosition = 'tail' | 'head'
 
@@ -7927,7 +7954,8 @@ export interface IlmDeleteLifecycleRequest extends RequestBase {
   policy_id: Id
 }
 
-export interface IlmDeleteLifecycleResponse extends AcknowledgedResponseBase {}
+export interface IlmDeleteLifecycleResponse extends AcknowledgedResponseBase {
+}
 
 export interface IlmExplainLifecycleLifecycleExplain {
   action: Name
@@ -7984,7 +8012,8 @@ export interface IlmGetLifecycleRequest extends RequestBase {
   policy_id?: Id
 }
 
-export interface IlmGetLifecycleResponse extends DictionaryResponseBase<string, IlmGetLifecycleLifecyclePolicy> {}
+export interface IlmGetLifecycleResponse extends DictionaryResponseBase<string, IlmGetLifecycleLifecyclePolicy> {
+}
 
 export type IlmGetStatusLifecycleOperationMode = 'RUNNING' | 'STOPPING' | 'STOPPED'
 
@@ -8003,7 +8032,8 @@ export interface IlmMoveToStepRequest extends RequestBase {
   }
 }
 
-export interface IlmMoveToStepResponse extends AcknowledgedResponseBase {}
+export interface IlmMoveToStepResponse extends AcknowledgedResponseBase {
+}
 
 export interface IlmMoveToStepStepKey {
   action: string
@@ -8019,7 +8049,8 @@ export interface IlmPutLifecycleRequest extends RequestBase {
   }
 }
 
-export interface IlmPutLifecycleResponse extends AcknowledgedResponseBase {}
+export interface IlmPutLifecycleResponse extends AcknowledgedResponseBase {
+}
 
 export interface IlmRemovePolicyRequest extends RequestBase {
   index: IndexName
@@ -8034,7 +8065,8 @@ export interface IlmRetryRequest extends RequestBase {
   index: IndexName
 }
 
-export interface IlmRetryResponse extends AcknowledgedResponseBase {}
+export interface IlmRetryResponse extends AcknowledgedResponseBase {
+}
 
 export interface IlmStartRequest extends RequestBase {
   body?: {
@@ -8042,7 +8074,8 @@ export interface IlmStartRequest extends RequestBase {
   }
 }
 
-export interface IlmStartResponse extends AcknowledgedResponseBase {}
+export interface IlmStartResponse extends AcknowledgedResponseBase {
+}
 
 export interface IlmStopRequest extends RequestBase {
   body?: {
@@ -8050,7 +8083,8 @@ export interface IlmStopRequest extends RequestBase {
   }
 }
 
-export interface IlmStopResponse extends AcknowledgedResponseBase {}
+export interface IlmStopResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesAlias {
   filter?: QueryDslQueryContainer
@@ -8319,7 +8353,8 @@ export interface IndicesClearCacheRequest extends RequestBase {
   request?: boolean
 }
 
-export interface IndicesClearCacheResponse extends ShardsOperationResponseBase {}
+export interface IndicesClearCacheResponse extends ShardsOperationResponseBase {
+}
 
 export interface IndicesCloneRequest extends RequestBase {
   index: IndexName
@@ -8384,7 +8419,8 @@ export interface IndicesCreateDataStreamRequest extends RequestBase {
   name: DataStreamName
 }
 
-export interface IndicesCreateDataStreamResponse extends AcknowledgedResponseBase {}
+export interface IndicesCreateDataStreamResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesDataStreamsStatsDataStreamsStatsItem {
   backing_indices: integer
@@ -8418,7 +8454,8 @@ export interface IndicesDeleteRequest extends RequestBase {
   timeout?: Time
 }
 
-export interface IndicesDeleteResponse extends IndicesResponseBase {}
+export interface IndicesDeleteResponse extends IndicesResponseBase {
+}
 
 export interface IndicesDeleteAliasRequest extends RequestBase {
   index: Indices
@@ -8427,19 +8464,21 @@ export interface IndicesDeleteAliasRequest extends RequestBase {
   timeout?: Time
 }
 
-export interface IndicesDeleteAliasResponse {}
+export type IndicesDeleteAliasResponse = boolean
 
 export interface IndicesDeleteDataStreamRequest extends RequestBase {
   name: DataStreamName
 }
 
-export interface IndicesDeleteDataStreamResponse extends AcknowledgedResponseBase {}
+export interface IndicesDeleteDataStreamResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesDeleteIndexTemplateRequest extends RequestBase {
   name: Name
 }
 
-export interface IndicesDeleteIndexTemplateResponse extends AcknowledgedResponseBase {}
+export interface IndicesDeleteIndexTemplateResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesDeleteTemplateRequest extends RequestBase {
   name: Name
@@ -8447,7 +8486,8 @@ export interface IndicesDeleteTemplateRequest extends RequestBase {
   timeout?: Time
 }
 
-export interface IndicesDeleteTemplateResponse extends AcknowledgedResponseBase {}
+export interface IndicesDeleteTemplateResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesExistsRequest extends RequestBase {
   index: Indices
@@ -8508,7 +8548,8 @@ export interface IndicesFlushRequest extends RequestBase {
   wait_if_ongoing?: boolean
 }
 
-export interface IndicesFlushResponse extends ShardsOperationResponseBase {}
+export interface IndicesFlushResponse extends ShardsOperationResponseBase {
+}
 
 export interface IndicesFlushSyncedRequest extends RequestBase {
   index?: Indices
@@ -8531,7 +8572,8 @@ export interface IndicesForcemergeRequest extends RequestBase {
   only_expunge_deletes?: boolean
 }
 
-export interface IndicesForcemergeResponse extends ShardsOperationResponseBase {}
+export interface IndicesForcemergeResponse extends ShardsOperationResponseBase {
+}
 
 export interface IndicesFreezeRequest extends RequestBase {
   index: IndexName
@@ -8559,7 +8601,8 @@ export interface IndicesGetRequest extends RequestBase {
   master_timeout?: Time
 }
 
-export interface IndicesGetResponse extends DictionaryResponseBase<IndexName, IndicesIndexState> {}
+export interface IndicesGetResponse extends DictionaryResponseBase<IndexName, IndicesIndexState> {
+}
 
 export interface IndicesGetAliasIndexAliases {
   aliases: Record<string, IndicesAliasDefinition>
@@ -8574,7 +8617,8 @@ export interface IndicesGetAliasRequest extends RequestBase {
   local?: boolean
 }
 
-export interface IndicesGetAliasResponse extends DictionaryResponseBase<IndexName, IndicesGetAliasIndexAliases> {}
+export interface IndicesGetAliasResponse extends DictionaryResponseBase<IndexName, IndicesGetAliasIndexAliases> {
+}
 
 export interface IndicesGetDataStreamIndicesGetDataStreamItem {
   name: DataStreamName
@@ -8619,7 +8663,8 @@ export interface IndicesGetFieldMappingRequest extends RequestBase {
   local?: boolean
 }
 
-export interface IndicesGetFieldMappingResponse extends DictionaryResponseBase<IndexName, IndicesGetFieldMappingTypeFieldMappings> {}
+export interface IndicesGetFieldMappingResponse extends DictionaryResponseBase<IndexName, IndicesGetFieldMappingTypeFieldMappings> {
+}
 
 export interface IndicesGetFieldMappingTypeFieldMappings {
   mappings: Record<Field, MappingFieldMapping>
@@ -8677,7 +8722,8 @@ export interface IndicesGetMappingRequest extends RequestBase {
   master_timeout?: Time
 }
 
-export interface IndicesGetMappingResponse extends DictionaryResponseBase<IndexName, IndicesGetMappingIndexMappingRecord> {}
+export interface IndicesGetMappingResponse extends DictionaryResponseBase<IndexName, IndicesGetMappingIndexMappingRecord> {
+}
 
 export interface IndicesGetSettingsRequest extends RequestBase {
   index?: Indices
@@ -8691,7 +8737,8 @@ export interface IndicesGetSettingsRequest extends RequestBase {
   master_timeout?: Time
 }
 
-export interface IndicesGetSettingsResponse extends DictionaryResponseBase<IndexName, IndicesIndexState> {}
+export interface IndicesGetSettingsResponse extends DictionaryResponseBase<IndexName, IndicesIndexState> {
+}
 
 export interface IndicesGetTemplateRequest extends RequestBase {
   name?: Names
@@ -8701,7 +8748,8 @@ export interface IndicesGetTemplateRequest extends RequestBase {
   master_timeout?: Time
 }
 
-export interface IndicesGetTemplateResponse extends DictionaryResponseBase<string, IndicesTemplateMapping> {}
+export interface IndicesGetTemplateResponse extends DictionaryResponseBase<string, IndicesTemplateMapping> {
+}
 
 export interface IndicesGetUpgradeRequest extends RequestBase {
   stub: string
@@ -8716,7 +8764,8 @@ export interface IndicesMigrateToDataStreamRequest extends RequestBase {
   name: IndexName
 }
 
-export interface IndicesMigrateToDataStreamResponse extends AcknowledgedResponseBase {}
+export interface IndicesMigrateToDataStreamResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesOpenRequest extends RequestBase {
   index: Indices
@@ -8754,7 +8803,7 @@ export interface IndicesPutAliasRequest extends RequestBase {
   }
 }
 
-export interface IndicesPutAliasResponse {}
+export type IndicesPutAliasResponse = boolean
 
 export interface IndicesPutIndexTemplateIndexTemplateMapping {
   aliases?: Record<IndexName, IndicesAlias>
@@ -8775,7 +8824,8 @@ export interface IndicesPutIndexTemplateRequest extends RequestBase {
   }
 }
 
-export interface IndicesPutIndexTemplateResponse extends AcknowledgedResponseBase {}
+export interface IndicesPutIndexTemplateResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesPutMappingRequest extends RequestBase {
   index?: Indices
@@ -8805,7 +8855,8 @@ export interface IndicesPutMappingRequest extends RequestBase {
   }
 }
 
-export interface IndicesPutMappingResponse extends IndicesResponseBase {}
+export interface IndicesPutMappingResponse extends IndicesResponseBase {
+}
 
 export interface IndicesPutSettingsIndexSettingsBody extends IndicesIndexSettings {
   settings?: IndicesIndexSettings
@@ -8823,7 +8874,8 @@ export interface IndicesPutSettingsRequest extends RequestBase {
   body?: IndicesPutSettingsIndexSettingsBody
 }
 
-export interface IndicesPutSettingsResponse extends AcknowledgedResponseBase {}
+export interface IndicesPutSettingsResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesPutTemplateRequest extends RequestBase {
   name: Name
@@ -8842,7 +8894,8 @@ export interface IndicesPutTemplateRequest extends RequestBase {
   }
 }
 
-export interface IndicesPutTemplateResponse extends AcknowledgedResponseBase {}
+export interface IndicesPutTemplateResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesRecoveryRecoveryBytes {
   percent: Percentage
@@ -8926,7 +8979,8 @@ export interface IndicesRecoveryRequest extends RequestBase {
   detailed?: boolean
 }
 
-export interface IndicesRecoveryResponse extends DictionaryResponseBase<IndexName, IndicesRecoveryRecoveryStatus> {}
+export interface IndicesRecoveryResponse extends DictionaryResponseBase<IndexName, IndicesRecoveryRecoveryStatus> {
+}
 
 export interface IndicesRecoveryShardRecovery {
   id: long
@@ -8954,7 +9008,8 @@ export interface IndicesRefreshRequest extends RequestBase {
   ignore_unavailable?: boolean
 }
 
-export interface IndicesRefreshResponse extends ShardsOperationResponseBase {}
+export interface IndicesRefreshResponse extends ShardsOperationResponseBase {
+}
 
 export interface IndicesReloadSearchAnalyzersReloadDetails {
   index: string
@@ -9148,7 +9203,8 @@ export interface IndicesSimulateIndexTemplateRequest extends RequestBase {
   }
 }
 
-export interface IndicesSimulateIndexTemplateResponse extends AcknowledgedResponseBase {}
+export interface IndicesSimulateIndexTemplateResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesSimulateTemplateRequest extends RequestBase {
   name?: Name
@@ -9332,7 +9388,8 @@ export interface IndicesUpdateAliasesRequest extends RequestBase {
   }
 }
 
-export interface IndicesUpdateAliasesResponse extends AcknowledgedResponseBase {}
+export interface IndicesUpdateAliasesResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesUpgradeRequest extends RequestBase {
   stub_b: integer
@@ -9691,7 +9748,8 @@ export interface IngestDeletePipelineRequest extends RequestBase {
   timeout?: Time
 }
 
-export interface IngestDeletePipelineResponse extends AcknowledgedResponseBase {}
+export interface IngestDeletePipelineResponse extends AcknowledgedResponseBase {
+}
 
 export interface IngestGeoIpStatsGeoIpDownloadStatistics {
   successful_downloads: integer
@@ -9724,7 +9782,8 @@ export interface IngestGetPipelineRequest extends RequestBase {
   summary?: boolean
 }
 
-export interface IngestGetPipelineResponse extends DictionaryResponseBase<string, IngestPipeline> {}
+export interface IngestGetPipelineResponse extends DictionaryResponseBase<string, IngestPipeline> {
+}
 
 export interface IngestProcessorGrokRequest extends RequestBase {
 }
@@ -9745,7 +9804,8 @@ export interface IngestPutPipelineRequest extends RequestBase {
   }
 }
 
-export interface IngestPutPipelineResponse extends AcknowledgedResponseBase {}
+export interface IngestPutPipelineResponse extends AcknowledgedResponseBase {
+}
 
 export interface IngestSimulatePipelineDocumentSimulation {
   _id: Id
@@ -9809,7 +9869,8 @@ export type LicenseLicenseType = 'missing' | 'trial' | 'basic' | 'standard' | 'd
 export interface LicenseDeleteLicenseRequest extends RequestBase {
 }
 
-export interface LicenseDeleteLicenseResponse extends AcknowledgedResponseBase {}
+export interface LicenseDeleteLicenseResponse extends AcknowledgedResponseBase {
+}
 
 export interface LicenseGetBasicLicenseStatusRequest extends RequestBase {
 }
@@ -10566,14 +10627,16 @@ export interface MlDeleteCalendarRequest extends RequestBase {
   calendar_id: Id
 }
 
-export interface MlDeleteCalendarResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteCalendarResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlDeleteCalendarEventRequest extends RequestBase {
   calendar_id: Id
   event_id: Id
 }
 
-export interface MlDeleteCalendarEventResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteCalendarEventResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlDeleteCalendarJobRequest extends RequestBase {
   calendar_id: Id
@@ -10592,14 +10655,16 @@ export interface MlDeleteDataFrameAnalyticsRequest extends RequestBase {
   timeout?: Time
 }
 
-export interface MlDeleteDataFrameAnalyticsResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteDataFrameAnalyticsResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlDeleteDatafeedRequest extends RequestBase {
   datafeed_id: Id
   force?: boolean
 }
 
-export interface MlDeleteDatafeedResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteDatafeedResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlDeleteExpiredDataRequest extends RequestBase {
   name?: Name
@@ -10619,7 +10684,8 @@ export interface MlDeleteFilterRequest extends RequestBase {
   filter_id: Id
 }
 
-export interface MlDeleteFilterResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteFilterResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlDeleteForecastRequest extends RequestBase {
   job_id: Id
@@ -10628,7 +10694,8 @@ export interface MlDeleteForecastRequest extends RequestBase {
   timeout?: Time
 }
 
-export interface MlDeleteForecastResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteForecastResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlDeleteJobRequest extends RequestBase {
   job_id: Id
@@ -10636,27 +10703,31 @@ export interface MlDeleteJobRequest extends RequestBase {
   wait_for_completion?: boolean
 }
 
-export interface MlDeleteJobResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteJobResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlDeleteModelSnapshotRequest extends RequestBase {
   job_id: Id
   snapshot_id: Id
 }
 
-export interface MlDeleteModelSnapshotResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteModelSnapshotResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlDeleteTrainedModelRequest extends RequestBase {
   model_id: Id
 }
 
-export interface MlDeleteTrainedModelResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteTrainedModelResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlDeleteTrainedModelAliasRequest extends RequestBase {
   model_alias: Name
   model_id: Id
 }
 
-export interface MlDeleteTrainedModelAliasResponse extends AcknowledgedResponseBase {}
+export interface MlDeleteTrainedModelAliasResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlEstimateModelMemoryRequest extends RequestBase {
   body?: {
@@ -11475,7 +11546,8 @@ export interface MlPutTrainedModelAliasRequest extends RequestBase {
   reassign?: boolean
 }
 
-export interface MlPutTrainedModelAliasResponse extends AcknowledgedResponseBase {}
+export interface MlPutTrainedModelAliasResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlRevertModelSnapshotRequest extends RequestBase {
   job_id: Id
@@ -11494,7 +11566,8 @@ export interface MlSetUpgradeModeRequest extends RequestBase {
   timeout?: Time
 }
 
-export interface MlSetUpgradeModeResponse extends AcknowledgedResponseBase {}
+export interface MlSetUpgradeModeResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlStartDataFrameAnalyticsRequest extends RequestBase {
   id: Id
@@ -11683,7 +11756,8 @@ export interface MlValidateDetectorRequest extends RequestBase {
   body?: MlDetector
 }
 
-export interface MlValidateDetectorResponse extends AcknowledgedResponseBase {}
+export interface MlValidateDetectorResponse extends AcknowledgedResponseBase {
+}
 
 export interface MlValidateJobRequest extends RequestBase {
   body?: {
@@ -11698,7 +11772,8 @@ export interface MlValidateJobRequest extends RequestBase {
   }
 }
 
-export interface MlValidateJobResponse extends AcknowledgedResponseBase {}
+export interface MlValidateJobResponse extends AcknowledgedResponseBase {
+}
 
 export interface MonitoringBulkRequest extends RequestBase {
   stub_a: string
@@ -12421,7 +12496,8 @@ export interface RollupCreateRollupJobRequest extends RequestBase {
   }
 }
 
-export interface RollupCreateRollupJobResponse extends AcknowledgedResponseBase {}
+export interface RollupCreateRollupJobResponse extends AcknowledgedResponseBase {
+}
 
 export interface RollupDeleteRollupJobRequest extends RequestBase {
   id: Id
@@ -12447,7 +12523,8 @@ export interface RollupGetRollupCapabilitiesRequest extends RequestBase {
   id?: Id
 }
 
-export interface RollupGetRollupCapabilitiesResponse extends DictionaryResponseBase<IndexName, RollupGetRollupCapabilitiesRollupCapabilities> {}
+export interface RollupGetRollupCapabilitiesResponse extends DictionaryResponseBase<IndexName, RollupGetRollupCapabilitiesRollupCapabilities> {
+}
 
 export interface RollupGetRollupCapabilitiesRollupCapabilities {
   rollup_jobs: RollupGetRollupCapabilitiesRollupCapabilitySummary[]
@@ -12468,7 +12545,8 @@ export interface RollupGetRollupIndexCapabilitiesRequest extends RequestBase {
   index: Id
 }
 
-export interface RollupGetRollupIndexCapabilitiesResponse extends DictionaryResponseBase<IndexName, RollupGetRollupIndexCapabilitiesIndexCapabilities> {}
+export interface RollupGetRollupIndexCapabilitiesResponse extends DictionaryResponseBase<IndexName, RollupGetRollupIndexCapabilitiesIndexCapabilities> {
+}
 
 export interface RollupGetRollupIndexCapabilitiesRollupJobSummary {
   fields: Record<Field, RollupGetRollupIndexCapabilitiesRollupJobSummaryField[]>
@@ -12555,7 +12633,7 @@ export interface RollupRollupSearchRequest extends RequestBase {
   }
 }
 
-export interface RollupRollupSearchResponse<TDocument = unknown> {}
+export type RollupRollupSearchResponse<TDocument = unknown> = boolean
 
 export interface RollupStartRollupJobRequest extends RequestBase {
   id: Id
@@ -12741,7 +12819,7 @@ export interface SecurityChangePasswordRequest extends RequestBase {
   }
 }
 
-export interface SecurityChangePasswordResponse {}
+export type SecurityChangePasswordResponse = boolean
 
 export interface SecurityClearApiKeyCacheClearApiKeyCacheNode {
   name: Name
@@ -12836,7 +12914,8 @@ export interface SecurityDeletePrivilegesRequest extends RequestBase {
   refresh?: Refresh
 }
 
-export interface SecurityDeletePrivilegesResponse extends DictionaryResponseBase<string, Record<string, SecurityDeletePrivilegesFoundUserPrivilege>> {}
+export interface SecurityDeletePrivilegesResponse extends DictionaryResponseBase<string, Record<string, SecurityDeletePrivilegesFoundUserPrivilege>> {
+}
 
 export interface SecurityDeleteRoleRequest extends RequestBase {
   name: Name
@@ -12915,19 +12994,22 @@ export interface SecurityGetPrivilegesRequest extends RequestBase {
   name?: Name
 }
 
-export interface SecurityGetPrivilegesResponse extends DictionaryResponseBase<string, Record<string, SecurityPutPrivilegesPrivilegesActions>> {}
+export interface SecurityGetPrivilegesResponse extends DictionaryResponseBase<string, Record<string, SecurityPutPrivilegesPrivilegesActions>> {
+}
 
 export interface SecurityGetRoleRequest extends RequestBase {
   name?: Name
 }
 
-export interface SecurityGetRoleResponse extends DictionaryResponseBase<string, SecurityXPackRole> {}
+export interface SecurityGetRoleResponse extends DictionaryResponseBase<string, SecurityXPackRole> {
+}
 
 export interface SecurityGetRoleMappingRequest extends RequestBase {
   name?: Name
 }
 
-export interface SecurityGetRoleMappingResponse extends DictionaryResponseBase<string, SecurityXPackRoleMapping> {}
+export interface SecurityGetRoleMappingResponse extends DictionaryResponseBase<string, SecurityXPackRoleMapping> {
+}
 
 export interface SecurityGetTokenAuthenticatedUser extends SecurityXPackUser {
   authentication_realm: SecurityGetTokenUserRealm
@@ -12971,7 +13053,8 @@ export interface SecurityGetUserRequest extends RequestBase {
   username?: Username | Username[]
 }
 
-export interface SecurityGetUserResponse extends DictionaryResponseBase<string, SecurityXPackUser> {}
+export interface SecurityGetUserResponse extends DictionaryResponseBase<string, SecurityXPackUser> {
+}
 
 export interface SecurityGetUserPrivilegesApplicationGlobalUserPrivileges {
   manage: SecurityGetUserPrivilegesManageUserPrivileges
@@ -13134,7 +13217,8 @@ export interface SecurityPutPrivilegesRequest extends RequestBase {
   body?: Record<string, Record<string, SecurityPutPrivilegesPrivilegesActions>>
 }
 
-export interface SecurityPutPrivilegesResponse extends DictionaryResponseBase<string, Record<string, SecurityPutPrivilegesPutPrivilegesStatus>> {}
+export interface SecurityPutPrivilegesResponse extends DictionaryResponseBase<string, Record<string, SecurityPutPrivilegesPutPrivilegesStatus>> {
+}
 
 export interface SecurityPutRoleApplicationPrivileges {
   application: string
@@ -13307,7 +13391,8 @@ export interface SlmDeleteLifecycleRequest extends RequestBase {
   policy_id: Name
 }
 
-export interface SlmDeleteLifecycleResponse extends AcknowledgedResponseBase {}
+export interface SlmDeleteLifecycleResponse extends AcknowledgedResponseBase {
+}
 
 export interface SlmExecuteLifecycleRequest extends RequestBase {
   policy_id: Name
@@ -13320,13 +13405,15 @@ export interface SlmExecuteLifecycleResponse {
 export interface SlmExecuteRetentionRequest extends RequestBase {
 }
 
-export interface SlmExecuteRetentionResponse extends AcknowledgedResponseBase {}
+export interface SlmExecuteRetentionResponse extends AcknowledgedResponseBase {
+}
 
 export interface SlmGetLifecycleRequest extends RequestBase {
   policy_id?: Names
 }
 
-export interface SlmGetLifecycleResponse extends DictionaryResponseBase<Id, SlmSnapshotLifecyclePolicyMetadata> {}
+export interface SlmGetLifecycleResponse extends DictionaryResponseBase<Id, SlmSnapshotLifecyclePolicyMetadata> {
+}
 
 export interface SlmGetStatsRequest extends RequestBase {
 }
@@ -13362,17 +13449,20 @@ export interface SlmPutLifecycleRequest extends RequestBase {
   }
 }
 
-export interface SlmPutLifecycleResponse extends AcknowledgedResponseBase {}
+export interface SlmPutLifecycleResponse extends AcknowledgedResponseBase {
+}
 
 export interface SlmStartRequest extends RequestBase {
 }
 
-export interface SlmStartResponse extends AcknowledgedResponseBase {}
+export interface SlmStartResponse extends AcknowledgedResponseBase {
+}
 
 export interface SlmStopRequest extends RequestBase {
 }
 
-export interface SlmStopResponse extends AcknowledgedResponseBase {}
+export interface SlmStopResponse extends AcknowledgedResponseBase {
+}
 
 export interface SnapshotFileCountSnapshotStats {
   file_count: integer
@@ -13515,7 +13605,8 @@ export interface SnapshotCloneRequest extends RequestBase {
   }
 }
 
-export interface SnapshotCloneResponse extends AcknowledgedResponseBase {}
+export interface SnapshotCloneResponse extends AcknowledgedResponseBase {
+}
 
 export interface SnapshotCreateRequest extends RequestBase {
   repository: Name
@@ -13548,7 +13639,8 @@ export interface SnapshotCreateRepositoryRequest extends RequestBase {
   }
 }
 
-export interface SnapshotCreateRepositoryResponse extends AcknowledgedResponseBase {}
+export interface SnapshotCreateRepositoryResponse extends AcknowledgedResponseBase {
+}
 
 export interface SnapshotDeleteRequest extends RequestBase {
   repository: Name
@@ -13556,7 +13648,8 @@ export interface SnapshotDeleteRequest extends RequestBase {
   master_timeout?: Time
 }
 
-export interface SnapshotDeleteResponse extends AcknowledgedResponseBase {}
+export interface SnapshotDeleteResponse extends AcknowledgedResponseBase {
+}
 
 export interface SnapshotDeleteRepositoryRequest extends RequestBase {
   repository: Names
@@ -13564,7 +13657,8 @@ export interface SnapshotDeleteRepositoryRequest extends RequestBase {
   timeout?: Time
 }
 
-export interface SnapshotDeleteRepositoryResponse extends AcknowledgedResponseBase {}
+export interface SnapshotDeleteRepositoryResponse extends AcknowledgedResponseBase {
+}
 
 export interface SnapshotGetRequest extends RequestBase {
   repository: Name
@@ -13593,7 +13687,8 @@ export interface SnapshotGetRepositoryRequest extends RequestBase {
   master_timeout?: Time
 }
 
-export interface SnapshotGetRepositoryResponse extends DictionaryResponseBase<string, SnapshotSnapshotRepository> {}
+export interface SnapshotGetRepositoryResponse extends DictionaryResponseBase<string, SnapshotSnapshotRepository> {
+}
 
 export interface SnapshotRestoreRequest extends RequestBase {
   repository: Name
@@ -13925,7 +14020,8 @@ export interface TransformDeleteTransformRequest extends RequestBase {
   force?: boolean
 }
 
-export interface TransformDeleteTransformResponse extends AcknowledgedResponseBase {}
+export interface TransformDeleteTransformResponse extends AcknowledgedResponseBase {
+}
 
 export interface TransformGetTransformRequest extends RequestBase {
   transform_id?: Name
@@ -14026,16 +14122,20 @@ export interface TransformPreviewTransformResponse<TTransform = unknown> {
 export interface TransformPutTransformRequest extends TransformPreviewTransformRequest {
   transform_id: Id
   defer_validation?: boolean
+  body?: {
+  }
 }
 
-export interface TransformPutTransformResponse extends AcknowledgedResponseBase {}
+export interface TransformPutTransformResponse extends AcknowledgedResponseBase {
+}
 
 export interface TransformStartTransformRequest extends RequestBase {
   transform_id: Name
   timeout?: Time
 }
 
-export interface TransformStartTransformResponse extends AcknowledgedResponseBase {}
+export interface TransformStartTransformResponse extends AcknowledgedResponseBase {
+}
 
 export interface TransformStopTransformRequest extends RequestBase {
   transform_id: Name
@@ -14046,9 +14146,12 @@ export interface TransformStopTransformRequest extends RequestBase {
   wait_for_completion?: boolean
 }
 
-export interface TransformStopTransformResponse extends AcknowledgedResponseBase {}
+export interface TransformStopTransformResponse extends AcknowledgedResponseBase {
+}
 
 export interface TransformUpdateTransformRequest extends TransformPutTransformRequest {
+  body?: {
+  }
 }
 
 export interface TransformUpdateTransformResponse {
@@ -14630,7 +14733,8 @@ export interface WatcherQueryWatchesResponse {
 export interface WatcherStartRequest extends RequestBase {
 }
 
-export interface WatcherStartResponse extends AcknowledgedResponseBase {}
+export interface WatcherStartResponse extends AcknowledgedResponseBase {
+}
 
 export interface WatcherStatsRequest extends RequestBase {
   metric?: WatcherStatsWatcherMetric | WatcherStatsWatcherMetric[]
@@ -14672,7 +14776,8 @@ export type WatcherStatsWatcherState = 'stopped' | 'starting' | 'started' | 'sto
 export interface WatcherStopRequest extends RequestBase {
 }
 
-export interface WatcherStopResponse extends AcknowledgedResponseBase {}
+export interface WatcherStopResponse extends AcknowledgedResponseBase {
+}
 
 export interface XpackInfoBuildInformation {
   date: DateString

--- a/specification/_global/info/RootNodeInfoRequest.ts
+++ b/specification/_global/info/RootNodeInfoRequest.ts
@@ -24,7 +24,4 @@ import { RequestBase } from '@_types/Base'
  * @since 0.0.0
  * @stability TODO
  */
-export interface Request extends RequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends RequestBase {}

--- a/specification/_global/info/RootNodeInfoResponse.ts
+++ b/specification/_global/info/RootNodeInfoResponse.ts
@@ -18,12 +18,13 @@
  */
 
 import { ElasticsearchVersionInfo } from '@_types/Base'
+import { Name, Uuid } from '@_types/common'
 
 export class Response {
   body: {
-    cluster_name: string
-    cluster_uuid: string
-    name: string
+    cluster_name: Name
+    cluster_uuid: Uuid
+    name: Name
     tagline: string
     version: ElasticsearchVersionInfo
   }

--- a/typescript-generator/client.ts
+++ b/typescript-generator/client.ts
@@ -335,7 +335,7 @@ export {
              hasRequiredProps(requestType.query) ||
              hasRequiredProps(requestType.body)
 
-      function hasRequiredProps (props?: M.Property[] | M.ValueBody | M.PropertiesBody): boolean {
+      function hasRequiredProps (props?: M.Property[] | M.Body): boolean {
         if (!Array.isArray(props)) return false
         for (const prop of props) {
           if (prop.required) return true

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -100,8 +100,6 @@ function buildValue (type: M.ValueOf, openGenerics?: string[]): string | number 
       return 'any'
     case 'literal_value':
       return typeof type.value === 'string' ? `'${type.value}'` : type.value
-    case 'void_value':
-      return 'boolean'
   }
 }
 
@@ -254,13 +252,13 @@ function buildRequest (type: M.Request): string {
     if (pathPropertiesNames.includes(property.name)) continue
     code += `  ${cleanPropertyName(property.name)}${property.required ? '' : '?'}: ${buildValue(property.type, openGenerics)}\n`
   }
-  if ((type.body != null) && type.body.kind === 'properties') {
+  if (type.body.kind === 'properties') {
     code += `  body${isBodyRequired() ? '' : '?'}: {\n`
     for (const property of type.body.properties) {
       code += `    ${cleanPropertyName(property.name)}${property.required ? '' : '?'}: ${buildValue(property.type, openGenerics)}\n`
     }
     code += '  }\n'
-  } else if (type.body != null && type.body.kind === 'value') {
+  } else if (type.body.kind === 'value') {
     code += `  body${isBodyRequired() ? '' : '?'}: ${buildValue(type.body.value, openGenerics)}\n`
   }
   code += '}\n'
@@ -279,15 +277,15 @@ function buildRequest (type: M.Request): string {
 function buildResponse (type: M.Response): string {
   const openGenerics = type.generics?.map(t => t.name) ?? []
 
-  if (type.body == null) {
-    return `export interface ${createName(type.name)}${buildGenerics(type.generics, openGenerics)}${buildInherits(type, openGenerics)} {}\n`
-  } else if (type.body.kind === 'properties') {
+  if (type.body.kind === 'properties') {
     let code = `export interface ${createName(type.name)}${buildGenerics(type.generics, openGenerics)}${buildInherits(type, openGenerics)} {\n`
     for (const property of type.body.properties) {
       code += `  ${cleanPropertyName(property.name)}${property.required ? '' : '?'}: ${buildValue(property.type, openGenerics)}\n`
     }
     code += '}\n'
     return code
+  } else if (type.body.kind === 'no_body') {
+    return `export type ${createName(type.name)}${buildGenerics(type.generics, openGenerics)} = boolean\n`
   } else {
     return `export type ${createName(type.name)}${buildGenerics(type.generics, openGenerics)} = ${buildValue(type.body.value, openGenerics)}\n`
   }

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -252,7 +252,7 @@ function buildRequest (type: M.Request): string {
     if (pathPropertiesNames.includes(property.name)) continue
     code += `  ${cleanPropertyName(property.name)}${property.required ? '' : '?'}: ${buildValue(property.type, openGenerics)}\n`
   }
-  if (type.body.kind === 'properties') {
+  if (type.body.kind === 'properties' && type.body.properties.length > 0) {
     code += `  body${isBodyRequired() ? '' : '?'}: {\n`
     for (const property of type.body.properties) {
       code += `    ${cleanPropertyName(property.name)}${property.required ? '' : '?'}: ${buildValue(property.type, openGenerics)}\n`


### PR DESCRIPTION
Follow-up to https://github.com/elastic/elastic-client-generator/pull/391#discussion_r626069633

This PR changes the way we represent no-body responses (and requests) in `schema.json`:
- the `body` property is now required
- it can now be a `NoBody` in addition to the existing `PropertyBody | ValueBody`
- the `void_value` value kind has been removed (it doesn't make sense for a property to be of type void)

We also formalize the the close relation between body type and inheritance: when a request or response extends a class, the parent class defines body properties inherited by the child class. The child class therefore has to have a `PropertyBody`.

The body is required in the schema but is still optional in the spec (ultimately we should enforce it), and a simple heuristic is used to find the correct body type when it's not present in the TS spec:
- if the request extends a parent class, the body is set to a `PropertyBody` with an emptu list of properties
- otherwise it is set to `NoBody`

New validations verify this.

Aside:
> The only exception to the above is `RequestBase` which is actually a marker class that also links to the `CommonRequestParameter` behavior. IMHO we should get rid of `RequestBase` entirely and have requests directly implement the behavior. This is out of scope of this PR.

There are changes in the schema with the new body type, but the TS output has no change except some formatting that is a side effect of `body` now being required.

