### PR TITLE
Allow empty object responses

### DIFF
--- a/compiler/model/build-model.ts
+++ b/compiler/model/build-model.ts
@@ -253,7 +253,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
             } else {
               type.body = { kind: 'value', value: property.valueOf }
             }
-          } else if (property.properties.length > 0) {
+          } else {
             type.body = { kind: 'properties', properties: property.properties }
           }
         } else {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -85632,7 +85632,14 @@
     },
     {
       "body": {
-        "kind": "no_body"
+        "kind": "properties",
+        "properties": []
+      },
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
+        }
       },
       "kind": "response",
       "name": {
@@ -88667,7 +88674,14 @@
     },
     {
       "body": {
-        "kind": "no_body"
+        "kind": "properties",
+        "properties": []
+      },
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
+        }
       },
       "kind": "response",
       "name": {
@@ -123016,7 +123030,8 @@
     },
     {
       "body": {
-        "kind": "no_body"
+        "kind": "properties",
+        "properties": []
       },
       "kind": "response",
       "name": {
@@ -124091,7 +124106,8 @@
     },
     {
       "body": {
-        "kind": "no_body"
+        "kind": "properties",
+        "properties": []
       },
       "kind": "response",
       "name": {
@@ -124146,7 +124162,8 @@
     },
     {
       "body": {
-        "kind": "no_body"
+        "kind": "properties",
+        "properties": []
       },
       "kind": "response",
       "name": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8489,7 +8489,8 @@ export interface IndicesDeleteAliasRequest extends RequestBase {
   timeout?: Time
 }
 
-export type IndicesDeleteAliasResponse = boolean
+export interface IndicesDeleteAliasResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesDeleteDataStreamRequest extends RequestBase {
   name: DataStreamName
@@ -8828,7 +8829,8 @@ export interface IndicesPutAliasRequest extends RequestBase {
   }
 }
 
-export type IndicesPutAliasResponse = boolean
+export interface IndicesPutAliasResponse extends AcknowledgedResponseBase {
+}
 
 export interface IndicesPutIndexTemplateIndexTemplateMapping {
   aliases?: Record<IndexName, IndicesAlias>
@@ -12812,7 +12814,8 @@ export interface SecurityChangePasswordRequest extends RequestBase {
   }
 }
 
-export type SecurityChangePasswordResponse = boolean
+export interface SecurityChangePasswordResponse {
+}
 
 export interface SecurityClearApiKeyCacheClearApiKeyCacheNode {
   name: Name
@@ -12942,14 +12945,16 @@ export interface SecurityDisableUserRequest extends RequestBase {
   refresh?: Refresh
 }
 
-export type SecurityDisableUserResponse = boolean
+export interface SecurityDisableUserResponse {
+}
 
 export interface SecurityEnableUserRequest extends RequestBase {
   username: Username
   refresh?: Refresh
 }
 
-export type SecurityEnableUserResponse = boolean
+export interface SecurityEnableUserResponse {
+}
 
 export interface SecurityGetApiKeyApiKeys {
   creation: long

--- a/specification/indices/delete_alias/IndicesDeleteAliasResponse.ts
+++ b/specification/indices/delete_alias/IndicesDeleteAliasResponse.ts
@@ -17,4 +17,6 @@
  * under the License.
  */
 
-export class Response {}
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response extends AcknowledgedResponseBase {}

--- a/specification/indices/put_alias/IndicesPutAliasResponse.ts
+++ b/specification/indices/put_alias/IndicesPutAliasResponse.ts
@@ -17,4 +17,6 @@
  * under the License.
  */
 
-export class Response {}
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response extends AcknowledgedResponseBase {}

--- a/specification/security/change_password/SecurityChangePasswordResponse.ts
+++ b/specification/security/change_password/SecurityChangePasswordResponse.ts
@@ -17,4 +17,6 @@
  * under the License.
  */
 
-export class Response {}
+export class Response {
+  body: {}
+}

--- a/specification/security/disable_user/SecurityDisableUserResponse.ts
+++ b/specification/security/disable_user/SecurityDisableUserResponse.ts
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import { Void } from '@spec_utils/VoidValue'
-
 export class Response {
-  body: Void
+  body: {}
 }

--- a/specification/security/enable_user/SecurityEnableUserResponse.ts
+++ b/specification/security/enable_user/SecurityEnableUserResponse.ts
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import { Void } from '@spec_utils/VoidValue'
-
 export class Response {
-  body: Void
+  body: {}
 }


### PR DESCRIPTION
#444 surfaced a bug, where we aren't allowing empty object responses, which some security APIs are using.
It would be nice to see those APIs migrate to the `AcknowledgedResponseBase` tho.

Related: #450